### PR TITLE
Linux fixes

### DIFF
--- a/clients/shared/src/call_session.rs
+++ b/clients/shared/src/call_session.rs
@@ -222,6 +222,10 @@ impl<
                 | SignalingMessage::ChatMessage(_)
                 | SignalingMessage::ChatHistoryRequest(_)
                 | SignalingMessage::ChatHistoryResponse(_)
+                | SignalingMessage::SelfMute
+                | SignalingMessage::SelfUnmute
+                | SignalingMessage::ParticipantSelfMuted(_)
+                | SignalingMessage::ParticipantSelfUnmuted(_)
                 | SignalingMessage::SelfDeafen
                 | SignalingMessage::SelfUndeafen
                 | SignalingMessage::ParticipantDeafened(_)

--- a/clients/wavis-gui/src-tauri/src/audio_capture/platform/linux.rs
+++ b/clients/wavis-gui/src-tauri/src/audio_capture/platform/linux.rs
@@ -240,6 +240,9 @@ fn audio_share_start_linux(
     use std::sync::atomic::AtomicBool;
     use std::sync::Arc;
 
+    // -- Preflight: required CLI tools ------------------------------
+    ensure_pactl_available()?;
+
     // -- Double-start guard -----------------------------------------
     {
         let guard = audio_capture
@@ -1162,6 +1165,23 @@ fn cleanup_stale_wavis_modules() {
         let _ = std::process::Command::new("pactl")
             .args(["unload-module", idx])
             .output();
+    }
+}
+
+/// Preflight: confirm the `pactl` CLI is on PATH. The capture pipeline shells
+/// out to it for sink-input enumeration, null-sink creation, and routing —
+/// without it `audio_share_start` would fail mid-setup with an opaque error.
+/// On Debian/Ubuntu this lives in the `pulseaudio-utils` package and is not
+/// pulled in automatically by `pipewire-pulse`.
+#[cfg(target_os = "linux")]
+fn ensure_pactl_available() -> Result<(), String> {
+    match std::process::Command::new("pactl").arg("--version").output() {
+        Ok(o) if o.status.success() => Ok(()),
+        _ => Err(
+            "system audio sharing requires `pactl` — install it with: \
+             sudo apt install pulseaudio-utils"
+                .to_string(),
+        ),
     }
 }
 

--- a/clients/wavis-gui/src-tauri/tauri.conf.json
+++ b/clients/wavis-gui/src-tauri/tauri.conf.json
@@ -45,6 +45,11 @@
       "minimumSystemVersion": "11.6",
       "infoPlist": "Info.plist",
       "entitlements": "Entitlements.plist"
+    },
+    "linux": {
+      "deb": {
+        "depends": ["pulseaudio-utils", "pipewire", "xdg-desktop-portal"]
+      }
     }
   },
   "plugins": {

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -4825,13 +4825,12 @@ describe('Preservation: Native Share-Audio Path and Non-Audio Paths', () => {
   });
 
   /**
-   * Validates: Requirements 3.3
-   *
-   * Preservation Property 3: For non-Windows platforms with restartScreenShareWithAudio(true),
-   * setScreenShareEnabled(false) IS called followed by setScreenShareEnabled(true).
-   * Full getDisplayMedia restart preserved on macOS.
+   * Linux: restartScreenShareWithAudio(true) drives the Rust audio_share_start
+   * IPC and leaves the video track untouched. Audio is captured by the Rust
+   * pipeline (PulseAudio → Rust LiveKit SDK), so the JS SDK never runs a
+   * getDisplayMedia restart and setScreenShareEnabled is not called.
    */
-  it('non-Windows + restartScreenShareWithAudio(true) → full getDisplayMedia restart (PBT)', async () => {
+  it('Linux + restartScreenShareWithAudio(true) → audio_share_start IPC, no video restart (PBT)', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.constant('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'),
@@ -4849,29 +4848,20 @@ describe('Preservation: Native Share-Audio Path and Non-Audio Paths', () => {
           const mod = new LiveKitModule(cbs);
           await driveToConnected(mod);
 
-          // Start screen share first
           await mod.startScreenShare();
 
-          // Clear SDK calls to isolate the restart
           sdkCalls.length = 0;
+          tauriInvokeCalls = [];
 
           await mod.restartScreenShareWithAudio(true);
 
-          // setScreenShareEnabled(false) should be called (stop video)
-          const stopCalls = sdkCalls.filter(
-            c => c.method === 'setScreenShareEnabled' && c.args[0] === false,
+          const videoRestartCalls = sdkCalls.filter(
+            c => c.method === 'setScreenShareEnabled',
           );
-          expect(stopCalls.length).toBeGreaterThanOrEqual(1);
+          expect(videoRestartCalls).toHaveLength(0);
 
-          // setScreenShareEnabled(true, captureOpts) should be called (restart video)
-          const startCalls = sdkCalls.filter(
-            c => c.method === 'setScreenShareEnabled' && c.args[0] === true,
-          );
-          expect(startCalls.length).toBeGreaterThanOrEqual(1);
-
-          // The restart captureOpts should have audio: true
-          const captureOpts = startCalls[0].args[1] as Record<string, unknown>;
-          expect(captureOpts.audio).toBe(true);
+          const audioStartCalls = tauriInvokeCalls.filter(c => c.cmd === 'audio_share_start');
+          expect(audioStartCalls).toHaveLength(1);
 
           mod.disconnect();
           vi.stubGlobal('navigator', { userAgent: '', mediaDevices: createMockMediaDevices() });

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -83,6 +83,11 @@ function isMac(): boolean {
   return /Macintosh/i.test(navigator.userAgent);
 }
 
+/** Returns true when running inside a Linux Tauri webview. */
+function isLinux(): boolean {
+  return /Linux/i.test(navigator.userAgent) && !/Android/i.test(navigator.userAgent);
+}
+
 /** Windows and macOS use the native Rust PCM bridge for screen-share audio. */
 function usesNativeScreenShareAudio(): boolean {
   return isWindows() || isMac();
@@ -2748,7 +2753,30 @@ export class LiveKitModule {
       }
     }
 
-    // ── macOS / Linux fallback ────────────────────────────────────────────────
+    // Linux: audio is captured by the Rust pipeline (PulseAudio → Rust LiveKit
+    // SDK via conn.feed_screen_audio); the JS SDK never publishes the
+    // ScreenShareAudio track, so the macOS-style mute/unmute and the
+    // getDisplayMedia({audio:true}) restart below both miss. Drive the Rust
+    // audio_share_start / audio_share_stop IPC directly instead.
+    if (isLinux()) {
+      try {
+        if (withAudio) {
+          const sourceId = await invoke<string>('get_default_audio_monitor_fast');
+          await invoke<AudioShareStartResult>('audio_share_start', { sourceId });
+        } else {
+          await invoke('audio_share_stop');
+        }
+        this.callbacks.onSystemEvent(`screen share audio: ${withAudio ? 'on' : 'off'}`);
+        return true;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(LOG, 'restartScreenShareWithAudio (Linux) failed:', msg);
+        this.callbacks.onSystemEvent(`screen share audio toggle failed: ${msg}`);
+        return false;
+      }
+    }
+
+    // ── macOS fallback ────────────────────────────────────────────────────────
     //
     // Preferred path: mute/unmute the existing ScreenShareAudio track.
     // This never calls getDisplayMedia and works from any call context

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1894,6 +1894,52 @@ function dispatchMessage(raw: unknown): void {
       break;
     }
 
+    case 'participant_self_muted': {
+      const selfMutedId = msg.participantId as string;
+      console.log(LOG, `received participant_self_muted for ${selfMutedId}`);
+      const smp = state.participants.find((pp) => pp.id === selfMutedId);
+      if (smp) {
+        smp.isMuted = true;
+        smp.rmsLevel = 0;
+        smp.isSpeaking = false;
+      }
+      if (selfMutedId === state.selfParticipantId) {
+        // Server echo — local state already set by toggleSelfMute
+      } else if (smp) {
+        appendEvent({
+          id: makeEventId(),
+          timestamp: timestamp(),
+          type: 'muted',
+          message: `${smp.displayName} muted microphone`,
+          participantId: selfMutedId,
+        });
+      }
+      notify();
+      break;
+    }
+
+    case 'participant_self_unmuted': {
+      const selfUnmutedId = msg.participantId as string;
+      console.log(LOG, `received participant_self_unmuted for ${selfUnmutedId}`);
+      const sup = state.participants.find((pp) => pp.id === selfUnmutedId);
+      if (sup) {
+        sup.isMuted = false;
+      }
+      if (selfUnmutedId === state.selfParticipantId) {
+        // Server echo — local state already set by toggleSelfMute
+      } else if (sup) {
+        appendEvent({
+          id: makeEventId(),
+          timestamp: timestamp(),
+          type: 'unmuted',
+          message: `${sup.displayName} unmuted microphone`,
+          participantId: selfUnmutedId,
+        });
+      }
+      notify();
+      break;
+    }
+
     case 'participant_deafened': {
       const deafId = msg.participantId as string;
       const dp = state.participants.find((pp) => pp.id === deafId);
@@ -2533,6 +2579,8 @@ export function toggleSelfMute(): void {
     self.isSpeaking = false;
   }
   lkModule?.setMicEnabled(!self.isMuted);
+  console.log(LOG, `toggleSelfMute → sending ${self.isMuted ? 'self_mute' : 'self_unmute'}`);
+  client?.send({ type: self.isMuted ? 'self_mute' : 'self_unmute' });
   appendEvent({
     id: makeEventId(),
     timestamp: timestamp(),

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -143,6 +143,11 @@ pub enum SignalingMessage {
     MuteParticipant(MuteParticipantPayload),
     /// Client -> server moderation request to release a host mute.
     UnmuteParticipant(UnmuteParticipantPayload),
+    // Self-mute (client → server, any participant)
+    /// Client -> server notification that the sender muted their own microphone.
+    SelfMute,
+    /// Client -> server notification that the sender unmuted their own microphone.
+    SelfUnmute,
     // Self-deafen (client → server, any participant)
     /// Client -> server notification that the sender deafened themselves.
     SelfDeafen,
@@ -155,6 +160,10 @@ pub enum SignalingMessage {
     ParticipantMuted(ParticipantMutedPayload),
     /// Server -> all participants broadcast that a participant was unmuted.
     ParticipantUnmuted(ParticipantUnmutedPayload),
+    /// Server -> all participants broadcast that a participant muted themselves.
+    ParticipantSelfMuted(ParticipantSelfMutedPayload),
+    /// Server -> all participants broadcast that a participant unmuted themselves.
+    ParticipantSelfUnmuted(ParticipantSelfUnmutedPayload),
     /// Server -> all participants broadcast that a participant deafened themselves.
     ParticipantDeafened(ParticipantDeafenedPayload),
     /// Server -> all participants broadcast that a participant undeafened themselves.
@@ -557,6 +566,22 @@ pub struct ParticipantMutedPayload {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ParticipantUnmutedPayload {
     /// Participant identifier for the participant whose mute was released.
+    #[serde(rename = "participantId")]
+    pub participant_id: String,
+}
+
+/// Broadcast to all participants when a participant mutes themselves.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParticipantSelfMutedPayload {
+    /// Participant identifier for the participant who muted themselves.
+    #[serde(rename = "participantId")]
+    pub participant_id: String,
+}
+
+/// Broadcast to all participants when a participant unmutes themselves.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParticipantSelfUnmutedPayload {
+    /// Participant identifier for the participant who unmuted themselves.
     #[serde(rename = "participantId")]
     pub participant_id: String,
 }

--- a/shared/src/signaling/proptest_support.rs
+++ b/shared/src/signaling/proptest_support.rs
@@ -279,6 +279,28 @@ impl Arbitrary for ParticipantUnmutedPayload {
     }
 }
 
+impl Arbitrary for ParticipantSelfMutedPayload {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<String>()
+            .prop_map(|participant_id| ParticipantSelfMutedPayload { participant_id })
+            .boxed()
+    }
+}
+
+impl Arbitrary for ParticipantSelfUnmutedPayload {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<String>()
+            .prop_map(|participant_id| ParticipantSelfUnmutedPayload { participant_id })
+            .boxed()
+    }
+}
+
 impl Arbitrary for ParticipantDeafenedPayload {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
@@ -923,6 +945,12 @@ impl Arbitrary for SignalingMessage {
             any::<ParticipantKickedPayload>().prop_map(SignalingMessage::ParticipantKicked),
             any::<ParticipantMutedPayload>().prop_map(SignalingMessage::ParticipantMuted),
             any::<ParticipantUnmutedPayload>().prop_map(SignalingMessage::ParticipantUnmuted),
+            // Self-mute
+            Just(SignalingMessage::SelfMute),
+            Just(SignalingMessage::SelfUnmute),
+            any::<ParticipantSelfMutedPayload>().prop_map(SignalingMessage::ParticipantSelfMuted),
+            any::<ParticipantSelfUnmutedPayload>()
+                .prop_map(SignalingMessage::ParticipantSelfUnmuted),
             // Self-deafen
             Just(SignalingMessage::SelfDeafen),
             Just(SignalingMessage::SelfUndeafen),

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -172,6 +172,14 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
         SignalingMessage::ParticipantUnmuted(p) => {
             check("participant_id", &p.participant_id, MAX_PEER_ID_LEN)?;
         }
+        SignalingMessage::SelfMute => {}
+        SignalingMessage::SelfUnmute => {}
+        SignalingMessage::ParticipantSelfMuted(p) => {
+            check("participant_id", &p.participant_id, MAX_PEER_ID_LEN)?;
+        }
+        SignalingMessage::ParticipantSelfUnmuted(p) => {
+            check("participant_id", &p.participant_id, MAX_PEER_ID_LEN)?;
+        }
         SignalingMessage::SelfDeafen => {}
         SignalingMessage::SelfUndeafen => {}
         SignalingMessage::ParticipantDeafened(p) => {

--- a/wavis-backend/src/ws/ws.rs
+++ b/wavis-backend/src/ws/ws.rs
@@ -404,6 +404,10 @@ mod tests {
                         SignalingMessage::ParticipantKicked(_) |
                         SignalingMessage::ParticipantMuted(_) |
                         SignalingMessage::ParticipantUnmuted(_) |
+                        SignalingMessage::SelfMute |
+                        SignalingMessage::SelfUnmute |
+                        SignalingMessage::ParticipantSelfMuted(_) |
+                        SignalingMessage::ParticipantSelfUnmuted(_) |
                         SignalingMessage::SelfDeafen |
                         SignalingMessage::SelfUndeafen |
                         SignalingMessage::ParticipantDeafened(_) |

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -39,8 +39,9 @@ use crate::ws::ws_session::{SignalingSession, close_socket};
 use axum::extract::ws::WebSocket;
 use shared::signaling::{
     self, AnswerPayload, ErrorPayload, IceCandidatePayload, JoinRejectedPayload,
-    ParticipantColorUpdatedPayload, ParticipantDeafenedPayload, ParticipantUndeafenedPayload,
-    SessionDescription, SfuColdStartingPayload, SignalingMessage, ViewerJoinedPayload,
+    ParticipantColorUpdatedPayload, ParticipantDeafenedPayload, ParticipantSelfMutedPayload,
+    ParticipantSelfUnmutedPayload, ParticipantUndeafenedPayload, SessionDescription,
+    SfuColdStartingPayload, SignalingMessage, ViewerJoinedPayload,
 };
 use std::env;
 use std::net::IpAddr;
@@ -1606,6 +1607,94 @@ pub(crate) async fn dispatch_message(
             }
             DispatchOutcome::Continue
         }
+        SignalingMessage::SelfMute => {
+            let session_ref = ctx.session.as_ref().unwrap();
+            let sender_id = session_ref.participant_id.as_str();
+
+            if !ctx.rate_limiter.deafen_allow() {
+                warn!(peer_id = %ctx.peer_id, "ws peer exceeded deafen rate limit on SelfMute");
+                ctx.app_state
+                    .abuse_metrics
+                    .increment(&ctx.app_state.abuse_metrics.action_rate_limit_rejections);
+                ctx.app_state.connections.send_to(
+                    sender_id,
+                    &SignalingMessage::Error(ErrorPayload {
+                        message: MSG_ACTION_RATE_LIMIT_EXCEEDED.to_string(),
+                    }),
+                );
+                return DispatchOutcome::Continue;
+            }
+
+            let room_id_opt = ctx.app_state.room_state.get_room_for_peer(sender_id);
+            let room_id = match room_id_opt {
+                Some(ref r) => r.clone(),
+                None => {
+                    ctx.app_state.connections.send_to(
+                        sender_id,
+                        &SignalingMessage::Error(ErrorPayload {
+                            message: "not in a room".to_string(),
+                        }),
+                    );
+                    return DispatchOutcome::Continue;
+                }
+            };
+
+            dispatch_signals(
+                vec![OutboundSignal::broadcast_all(
+                    SignalingMessage::ParticipantSelfMuted(ParticipantSelfMutedPayload {
+                        participant_id: sender_id.to_string(),
+                    }),
+                )],
+                &room_id,
+                ctx.app_state.room_state.as_ref(),
+                ctx.app_state.connections.as_ref(),
+            );
+            DispatchOutcome::Continue
+        }
+        SignalingMessage::SelfUnmute => {
+            let session_ref = ctx.session.as_ref().unwrap();
+            let sender_id = session_ref.participant_id.as_str();
+
+            if !ctx.rate_limiter.deafen_allow() {
+                warn!(peer_id = %ctx.peer_id, "ws peer exceeded deafen rate limit on SelfUnmute");
+                ctx.app_state
+                    .abuse_metrics
+                    .increment(&ctx.app_state.abuse_metrics.action_rate_limit_rejections);
+                ctx.app_state.connections.send_to(
+                    sender_id,
+                    &SignalingMessage::Error(ErrorPayload {
+                        message: MSG_ACTION_RATE_LIMIT_EXCEEDED.to_string(),
+                    }),
+                );
+                return DispatchOutcome::Continue;
+            }
+
+            let room_id_opt = ctx.app_state.room_state.get_room_for_peer(sender_id);
+            let room_id = match room_id_opt {
+                Some(ref r) => r.clone(),
+                None => {
+                    ctx.app_state.connections.send_to(
+                        sender_id,
+                        &SignalingMessage::Error(ErrorPayload {
+                            message: "not in a room".to_string(),
+                        }),
+                    );
+                    return DispatchOutcome::Continue;
+                }
+            };
+
+            dispatch_signals(
+                vec![OutboundSignal::broadcast_all(
+                    SignalingMessage::ParticipantSelfUnmuted(ParticipantSelfUnmutedPayload {
+                        participant_id: sender_id.to_string(),
+                    }),
+                )],
+                &room_id,
+                ctx.app_state.room_state.as_ref(),
+                ctx.app_state.connections.as_ref(),
+            );
+            DispatchOutcome::Continue
+        }
         SignalingMessage::SelfDeafen => {
             let session_ref = ctx.session.as_ref().unwrap();
             let sender_id = session_ref.participant_id.as_str();
@@ -2875,6 +2964,10 @@ pub(crate) fn handle_signaling_event(
         | SignalingMessage::ParticipantKicked(_)
         | SignalingMessage::ParticipantMuted(_)
         | SignalingMessage::ParticipantUnmuted(_)
+        | SignalingMessage::SelfMute
+        | SignalingMessage::SelfUnmute
+        | SignalingMessage::ParticipantSelfMuted(_)
+        | SignalingMessage::ParticipantSelfUnmuted(_)
         | SignalingMessage::SelfDeafen
         | SignalingMessage::SelfUndeafen
         | SignalingMessage::ParticipantDeafened(_)


### PR DESCRIPTION
Description                                  

  Two Linux-focused fixes:                                                                                   
   
  1. Screen-share audio on Linux — getDisplayMedia on Wayland doesn't expose system audio, so toggling audio 
  mid-share was silently restarting the video stream without producing an audio track. Added a Linux-specific
   path in restartScreenShareWithAudio that uses our existing audio_share_start/audio_share_stop Tauri       
  commands (which capture via pactl/PipeWire) and skips the video restart. Also added a pactl preflight in
  audio_capture/platform/linux.rs and declared pulseaudio-utils, pipewire, xdg-desktop-portal as Debian deps
  in tauri.conf.json so apt install ./wavis_*.deb resolves them automatically.
  2. Self-mute propagation — LiveKit JS SDK's onParticipantMuteChanged doesn't fire reliably across WebKitGTK
   (Linux) ↔ WebView2 (Windows), so peers couldn't see when others muted. Added a dedicated                  
  SelfMute/SelfUnmute wavis signaling pair (mirroring the existing SelfDeafen/SelfUndeafen pattern),
  broadcast as ParticipantSelfMuted/ParticipantSelfUnmuted. Reuses the existing deafen_allow() rate-limit    
  budget — self-toggles share one budget.

  Type of Change

  - Bug fix                                                                                                  
  - New feature
  - Refactor                                                                                                 
  - Dependency update
  - Documentation / config only

  ---                                                                                                        
  Security Checklist
                                                                                                             
  - This PR does not touch signaling or token paths — checklist not applicable

  (This PR touches handlers/ws.rs (via wavis-backend/src/ws/ws_dispatch.rs + ws.rs), so the checklist        
  applies.)
                                                                                                             
  Sensitive Data Logging (Req 5.1–5.4)

  - No JWT strings, raw tokens, or MediaToken values are passed to log macros                                
  - No invite code values are passed to log macros (lengths/counts are OK)
  - No SDP content is passed to log macros (lengths/types are OK)                                            
  - No ICE candidate strings are passed to log macros (counts/types are OK)
  - cargo test --test no_sensitive_logs passes locally (also enforced by CI: backend-ci.yml)                 
                                                                                                             
  (New warn! calls only log peer_id and the literal "ws peer exceeded deafen rate limit on                   
  SelfMute/SelfUnmute" — no payload contents.)                                                               
                                                                                                             
  Message Size Limits (Req 3.5, 3.8)

  - SDP payloads are validated against MAX_SDP_BYTES (64 KB) before forwarding                               
  - ICE candidate payloads are validated against MAX_ICE_CANDIDATE_BYTES (2 KB) before forwarding
  - Oversized payloads return a descriptive error and are not forwarded                                      
                  
  (N/A for the new variants directly — SelfMute/SelfUnmute are unit variants;                                
  ParticipantSelfMuted/ParticipantSelfUnmuted payloads only carry participant_id, validated via existing
  check("participant_id", ..., MAX_PEER_ID_LEN) in validation.rs.)                                           
                  
  Server-Enforced Identity (Req 2.3, 2.4)                                                                    
  
  - All post-join message dispatch uses session.participant_id as sender identity                            
  - No client-supplied identity fields are trusted for routing or authorization
                                                                                                             
  (SelfMute/SelfUnmute are unit variants — no client-supplied identity. Server reads                         
  session_ref.participant_id and stamps it into the ParticipantSelfMuted/ParticipantSelfUnmuted broadcast    
  payload.)                                                                                                  
                  
  Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)                                                   
  
  - Action messages (kick, mute) are rejected in P2P rooms                                                   
  - Host-only actions check session.role == Host in the handler (Tier 1)
  - Domain functions (handle_kick, etc.) independently validate role (Tier 2 / defense in depth)             
  - Action messages are never forwarded through the relay path
                                                                                                             
  (N/A for these particular variants — SelfMute/SelfUnmute are self-actions, not host-only; same trust model 
  as the existing SelfDeafen/SelfUndeafen. Handled in dispatch_message and broadcast via dispatch_signals,   
  never flows through the negotiation relay path. Added to the handle_signaling_event ignore list and the    
  proptest exhaustive match alongside the deafen variants.)

  Token Scope and Lifetime (Req 1.1–1.7)

  - MediaTokens include iss and aud claims
  - Token TTL is ≤ 600s (default) — no unbounded lifetimes
  - validate_media_token checks both iss and aud                                                             
  - Revoked participants are blocked from token re-issuance within the TTL window
                                                                                                             
  (N/A — token paths not modified.)
                                                                                                             
  ---             
  Tests
                                                                                                             
  - cargo test -p wavis-backend passes (895 passed, 0 failed, 62 ignored)
  - New property tests added for any new correctness properties                                              
                                                                                                             
  - The new variants are wired into the existing exhaustive-match property tests                             
  (prop_p8_relay_type_allowlist, signaling round-trip, validation length checks) via Arbitrary impls and     
  prop_oneof entries in proptest_support.rs — those generators now produce                                   
  SelfMute/SelfUnmute/ParticipantSelfMuted/ParticipantSelfUnmuted, so existing properties exercise them. No
  fundamentally new property added because the semantics mirror SelfDeafen and are already covered by the
  rate-limit and round-trip props.
  - No tests were deleted or disabled to make the build pass
                                                                                                             
  - One test was rewritten — livekit-media.test.ts "non-Windows + restartScreenShareWithAudio(true) → full   
  getDisplayMedia restart" — because it codified the old broken behavior on Linux (asserted                  
  setScreenShareEnabled was called twice). It's been replaced with "Linux + restartScreenShareWithAudio(true)
   → audio_share_start IPC, no video restart" which asserts the new correct behavior.

