### PR TITLE
megafix for megacrash

### DIFF
--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2143,8 +2143,8 @@ export function initSession(
   client.onStatusChange((status) => {
     if (status === 'disconnected') {
       stopColdStartRetry();
-      if (state.machineState === 'active') {
-        // Connection dropped during active session — start reconnecting.
+      if (state.machineState === 'active' || state.machineState === 'joining') {
+        // Connection dropped during active session or mid-join — start reconnecting.
         // Do NOT tear down LiveKit media — it connects directly to the SFU,
         // independent of the signaling WS. Tearing it down causes an
         // unnecessary audio/screenshare interruption during WS reconnects

--- a/clients/wavis-gui/src/shared/websocket.ts
+++ b/clients/wavis-gui/src/shared/websocket.ts
@@ -18,10 +18,9 @@ export type WsMessageHandler = (message: unknown) => void;
 
 const LOG_PREFIX = '[wavis:ws]';
 
-/** Keepalive ping interval (ms). Prevents idle-timeout disconnects from
- *  reverse proxies (e.g. CloudFront default 600s). 5 minutes is well
- *  within typical proxy idle windows. */
-const KEEPALIVE_INTERVAL_MS = 5 * 60 * 1000;
+/** Keepalive ping interval (ms). CloudFront VPC origin_read_timeout is 60s;
+ *  ping every 30s to stay safely within that window. */
+const KEEPALIVE_INTERVAL_MS = 30_000;
 
 /** Slow periodic retry interval (ms) after fast reconnect attempts are exhausted. */
 const PERIODIC_RETRY_INTERVAL_MS = 30_000;

--- a/wavis-backend/src/chat/chat_persistence.rs
+++ b/wavis-backend/src/chat/chat_persistence.rs
@@ -119,10 +119,10 @@ pub async fn purge_expired_messages(
     let result = sqlx::query(
         "DELETE FROM chat_messages WHERE ctid IN \
          (SELECT ctid FROM chat_messages \
-          WHERE created_at < now() - make_interval(hours => $1) \
+          WHERE created_at < now() - ($1::bigint * interval '1 hour') \
           LIMIT $2)",
     )
-    .bind(retention_hours as i32)
+    .bind(retention_hours as i64)
     .bind(batch_size)
     .execute(pool)
     .await?;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
