### PR TITLE
coeemagic test

### DIFF
--- a/.github/workflows/updater-manifest.yml
+++ b/.github/workflows/updater-manifest.yml
@@ -1,0 +1,194 @@
+# Generate and upload latest.json for the Tauri in-app auto-updater.
+#
+# Problem: three Codemagic workflows build platform binaries in parallel,
+# each uploading its own .sig file. latest.json needs all three signatures
+# and URLs, so no single Codemagic workflow can produce it.
+#
+# Solution: this lightweight GHA job polls the GitHub Release until all
+# three platform .sig files are present, then assembles and uploads
+# latest.json. Runs on a free Ubuntu runner (~3 minutes).
+#
+# The updater endpoint in tauri.conf.json points to:
+#   https://github.com/TommasoRibaudo/wavis-public/releases/latest/download/latest.json
+#
+# Manual re-run: use workflow_dispatch with the tag name if a Codemagic
+# build was re-triggered after initial failure.
+
+name: Updater Manifest
+
+on:
+  push:
+    tags:
+      - "desktop-v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to generate manifest for (e.g. desktop-v0.2.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: updater-manifest-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  generate-manifest:
+    name: Generate and upload latest.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+
+    env:
+      TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION="${TAG#desktop-v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${VERSION}"
+
+      # ── Wait for the GitHub Release to exist ──────────────────────
+      # Codemagic creates it with `gh release create ... || true`,
+      # so the first workflow to finish creates it.
+      - name: Wait for release to exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEADLINE=$(( $(date +%s) + 3600 ))
+          until gh release view "${TAG}" --json tagName -q .tagName > /dev/null 2>&1; do
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "::error::Timed out waiting for release ${TAG} to be created (60 min)."
+              exit 1
+            fi
+            echo "Release not yet created. Retrying in 30s..."
+            sleep 30
+          done
+          echo "Release ${TAG} found."
+
+      # ── Wait for all three platform updater .sig files ────────────
+      # Artifact naming (from Tauri + codemagic.yaml):
+      #   Linux:   *.AppImage.tar.gz.sig  (crate name: wavis-gui)
+      #   Windows: *.nsis.zip.sig         (productName: Wavis)
+      #   macOS:   *.app.tar.gz.sig       (productName: Wavis)
+      - name: Wait for all platform sig files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DEADLINE=$(( $(date +%s) + 3600 ))
+          while true; do
+            ASSETS=$(gh release view "${TAG}" --json assets -q '[.assets[].name]')
+
+            LINUX_SIG=$(echo "$ASSETS" | jq -r '[.[] | select(test("\\.AppImage\\.tar\\.gz\\.sig$"))] | first // empty')
+            WIN_SIG=$(echo "$ASSETS"   | jq -r '[.[] | select(test("\\.nsis\\.zip\\.sig$"))]          | first // empty')
+            MAC_SIG=$(echo "$ASSETS"   | jq -r '[.[] | select(test("\\.app\\.tar\\.gz\\.sig$"))]      | first // empty')
+
+            echo "linux_sig=${LINUX_SIG:-(missing)}  win_sig=${WIN_SIG:-(missing)}  mac_sig=${MAC_SIG:-(missing)}"
+
+            if [ -n "$LINUX_SIG" ] && [ -n "$WIN_SIG" ] && [ -n "$MAC_SIG" ]; then
+              echo "All 3 platform sig files present."
+              break
+            fi
+
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "::error::Timed out waiting for all sig files (60 min). Missing platforms will not get auto-updates."
+              exit 1
+            fi
+            sleep 30
+          done
+
+      # ── Discover the updater bundle asset names (without .sig) ───
+      - name: Discover asset names
+        id: assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ASSETS=$(gh release view "${TAG}" --json assets -q '[.assets[].name]')
+
+          LINUX=$(echo "$ASSETS" | jq -r '[.[] | select(test("\\.AppImage\\.tar\\.gz$"))] | first // empty')
+          WIN=$(echo "$ASSETS"   | jq -r '[.[] | select(test("\\.nsis\\.zip$"))]          | first // empty')
+          MAC=$(echo "$ASSETS"   | jq -r '[.[] | select(test("\\.app\\.tar\\.gz$"))]      | first // empty')
+
+          if [ -z "$LINUX" ] || [ -z "$WIN" ] || [ -z "$MAC" ]; then
+            echo "::error::Could not find all updater bundle assets."
+            echo "  linux=${LINUX:-(missing)}  win=${WIN:-(missing)}  mac=${MAC:-(missing)}"
+            exit 1
+          fi
+
+          echo "linux=${LINUX}" >> "$GITHUB_OUTPUT"
+          echo "win=${WIN}"     >> "$GITHUB_OUTPUT"
+          echo "mac=${MAC}"     >> "$GITHUB_OUTPUT"
+          echo "Discovered: linux=${LINUX}  win=${WIN}  mac=${MAC}"
+
+      # ── Download .sig files ──────────────────────────────────────
+      - name: Download sig files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINUX: ${{ steps.assets.outputs.linux }}
+          WIN: ${{ steps.assets.outputs.win }}
+          MAC: ${{ steps.assets.outputs.mac }}
+        run: |
+          mkdir -p sigs
+          gh release download "${TAG}" \
+            --pattern "${LINUX}.sig" \
+            --pattern "${WIN}.sig"   \
+            --pattern "${MAC}.sig"   \
+            --dir ./sigs
+
+          echo "Downloaded sig files:"
+          ls -la sigs/
+
+      # ── Build latest.json and upload ─────────────────────────────
+      # Schema: https://v2.tauri.app/plugin/updater/
+      # Platform keys: linux-x86_64, windows-x86_64, darwin-aarch64
+      # (macOS is ARM64-only — built on mac_mini_m2)
+      - name: Build and upload latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          VERSION: ${{ steps.version.outputs.version }}
+          LINUX: ${{ steps.assets.outputs.linux }}
+          WIN: ${{ steps.assets.outputs.win }}
+          MAC: ${{ steps.assets.outputs.mac }}
+        run: |
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+          NOTES=$(gh release view "${TAG}" --json body -q '.body // ""')
+
+          jq -n \
+            --arg version  "$VERSION" \
+            --arg notes    "$NOTES" \
+            --arg pub_date "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            --arg lurl     "${BASE}/${LINUX}" \
+            --arg lsig     "$(cat sigs/${LINUX}.sig)" \
+            --arg wurl     "${BASE}/${WIN}" \
+            --arg wsig     "$(cat sigs/${WIN}.sig)" \
+            --arg murl     "${BASE}/${MAC}" \
+            --arg msig     "$(cat sigs/${MAC}.sig)" \
+            '{
+              version:  $version,
+              notes:    $notes,
+              pub_date: $pub_date,
+              platforms: {
+                "linux-x86_64":   { url: $lurl, signature: $lsig },
+                "windows-x86_64": { url: $wurl, signature: $wsig },
+                "darwin-aarch64": { url: $murl, signature: $msig }
+              }
+            }' > latest.json
+
+          echo "Generated latest.json:"
+          cat latest.json
+
+          # Validate: all signatures must be non-empty
+          for platform in "linux-x86_64" "windows-x86_64" "darwin-aarch64"; do
+            SIG=$(jq -r ".platforms.\"${platform}\".signature" latest.json)
+            if [ -z "$SIG" ] || [ "$SIG" = "null" ]; then
+              echo "::error::Empty signature for ${platform}"
+              exit 1
+            fi
+          done
+
+          gh release upload "${TAG}" latest.json --clobber
+          echo "latest.json uploaded to release ${TAG}."

--- a/clients/shared/src/livekit_video.rs
+++ b/clients/shared/src/livekit_video.rs
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_rgba_to_i420_supports_minimum_1x1_input() {
-        let i420 = rgba_to_i420(&vec![100u8, 150, 200, 255], 1, 1);
+        let i420 = rgba_to_i420(&[100u8, 150, 200, 255], 1, 1);
         let (stride_y, stride_u, stride_v) = i420.strides();
         let (y_data, u_data, v_data) = i420.data();
 

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,20 +1,36 @@
 # Codemagic desktop release workflows.
 #
-# Initial scope:
-# - Build Linux AppImage artifacts for the Tauri desktop client.
-# - Do not publish to GitHub Releases yet.
-# - Use this workflow first to prove Ubuntu can produce the AppImage/update
-#   artifacts that local Arch currently cannot package because of linuxdeploy
-#   `.relr.dyn` strip errors.
+# Workflows:
+# - desktop-linux-release:   Ubuntu AppImage (linux_x2)
+# - desktop-windows-release: Windows NSIS installer (windows_x2)
+# - desktop-macos-release:   macOS DMG (mac_mini_m2, ARM64)
 #
-# Required Codemagic secret:
-# - TAURI_SIGNING_PRIVATE_KEY: contents of .local-secrets/wavis-tauri-updater.key
+# All workflows trigger on tags matching desktop-v*.
+# All workflows publish artifacts to GitHub Releases on success.
+#
+# Required secrets — all stored in the "desktop-release" Codemagic environment group:
+#
+#   Shared (all platforms):
+#     TAURI_SIGNING_PRIVATE_KEY  — contents of .local-secrets/wavis-tauri-updater.key
+#
+#   macOS only:
+#     APPLE_CERTIFICATE          — base64-encoded Developer ID Application .p12 cert
+#     APPLE_CERTIFICATE_PASSWORD — password for the .p12
+#     APPLE_SIGNING_IDENTITY     — e.g. "Developer ID Application: Wavis (TEAMID)"
+#     APPLE_ID                   — Apple ID email used for notarization
+#     APPLE_APP_SPECIFIC_PASSWORD — app-specific password for notarization
+#     APPLE_TEAM_ID              — Apple Developer team ID
 
 workflows:
   desktop-linux-release:
     name: Desktop Linux Release
     instance_type: linux_x2
     max_build_duration: 120
+    cache:
+      cache_paths:
+        - ~/.cargo/registry
+        - ~/.cargo/git
+        - target
     triggering:
       events:
         - push
@@ -87,6 +103,20 @@ workflows:
           find target/release/bundle -maxdepth 3 -type f \
             \( -name "*.AppImage" -o -name "*.sig" -o -name "*.tar.gz" -o -name "*.deb" -o -name "*.rpm" \) \
             -print
+      - name: Publish to GitHub Releases
+        script: |
+          if [ -z "$CM_TAG" ]; then
+            echo "Not a tag build, skipping GitHub Releases publish."
+            exit 0
+          fi
+          export GITHUB_TOKEN="$CM_GITHUB_TOKEN"
+          gh release create "$CM_TAG" --title "$CM_TAG" --generate-notes || true
+          gh release upload "$CM_TAG" \
+            target/release/bundle/appimage/*.AppImage \
+            target/release/bundle/appimage/*.AppImage.sig \
+            target/release/bundle/appimage/*.tar.gz \
+            target/release/bundle/appimage/*.tar.gz.sig \
+            --clobber
     artifacts:
       - target/release/bundle/appimage/*.AppImage
       - target/release/bundle/appimage/*.AppImage.sig
@@ -94,3 +124,170 @@ workflows:
       - target/release/bundle/appimage/*.tar.gz.sig
       - target/release/bundle/deb/*.deb
       - target/release/bundle/rpm/*.rpm
+
+  desktop-windows-release:
+    name: Desktop Windows Release
+    instance_type: windows_x2
+    max_build_duration: 120
+    cache:
+      cache_paths:
+        - ~/.cargo/registry
+        - ~/.cargo/git
+        - target
+    triggering:
+      events:
+        - push
+      tag_patterns:
+        - pattern: "desktop-v*"
+          include: true
+      cancel_previous_builds: true
+    environment:
+      groups:
+        - desktop-release
+      vars:
+        WAVIS_GUI_DIR: clients/wavis-gui
+    scripts:
+      - name: Install Rust toolchain
+        script: |
+          if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
+            Invoke-WebRequest -Uri "https://win.rustup.rs/x86_64" -OutFile "$env:TEMP\rustup-init.exe"
+            & "$env:TEMP\rustup-init.exe" -y --default-toolchain stable --no-modify-path
+          }
+          $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+          rustup default stable
+      - name: Verify toolchains
+        script: |
+          $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+          node --version
+          npm --version
+          rustc --version
+          cargo --version
+      - name: Install frontend dependencies
+        script: |
+          cd $env:WAVIS_GUI_DIR
+          npm install
+      - name: Run frontend tests
+        script: |
+          cd $env:WAVIS_GUI_DIR
+          npm test
+      - name: Build frontend
+        script: |
+          cd $env:WAVIS_GUI_DIR
+          npm run build
+      - name: Build signed Windows installer
+        script: |
+          if (-not $env:TAURI_SIGNING_PRIVATE_KEY) {
+            Write-Error "TAURI_SIGNING_PRIVATE_KEY is required for updater artifacts."
+            exit 1
+          }
+          $env:Path = "$env:USERPROFILE\.cargo\bin;$env:Path"
+          cd $env:WAVIS_GUI_DIR
+          npm run tauri build -- --bundles nsis --verbose
+      - name: Publish to GitHub Releases
+        script: |
+          if (-not $env:CM_TAG) {
+            Write-Host "Not a tag build, skipping GitHub Releases publish."
+            exit 0
+          }
+          $env:GITHUB_TOKEN = $env:CM_GITHUB_TOKEN
+          gh release create $env:CM_TAG --title $env:CM_TAG --generate-notes
+          if ($LASTEXITCODE -ne 0) { Write-Host "Release already exists, continuing." }
+          $artifacts = Get-ChildItem `
+            target/release/bundle/nsis/*.exe, `
+            target/release/bundle/nsis/*.exe.sig, `
+            target/release/bundle/nsis/*.nsis.zip, `
+            target/release/bundle/nsis/*.nsis.zip.sig `
+            -ErrorAction SilentlyContinue
+          gh release upload $env:CM_TAG $artifacts --clobber
+    artifacts:
+      - target/release/bundle/nsis/*.exe
+      - target/release/bundle/nsis/*.exe.sig
+      - target/release/bundle/nsis/*.nsis.zip
+      - target/release/bundle/nsis/*.nsis.zip.sig
+
+  desktop-macos-release:
+    name: Desktop macOS Release
+    instance_type: mac_mini_m2
+    max_build_duration: 120
+    cache:
+      cache_paths:
+        - ~/.cargo/registry
+        - ~/.cargo/git
+        - target
+    triggering:
+      events:
+        - push
+      tag_patterns:
+        - pattern: "desktop-v*"
+          include: true
+      cancel_previous_builds: true
+    environment:
+      groups:
+        - desktop-release
+      vars:
+        WAVIS_GUI_DIR: clients/wavis-gui
+    scripts:
+      - name: Install Rust toolchain
+        script: |
+          if ! command -v rustup >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          fi
+          export PATH="$HOME/.cargo/bin:$PATH"
+          rustup default stable
+      - name: Verify toolchains
+        script: |
+          export PATH="$HOME/.cargo/bin:$PATH"
+          node --version
+          npm --version
+          rustc --version
+          cargo --version
+      - name: Install frontend dependencies
+        script: |
+          cd "$WAVIS_GUI_DIR"
+          npm install
+      - name: Run frontend tests
+        script: |
+          cd "$WAVIS_GUI_DIR"
+          npm test
+      - name: Build frontend
+        script: |
+          cd "$WAVIS_GUI_DIR"
+          npm run build
+      - name: Import Apple signing certificate
+        script: |
+          echo "$APPLE_CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import /tmp/certificate.p12 -k build.keychain \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          rm /tmp/certificate.p12
+      - name: Build signed macOS DMG
+        script: |
+          if [ -z "$TAURI_SIGNING_PRIVATE_KEY" ]; then
+            echo "TAURI_SIGNING_PRIVATE_KEY is required for updater artifacts."
+            exit 1
+          fi
+          export PATH="$HOME/.cargo/bin:$PATH"
+          cd "$WAVIS_GUI_DIR"
+          npm run tauri build -- --bundles dmg --verbose
+      - name: Publish to GitHub Releases
+        script: |
+          if [ -z "$CM_TAG" ]; then
+            echo "Not a tag build, skipping GitHub Releases publish."
+            exit 0
+          fi
+          export GITHUB_TOKEN="$CM_GITHUB_TOKEN"
+          gh release create "$CM_TAG" --title "$CM_TAG" --generate-notes || true
+          gh release upload "$CM_TAG" \
+            target/release/bundle/dmg/*.dmg \
+            target/release/bundle/macos/*.app.tar.gz \
+            target/release/bundle/macos/*.app.tar.gz.sig \
+            --clobber
+    artifacts:
+      - target/release/bundle/dmg/*.dmg
+      - target/release/bundle/macos/*.app.tar.gz
+      - target/release/bundle/macos/*.app.tar.gz.sig

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Usage: node scripts/bump-version.js <version>
+//
+// Updates the version field in both:
+//   clients/wavis-gui/src-tauri/tauri.conf.json
+//   clients/wavis-gui/package.json
+//
+// Run this before committing and tagging a release:
+//   node scripts/bump-version.js 0.2.0
+//   git add clients/wavis-gui/src-tauri/tauri.conf.json clients/wavis-gui/package.json
+//   git commit -m "chore: bump version to 0.2.0"
+//   git tag desktop-v0.2.0
+//   git push && git push --tags
+
+import { readFileSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const version = process.argv[2];
+if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+  console.error('Usage: node scripts/bump-version.js <version>  (e.g. 0.2.0)');
+  process.exit(1);
+}
+
+function bump(filePath, mutate) {
+  const raw = readFileSync(filePath, 'utf8');
+  const obj = JSON.parse(raw);
+  const old = obj.version;
+  mutate(obj);
+  writeFileSync(filePath, JSON.stringify(obj, null, 2) + '\n');
+  console.log(`${filePath.replace(root + '/', '')}:  ${old} → ${obj.version}`);
+}
+
+bump(join(root, 'clients/wavis-gui/src-tauri/tauri.conf.json'), o => { o.version = version; });
+bump(join(root, 'clients/wavis-gui/package.json'),              o => { o.version = version; });
+
+console.log(`\nNext steps:`);
+console.log(`  git add clients/wavis-gui/src-tauri/tauri.conf.json clients/wavis-gui/package.json`);
+console.log(`  git commit -m "chore: bump version to ${version}"`);
+console.log(`  git tag desktop-v${version}`);
+console.log(`  git push && git push --tags`);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
