### PR TITLE
rate limiter updates

### DIFF
--- a/clients/wavis-gui/src/features/channels/ChannelDetail.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelDetail.tsx
@@ -35,6 +35,10 @@ import {
 } from '@shared/helpers';
 import { ChannelRoleBadge } from './ChannelRoleBadge';
 
+function apiErrorMessage(err: ApiError): string {
+  return err.kind === 'RateLimited' ? err.message : errorMessage(err.kind);
+}
+
 /* ─── Constants ─────────────────────────────────────────────────── */
 const DETAIL_POLL_MS = 15_000;
 const VOICE_POLL_MS = 5_000;
@@ -199,7 +203,7 @@ function InvitePanel({
       }
     } catch (err) {
       if (err instanceof ApiError) {
-        onError(errorMessage(err.kind));
+        onError(apiErrorMessage(err));
       } else {
         onError('something went wrong — try again');
       }
@@ -274,7 +278,7 @@ function RevokePanel({
         if (!cancelled) setInvites(list);
       } catch (err) {
         if (!cancelled) {
-          setLoadError(err instanceof ApiError ? errorMessage(err.kind) : 'failed to load invites');
+          setLoadError(err instanceof ApiError ? apiErrorMessage(err) : 'failed to load invites');
         }
       }
     })();
@@ -409,7 +413,7 @@ function UnbanPanel({
         if (!cancelled) setBanned(list);
       } catch (err) {
         if (!cancelled) {
-          setLoadError(err instanceof ApiError ? errorMessage(err.kind) : 'failed to load bans');
+          setLoadError(err instanceof ApiError ? apiErrorMessage(err) : 'failed to load bans');
         }
       }
     })();
@@ -539,7 +543,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
         }
         if (!silent) {
           if (err instanceof ApiError) {
-            setError(errorMessage(err.kind));
+            setError(apiErrorMessage(err));
           } else {
             setError('something went wrong — try again');
           }
@@ -613,7 +617,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
             }
             setSuccessMsg('state has changed — refreshed');
           } else {
-            setMutationError(errorMessage(err.kind));
+            setMutationError(apiErrorMessage(err));
           }
         } else {
           setMutationError('something went wrong — try again');
@@ -652,7 +656,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
       navigate('/', { replace: true });
     } catch (err) {
       if (err instanceof ApiError) {
-        setMutationError(errorMessage(err.kind));
+        setMutationError(apiErrorMessage(err));
       } else {
         setMutationError('something went wrong — try again');
       }
@@ -670,7 +674,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
       navigate('/', { replace: true });
     } catch (err) {
       if (err instanceof ApiError) {
-        setMutationError(errorMessage(err.kind));
+        setMutationError(apiErrorMessage(err));
       } else {
         setMutationError('something went wrong — try again');
       }

--- a/clients/wavis-gui/src/features/channels/ChannelsList.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelsList.tsx
@@ -23,6 +23,10 @@ import { usePolling } from '@shared/hooks/usePolling';
 const POLL_MS = 15_000;
 const DIVIDER = '─'.repeat(48);
 
+function apiErrorMessage(err: ApiError): string {
+  return err.kind === 'RateLimited' ? err.message : errorMessage(err.kind);
+}
+
 /* Component */
 export default function ChannelsList() {
   const navigate = useNavigate();
@@ -67,7 +71,7 @@ export default function ChannelsList() {
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.kind === 'RateLimited') skipTicksRef.current = 2;
-        setError(errorMessage(err.kind));
+        setError(apiErrorMessage(err));
       } else {
         setError('something went wrong — try again');
       }
@@ -143,7 +147,7 @@ export default function ChannelsList() {
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.kind === 'RateLimited') skipTicksRef.current = 2;
-        setCreateError(errorMessage(err.kind));
+        setCreateError(apiErrorMessage(err));
       } else {
         setCreateError('something went wrong — try again');
       }
@@ -176,7 +180,7 @@ export default function ChannelsList() {
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.kind === 'RateLimited') skipTicksRef.current = 2;
-        setJoinError(errorMessage(err.kind));
+        setJoinError(apiErrorMessage(err));
       } else {
         setJoinError('something went wrong — try again');
       }

--- a/clients/wavis-gui/src/features/diagnostics/bug-report.ts
+++ b/clients/wavis-gui/src/features/diagnostics/bug-report.ts
@@ -156,15 +156,23 @@ export async function submitBugReport(
   const token = await getAccessToken();
   const body = JSON.stringify(payload);
 
-  if (token) {
-    return apiFetch<BugReportResponse>('/bug-report', {
+  try {
+    if (token) {
+      return await apiFetch<BugReportResponse>('/bug-report', {
+        method: 'POST',
+        body,
+      });
+    }
+
+    return await apiPublicFetch<BugReportResponse>('/bug-report', {
       method: 'POST',
       body,
     });
+  } catch (err) {
+    if (err instanceof Error && 'kind' in err && (err as { kind?: string }).kind === 'RateLimited') {
+      const message = err.message.replace(/^too many requests — /i, 'please ');
+      throw new Error(message);
+    }
+    throw err;
   }
-
-  return apiPublicFetch<BugReportResponse>('/bug-report', {
-    method: 'POST',
-    body,
-  });
 }

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -166,13 +166,20 @@ interface ShareViewerWindow {
 
 /* ─── Sub-components ────────────────────────────────────────────── */
 
-function signalingIndicator(state: VoiceRoomMachineState): { color: string; label: string } {
+function signalingIndicator(
+  state: VoiceRoomMachineState,
+  lastRateLimitError: string | null,
+): { color: string; label: string } {
   switch (state) {
     case 'active': return { color: 'var(--wavis-accent)', label: 'Signaling: connected' };
     case 'connecting':
     case 'authenticated':
     case 'joining': return { color: 'var(--wavis-warn)', label: 'Signaling: connecting...' };
-    case 'reconnecting': return { color: 'var(--wavis-warn)', label: 'Signaling: reconnecting...' };
+    case 'reconnecting':
+      return {
+        color: 'var(--wavis-warn)',
+        label: lastRateLimitError ? 'Signaling: reconnecting after rate limit...' : 'Signaling: reconnecting...',
+      };
     case 'idle':
     default: return { color: 'var(--wavis-text-secondary)', label: 'Signaling: disconnected' };
   }
@@ -1881,7 +1888,7 @@ export default function ActiveRoom() {
 
   /* ── Reusable panel fragments ── */
 
-  const sigDot = signalingIndicator(roomState.machineState);
+  const sigDot = signalingIndicator(roomState.machineState, roomState.lastRateLimitError);
   const mediaDot = mediaIndicator(roomState.mediaState, roomState.mediaError);
   const statusBadge = combinedStatusBadge(roomState.machineState, roomState.mediaState);
 
@@ -1917,6 +1924,16 @@ export default function ActiveRoom() {
       >
         /retry
       </button>
+    </div>
+  ) : null;
+
+  const reconnectBanner = roomState.lastRateLimitError && (
+    roomState.machineState === 'reconnecting' ||
+    roomState.machineState === 'authenticated' ||
+    roomState.machineState === 'joining'
+  ) ? (
+    <div className="px-3 py-2 border-b border-wavis-warn bg-wavis-panel text-xs text-wavis-warn">
+      {roomState.lastRateLimitError}
     </div>
   ) : null;
 
@@ -2508,6 +2525,7 @@ export default function ActiveRoom() {
         </div>
 
         {mediaRetryBanner}
+        {reconnectBanner}
 
         {/* Tab bar */}
         <div className="flex border-b border-wavis-text-secondary bg-wavis-panel">
@@ -2545,6 +2563,7 @@ export default function ActiveRoom() {
         <div className="w-80 border-r border-wavis-text-secondary flex flex-col">
           {roomHeader}
           {mediaRetryBanner}
+          {reconnectBanner}
           {participantsSections}
           {youBar}
         </div>

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -166,6 +166,8 @@ export interface VoiceRoomState {
   activeAudioShare: { sourceId: string; sourceName: string } | null;
   /** Transient error from the last `error` signaling message (for chat panel display). */
   lastChatError: string | null;
+  /** Friendly reconnect notice persisted across a WS rate-limit disconnect cycle. */
+  lastRateLimitError: string | null;
   historyLoaded: boolean;
   /** Whether the local user is deafened (muted + volume 0). */
   isDeafened: boolean;
@@ -196,6 +198,8 @@ export const RMS_STOP_THRESHOLD = 0.03;
 export const MAX_EVENTS = 100;
 export const MAX_PARTICIPANTS = 6;
 export const MAX_CHAT_MESSAGES = 200;
+const WS_RATE_LIMIT_ERROR_MESSAGE = 'rate limit exceeded';
+const RATE_LIMIT_RECONNECT_MESSAGE = "Connection closed — you're sending messages too fast. Reconnecting";
 
 /**
  * EMA smoothing factor for RMS levels. Lower = smoother but more latent.
@@ -818,6 +822,7 @@ const DEFAULT_STATE: VoiceRoomState = {
   activeVideoShare: null,
   activeAudioShare: null,
   lastChatError: null,
+  lastRateLimitError: null,
   historyLoaded: false,
   isDeafened: false,
   latestClosedShareLeakSummary: null,
@@ -1029,6 +1034,10 @@ function appendEvent(event: RoomEvent): void {
   if (state.events.length > MAX_EVENTS) {
     state.events = state.events.slice(state.events.length - MAX_EVENTS);
   }
+}
+
+function isWsRateLimitError(message: string): boolean {
+  return message.trim().toLowerCase() === WS_RATE_LIMIT_ERROR_MESSAGE;
 }
 
 function deriveParticipantSubRoomById(subRooms: VoiceSubRoom[]): Record<string, string> {
@@ -1495,6 +1504,7 @@ function dispatchMessage(raw: unknown): void {
     case 'joined': {
       stopColdStartRetry();
       state.serverStartingEstimatedWaitSecs = null;
+      state.lastRateLimitError = null;
       state.selfParticipantId = msg.peerId as string;
       state.roomId = msg.roomId as string;
       syncDerivedSubRoomState();
@@ -1590,6 +1600,7 @@ function dispatchMessage(raw: unknown): void {
         invite_required: 'An invite code is required to join.',
         invite_exhausted: 'The invite code has been fully used.',
         invite_expired: 'The invite code has expired.',
+        rate_limited: 'Too many join attempts — please wait a moment before retrying.',
       };
       state.rejectionReason = friendlyMessages[rawReason] || `Join rejected: ${rawReason}`;
       if (client) {
@@ -2103,6 +2114,9 @@ function dispatchMessage(raw: unknown): void {
         message: errorMessage,
       });
       state.lastChatError = errorMessage;
+      state.lastRateLimitError = isWsRateLimitError(errorMessage)
+        ? RATE_LIMIT_RECONNECT_MESSAGE
+        : null;
       notify();
       break;
     }
@@ -2299,7 +2313,12 @@ export function initSession(
         // unnecessary audio/screenshare interruption during WS reconnects
         // (e.g. CloudFront idle timeout drops the WS every ~10 min).
         state.machineState = 'reconnecting';
-        appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'system', message: 'signaling connection lost — reconnecting' });
+        appendEvent({
+          id: makeEventId(),
+          timestamp: timestamp(),
+          type: 'system',
+          message: state.lastRateLimitError ?? 'signaling connection lost — reconnecting',
+        });
         notify();
       } else if (state.machineState === 'reconnecting') {
         // Already reconnecting and got another disconnect.
@@ -2313,6 +2332,7 @@ export function initSession(
           }
           appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'system', message: 'signaling reconnect failed — session lost' });
           state.error = 'Connection lost';
+          state.lastRateLimitError = null;
           state.machineState = 'idle';
           notify();
         }

--- a/clients/wavis-gui/src/shared/__tests__/api.test.ts
+++ b/clients/wavis-gui/src/shared/__tests__/api.test.ts
@@ -81,14 +81,22 @@ function mockOkResponse(body: string) {
   return {
     status: 200,
     ok: true,
+    headers: { get: () => null },
     text: () => Promise.resolve(body),
   };
 }
 
-function mockErrorResponse(status: number, body: string) {
+function mockErrorResponse(
+  status: number,
+  body: string,
+  headers: Record<string, string> = {},
+) {
   return {
     status,
     ok: false,
+    headers: {
+      get: (key: string) => headers[key] ?? headers[key.toLowerCase()] ?? null,
+    },
     text: () => Promise.resolve(body),
   };
 }
@@ -185,6 +193,19 @@ describe('apiFetch — server error message surfacing', () => {
 
     await expect(apiFetch('/test', {})).rejects.toMatchObject({
       message: 'too many requests — try again later',
+      kind: 'RateLimited',
+    });
+  });
+
+  it('includes Retry-After seconds in the 429 message when present', async () => {
+    tauriFetchMock.mockResolvedValue(
+      mockErrorResponse(429, JSON.stringify({ error: 'custom rate limit message' }), {
+        'Retry-After': '7',
+      }),
+    );
+
+    await expect(apiFetch('/test', {})).rejects.toMatchObject({
+      message: 'too many requests — try again in 7 seconds',
       kind: 'RateLimited',
     });
   });

--- a/clients/wavis-gui/src/shared/api.ts
+++ b/clients/wavis-gui/src/shared/api.ts
@@ -2,7 +2,7 @@
  * Wavis API Client (Tauri)
  *
  * Authenticated fetch wrapper using tauri-plugin-http.
- * Auto-attaches Bearer token, handles 401 → silent refresh → retry.
+ * Auto-attaches Bearer token, handles 401 -> silent refresh -> retry.
  * Classifies errors into typed ApiErrorKind for component-level handling.
  */
 
@@ -15,7 +15,7 @@ import {
   refreshTokens,
 } from '@features/auth/auth';
 
-// ─── Error Classification ──────────────────────────────────────────
+// Error Classification
 
 export type ApiErrorKind =
   | 'RateLimited'
@@ -39,7 +39,7 @@ export class ApiError extends Error {
   }
 }
 
-// ─── Helpers (private) ─────────────────────────────────────────────
+// Helpers (private)
 
 export function classifyError(status: number, body: string): ApiErrorKind {
   if (status === 429) return 'RateLimited';
@@ -52,6 +52,18 @@ export function classifyError(status: number, body: string): ApiErrorKind {
   if (status === 409 && bodyLower.includes('already a member')) return 'AlreadyMember';
   if (status === 0) return 'Network';
   return 'Unknown';
+}
+
+function rateLimitedMessage(headers: Headers): string {
+  const retryAfter = headers.get('Retry-After');
+  if (!retryAfter) return 'too many requests — try again later';
+
+  const secs = Number.parseInt(retryAfter, 10);
+  if (!Number.isFinite(secs) || secs <= 0) {
+    return 'too many requests — try again later';
+  }
+
+  return `too many requests — try again in ${secs} second${secs === 1 ? '' : 's'}`;
 }
 
 async function doFetch(
@@ -75,7 +87,7 @@ async function doFetch(
   return tauriFetch(endpoint, fetchOpts);
 }
 
-// ─── API Functions (exported) ──────────────────────────────────────
+// API Functions (exported)
 
 /**
  * Authenticated fetch wrapper.
@@ -150,7 +162,7 @@ export async function apiFetch<T = unknown>(
     }
     const message =
       kind === 'RateLimited'
-        ? 'too many requests — try again later'
+        ? rateLimitedMessage(res.headers)
         : kind === 'Forbidden'
           ? "you don't have permission"
           : kind === 'NotFound'
@@ -165,7 +177,7 @@ export async function apiFetch<T = unknown>(
     throw new ApiError(res.status, message, kind);
   }
 
-  // Some endpoints (DELETE, POST 204) return no body — avoid JSON parse errors.
+  // Some endpoints (DELETE, POST 204) return no body - avoid JSON parse errors.
   const text = await res.text();
   if (!text) return undefined as T;
   return JSON.parse(text) as T;
@@ -214,7 +226,7 @@ export async function apiPublicFetch<T = unknown>(
     }
     const message =
       kind === 'RateLimited'
-        ? 'too many requests — try again later'
+        ? rateLimitedMessage(res.headers)
         : kind === 'Forbidden'
           ? "you don't have permission"
           : kind === 'NotFound'

--- a/wavis-backend/src/abuse/join_rate_limiter.rs
+++ b/wavis-backend/src/abuse/join_rate_limiter.rs
@@ -1,67 +1,51 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
+use crate::abuse::SlidingWindow;
 use shared::signaling::JoinRejectionReason;
 
 // ---------------------------------------------------------------------------
-// SlidingWindow
+// JoinWindow
 // ---------------------------------------------------------------------------
 
-pub struct SlidingWindow {
-    timestamps: VecDeque<Instant>,
+struct JoinWindow {
+    attempts: SlidingWindow,
     cooldown_until: Option<Instant>,
 }
 
-impl SlidingWindow {
-    fn new() -> Self {
+impl JoinWindow {
+    fn new(window: Duration) -> Self {
         Self {
-            timestamps: VecDeque::new(),
+            attempts: SlidingWindow::new(window),
             cooldown_until: None,
         }
     }
 
-    /// Evict timestamps older than `window`.
-    fn evict_old(&mut self, window: Duration, now: Instant) {
-        let cutoff = now.checked_sub(window).unwrap_or(now);
-        while let Some(&front) = self.timestamps.front() {
-            if front < cutoff {
-                self.timestamps.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-
-    /// Returns true if currently in cooldown.
     fn in_cooldown(&self, now: Instant) -> bool {
         self.cooldown_until.is_some_and(|until| now < until)
     }
 
-    /// Check whether recording one more attempt would exceed `threshold`.
     /// Returns true if the attempt is allowed (count after recording <= threshold).
-    fn check(&mut self, threshold: u32, window: Duration, now: Instant) -> bool {
+    fn check(&mut self, threshold: u32, now: Instant) -> bool {
         if self.in_cooldown(now) {
             return false;
         }
-        self.evict_old(window, now);
-        // current count + 1 (the attempt being checked) must be <= threshold
-        (self.timestamps.len() as u32) < threshold
+        self.attempts.count(now) < threshold as usize
     }
 
     /// Record an attempt. If the count now exceeds `threshold`, set cooldown.
-    fn record(&mut self, threshold: u32, window: Duration, cooldown: Duration, now: Instant) {
-        self.evict_old(window, now);
-        self.timestamps.push_back(now);
-        if self.timestamps.len() as u32 > threshold {
+    fn record(&mut self, threshold: u32, cooldown: Duration, now: Instant) {
+        self.attempts.add(now);
+        if self.attempts.count(now) > threshold as usize {
             self.cooldown_until = Some(now + cooldown);
         }
     }
 
-    /// True if this window has no timestamps and no active cooldown — safe to prune.
-    fn is_stale(&self, now: Instant) -> bool {
-        self.timestamps.is_empty() && !self.in_cooldown(now)
+    /// True if this window has no timestamps and no active cooldown - safe to prune.
+    fn is_stale(&mut self, now: Instant) -> bool {
+        self.attempts.count(now) == 0 && !self.in_cooldown(now)
     }
 }
 
@@ -107,11 +91,11 @@ impl Default for JoinRateLimiterConfig {
 // ---------------------------------------------------------------------------
 
 pub struct JoinRateLimiter {
-    ip_total: RwLock<HashMap<IpAddr, SlidingWindow>>,
-    ip_failed: RwLock<HashMap<IpAddr, SlidingWindow>>,
-    code_attempts: RwLock<HashMap<String, SlidingWindow>>,
-    room_attempts: RwLock<HashMap<String, SlidingWindow>>,
-    connection_attempts: RwLock<HashMap<String, SlidingWindow>>,
+    ip_total: RwLock<HashMap<IpAddr, JoinWindow>>,
+    ip_failed: RwLock<HashMap<IpAddr, JoinWindow>>,
+    code_attempts: RwLock<HashMap<String, JoinWindow>>,
+    room_attempts: RwLock<HashMap<String, JoinWindow>>,
+    connection_attempts: RwLock<HashMap<String, JoinWindow>>,
     config: RwLock<JoinRateLimiterConfig>,
 }
 
@@ -140,7 +124,7 @@ impl JoinRateLimiter {
     }
 
     /// Check all rate limit dimensions. Returns Ok(()) or Err(RateLimited).
-    /// Does NOT record the attempt — call `record_attempt` after the outcome is known.
+    /// Does NOT record the attempt - call `record_attempt` after the outcome is known.
     pub fn check_join(
         &self,
         ip: IpAddr,
@@ -153,16 +137,20 @@ impl JoinRateLimiter {
         // ip_total
         {
             let mut map = self.ip_total.write().unwrap();
-            let w = map.entry(ip).or_insert_with(SlidingWindow::new);
-            if !w.check(cfg.ip_total_threshold, cfg.ip_total_window, now) {
+            let w = map
+                .entry(ip)
+                .or_insert_with(|| JoinWindow::new(cfg.ip_total_window));
+            if !w.check(cfg.ip_total_threshold, now) {
                 return Err(JoinRejectionReason::RateLimited);
             }
         }
         // ip_failed
         {
             let mut map = self.ip_failed.write().unwrap();
-            let w = map.entry(ip).or_insert_with(SlidingWindow::new);
-            if !w.check(cfg.ip_failed_threshold, cfg.ip_failed_window, now) {
+            let w = map
+                .entry(ip)
+                .or_insert_with(|| JoinWindow::new(cfg.ip_failed_window));
+            if !w.check(cfg.ip_failed_threshold, now) {
                 return Err(JoinRejectionReason::RateLimited);
             }
         }
@@ -171,8 +159,8 @@ impl JoinRateLimiter {
             let mut map = self.code_attempts.write().unwrap();
             let w = map
                 .entry(code.to_string())
-                .or_insert_with(SlidingWindow::new);
-            if !w.check(cfg.code_threshold, cfg.code_window, now) {
+                .or_insert_with(|| JoinWindow::new(cfg.code_window));
+            if !w.check(cfg.code_threshold, now) {
                 return Err(JoinRejectionReason::RateLimited);
             }
         }
@@ -181,8 +169,8 @@ impl JoinRateLimiter {
             let mut map = self.room_attempts.write().unwrap();
             let w = map
                 .entry(room_id.to_string())
-                .or_insert_with(SlidingWindow::new);
-            if !w.check(cfg.room_threshold, cfg.room_window, now) {
+                .or_insert_with(|| JoinWindow::new(cfg.room_window));
+            if !w.check(cfg.room_threshold, now) {
                 return Err(JoinRejectionReason::RateLimited);
             }
         }
@@ -191,8 +179,8 @@ impl JoinRateLimiter {
             let mut map = self.connection_attempts.write().unwrap();
             let w = map
                 .entry(connection_id.to_string())
-                .or_insert_with(SlidingWindow::new);
-            if !w.check(cfg.connection_threshold, cfg.connection_window, now) {
+                .or_insert_with(|| JoinWindow::new(cfg.connection_window));
+            if !w.check(cfg.connection_threshold, now) {
                 return Err(JoinRejectionReason::RateLimited);
             }
         }
@@ -214,49 +202,38 @@ impl JoinRateLimiter {
 
         {
             let mut map = self.ip_total.write().unwrap();
-            let w = map.entry(ip).or_insert_with(SlidingWindow::new);
-            w.record(
-                cfg.ip_total_threshold,
-                cfg.ip_total_window,
-                cfg.cooldown,
-                now,
-            );
+            let w = map
+                .entry(ip)
+                .or_insert_with(|| JoinWindow::new(cfg.ip_total_window));
+            w.record(cfg.ip_total_threshold, cfg.cooldown, now);
         }
         if failed {
             let mut map = self.ip_failed.write().unwrap();
-            let w = map.entry(ip).or_insert_with(SlidingWindow::new);
-            w.record(
-                cfg.ip_failed_threshold,
-                cfg.ip_failed_window,
-                cfg.cooldown,
-                now,
-            );
+            let w = map
+                .entry(ip)
+                .or_insert_with(|| JoinWindow::new(cfg.ip_failed_window));
+            w.record(cfg.ip_failed_threshold, cfg.cooldown, now);
         }
         if let Some(code) = code {
             let mut map = self.code_attempts.write().unwrap();
             let w = map
                 .entry(code.to_string())
-                .or_insert_with(SlidingWindow::new);
-            w.record(cfg.code_threshold, cfg.code_window, cfg.cooldown, now);
+                .or_insert_with(|| JoinWindow::new(cfg.code_window));
+            w.record(cfg.code_threshold, cfg.cooldown, now);
         }
         {
             let mut map = self.room_attempts.write().unwrap();
             let w = map
                 .entry(room_id.to_string())
-                .or_insert_with(SlidingWindow::new);
-            w.record(cfg.room_threshold, cfg.room_window, cfg.cooldown, now);
+                .or_insert_with(|| JoinWindow::new(cfg.room_window));
+            w.record(cfg.room_threshold, cfg.cooldown, now);
         }
         {
             let mut map = self.connection_attempts.write().unwrap();
             let w = map
                 .entry(connection_id.to_string())
-                .or_insert_with(SlidingWindow::new);
-            w.record(
-                cfg.connection_threshold,
-                cfg.connection_window,
-                cfg.cooldown,
-                now,
-            );
+                .or_insert_with(|| JoinWindow::new(cfg.connection_window));
+            w.record(cfg.connection_threshold, cfg.cooldown, now);
         }
 
         self.prune_stale_entries(now);
@@ -266,9 +243,10 @@ impl JoinRateLimiter {
     fn prune_stale_entries(&self, now: Instant) -> usize {
         macro_rules! prune {
             ($field:expr) => {{
-                let before = $field.read().unwrap().len();
-                $field.write().unwrap().retain(|_, w| !w.is_stale(now));
-                let after = $field.read().unwrap().len();
+                let mut map = $field.write().unwrap();
+                let before = map.len();
+                map.retain(|_, w| !w.is_stale(now));
+                let after = map.len();
                 before.saturating_sub(after)
             }};
         }
@@ -354,7 +332,7 @@ mod tests {
             let test_ip = ip(1);
             let now = Instant::now();
 
-            // Record exactly `threshold` attempts — each check before recording should pass
+            // Record exactly `threshold` attempts - each check before recording should pass
             for i in 0..threshold {
                 let result = rl.check_join(test_ip, Some("code"), "room1", "conn1", now);
                 prop_assert!(result.is_ok(), "attempt {} of {} should be allowed", i + 1, threshold);

--- a/wavis-backend/src/abuse/mod.rs
+++ b/wavis-backend/src/abuse/mod.rs
@@ -2,4 +2,7 @@ pub mod abuse_metrics;
 pub mod global_rate_limiter;
 pub mod ip_tracker;
 pub mod join_rate_limiter;
+pub(crate) mod sliding_window;
 pub mod temp_ban;
+
+pub(crate) use sliding_window::SlidingWindow;

--- a/wavis-backend/src/abuse/sliding_window.rs
+++ b/wavis-backend/src/abuse/sliding_window.rs
@@ -1,0 +1,100 @@
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+pub(crate) struct SlidingWindow {
+    timestamps: VecDeque<Instant>,
+    window: Duration,
+}
+
+impl SlidingWindow {
+    pub fn new(window: Duration) -> Self {
+        Self {
+            timestamps: VecDeque::new(),
+            window,
+        }
+    }
+
+    pub fn add(&mut self, now: Instant) {
+        self.timestamps.push_back(now);
+    }
+
+    pub fn count(&mut self, now: Instant) -> usize {
+        self.prune(now);
+        self.timestamps.len()
+    }
+
+    pub fn prune(&mut self, now: Instant) {
+        while self
+            .timestamps
+            .front()
+            .is_some_and(|t| now.saturating_duration_since(*t) > self.window)
+        {
+            self.timestamps.pop_front();
+        }
+    }
+
+    /// Returns seconds until the oldest in-window entry expires, iff count >= max.
+    pub fn seconds_until_retry(&self, max: usize, now: Instant) -> Option<u64> {
+        let mut count = 0usize;
+        let mut oldest_in_window = None;
+
+        for timestamp in &self.timestamps {
+            if now.saturating_duration_since(*timestamp) <= self.window {
+                count += 1;
+                if oldest_in_window.is_none() {
+                    oldest_in_window = Some(*timestamp);
+                }
+            }
+        }
+
+        if count < max {
+            return None;
+        }
+
+        oldest_in_window.map(|oldest| {
+            let elapsed = now.saturating_duration_since(oldest);
+            self.window
+                .saturating_sub(elapsed)
+                .as_secs()
+                .max(1)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_prunes_expired_entries() {
+        let now = Instant::now();
+        let mut window = SlidingWindow::new(Duration::from_secs(60));
+
+        window.add(now - Duration::from_secs(61));
+        window.add(now - Duration::from_secs(30));
+
+        assert_eq!(window.count(now), 1);
+    }
+
+    #[test]
+    fn seconds_until_retry_uses_oldest_in_window_entry() {
+        let now = Instant::now();
+        let mut window = SlidingWindow::new(Duration::from_secs(60));
+
+        window.add(now - Duration::from_secs(20));
+        window.add(now - Duration::from_secs(10));
+
+        assert_eq!(window.seconds_until_retry(2, now), Some(40));
+    }
+
+    #[test]
+    fn seconds_until_retry_ignores_expired_entries_without_pruning() {
+        let now = Instant::now();
+        let mut window = SlidingWindow::new(Duration::from_secs(60));
+
+        window.add(now - Duration::from_secs(61));
+        window.add(now - Duration::from_secs(10));
+
+        assert_eq!(window.seconds_until_retry(2, now), None);
+    }
+}

--- a/wavis-backend/src/abuse/temp_ban.rs
+++ b/wavis-backend/src/abuse/temp_ban.rs
@@ -15,7 +15,7 @@ impl TempBanConfig {
         let threshold = std::env::var("TEMP_BAN_THRESHOLD")
             .ok()
             .and_then(|v| v.parse().ok())
-            .unwrap_or(3);
+            .unwrap_or(5);
         let window_secs = std::env::var("TEMP_BAN_WINDOW_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -169,7 +169,10 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
     use std::net::Ipv4Addr;
+    use std::sync::{LazyLock, Mutex};
     use std::sync::atomic::{AtomicU64, Ordering};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     fn test_ip(n: u8) -> IpAddr {
         IpAddr::V4(Ipv4Addr::new(10, 0, 0, n))
@@ -177,11 +180,23 @@ mod tests {
 
     fn default_config() -> TempBanConfig {
         TempBanConfig {
-            threshold: 3,
+            threshold: 5,
             window: Duration::from_secs(300),
             ban_duration: Duration::from_secs(600),
             max_entries: 10,
         }
+    }
+
+    #[test]
+    fn from_env_uses_updated_threshold_default() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+
+        unsafe {
+            std::env::remove_var("TEMP_BAN_THRESHOLD");
+        }
+
+        let config = TempBanConfig::from_env();
+        assert_eq!(config.threshold, 5);
     }
 
     #[test]
@@ -194,7 +209,7 @@ mod tests {
     fn ban_triggers_after_threshold() {
         let list = TempBanList::new(default_config());
         let ip = test_ip(1);
-        for _ in 0..3 {
+        for _ in 0..5 {
             list.record_violation(ip);
         }
         assert!(list.is_banned(ip));
@@ -204,7 +219,7 @@ mod tests {
     fn no_ban_below_threshold() {
         let list = TempBanList::new(default_config());
         let ip = test_ip(1);
-        for _ in 0..2 {
+        for _ in 0..4 {
             list.record_violation(ip);
         }
         assert!(!list.is_banned(ip));

--- a/wavis-backend/src/auth/auth_rate_limiter.rs
+++ b/wavis-backend/src/auth/auth_rate_limiter.rs
@@ -3,6 +3,8 @@ use std::net::IpAddr;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use crate::abuse::SlidingWindow;
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -22,41 +24,6 @@ impl Default for AuthRateLimiterConfig {
             refresh_max_per_ip: 30,
             refresh_window_secs: 60,
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// SlidingWindow (private)
-// ---------------------------------------------------------------------------
-
-struct SlidingWindow {
-    timestamps: Vec<Instant>,
-}
-
-impl SlidingWindow {
-    fn new() -> Self {
-        Self {
-            timestamps: Vec::new(),
-        }
-    }
-
-    fn evict_old(&mut self, window: Duration, now: Instant) {
-        self.timestamps.retain(|t| now.duration_since(*t) < window);
-    }
-
-    fn count(&mut self, window: Duration, now: Instant) -> u32 {
-        self.evict_old(window, now);
-        self.timestamps.len() as u32
-    }
-
-    fn record(&mut self, now: Instant) {
-        self.timestamps.push(now);
-    }
-
-    fn is_stale(&self, max_window: Duration, now: Instant) -> bool {
-        self.timestamps
-            .iter()
-            .all(|t| now.duration_since(*t) >= max_window)
     }
 }
 
@@ -82,31 +49,49 @@ impl AuthRateLimiter {
     /// Returns true if the register request is allowed (under limit).
     pub fn check_register(&self, ip: IpAddr, now: Instant) -> bool {
         let mut map = self.register_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
         let dur = Duration::from_secs(self.config.register_window_secs);
-        window.count(dur, now) < self.config.register_max_per_ip
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.count(now) < self.config.register_max_per_ip as usize
     }
 
     /// Returns true if the refresh request is allowed (under limit).
     pub fn check_refresh(&self, ip: IpAddr, now: Instant) -> bool {
         let mut map = self.refresh_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
         let dur = Duration::from_secs(self.config.refresh_window_secs);
-        window.count(dur, now) < self.config.refresh_max_per_ip
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.count(now) < self.config.refresh_max_per_ip as usize
+    }
+
+    /// Returns seconds until register can be retried, or `None` if under the limit.
+    pub fn seconds_until_register(&self, ip: IpAddr, now: Instant) -> Option<u64> {
+        let mut map = self.register_windows.lock().unwrap();
+        let dur = Duration::from_secs(self.config.register_window_secs);
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.seconds_until_retry(self.config.register_max_per_ip as usize, now)
+    }
+
+    /// Returns seconds until refresh can be retried, or `None` if under the limit.
+    pub fn seconds_until_refresh(&self, ip: IpAddr, now: Instant) -> Option<u64> {
+        let mut map = self.refresh_windows.lock().unwrap();
+        let dur = Duration::from_secs(self.config.refresh_window_secs);
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.seconds_until_retry(self.config.refresh_max_per_ip as usize, now)
     }
 
     /// Record a register request.
     pub fn record_register(&self, ip: IpAddr, now: Instant) {
         let mut map = self.register_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
-        window.record(now);
+        let dur = Duration::from_secs(self.config.register_window_secs);
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.add(now);
     }
 
     /// Record a refresh request.
     pub fn record_refresh(&self, ip: IpAddr, now: Instant) {
         let mut map = self.refresh_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
-        window.record(now);
+        let dur = Duration::from_secs(self.config.refresh_window_secs);
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.add(now);
     }
 
     /// Clear all tracked state. Used between stress-test repetitions so
@@ -118,20 +103,17 @@ impl AuthRateLimiter {
 
     /// Prune stale entries from both maps. Returns total entries removed.
     pub fn prune_stale(&self, now: Instant) -> usize {
-        let reg_dur = Duration::from_secs(self.config.register_window_secs);
-        let ref_dur = Duration::from_secs(self.config.refresh_window_secs);
-
         let mut count = 0;
         {
             let mut map = self.register_windows.lock().unwrap();
             let before = map.len();
-            map.retain(|_, w| !w.is_stale(reg_dur, now));
+            map.retain(|_, w| w.count(now) > 0);
             count += before - map.len();
         }
         {
             let mut map = self.refresh_windows.lock().unwrap();
             let before = map.len();
-            map.retain(|_, w| !w.is_stale(ref_dur, now));
+            map.retain(|_, w| w.count(now) > 0);
             count += before - map.len();
         }
         count
@@ -143,6 +125,30 @@ mod tests {
     use super::*;
     use proptest::prelude::*;
     use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn seconds_until_register_returns_some_at_limit() {
+        let limiter = AuthRateLimiter::new(AuthRateLimiterConfig::default());
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let now = Instant::now();
+
+        for _ in 0..5 {
+            limiter.record_register(ip, now);
+        }
+
+        assert!(limiter.seconds_until_register(ip, now).is_some());
+    }
+
+    #[test]
+    fn seconds_until_refresh_returns_none_under_limit() {
+        let limiter = AuthRateLimiter::new(AuthRateLimiterConfig::default());
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let now = Instant::now();
+
+        limiter.record_refresh(ip, now);
+
+        assert!(limiter.seconds_until_refresh(ip, now).is_none());
+    }
 
     // Feature: device-auth, Property 10: Auth rate limiter ceiling
     // **Validates: Requirements 1.5, 2.6**

--- a/wavis-backend/src/auth/recovery_rate_limiter.rs
+++ b/wavis-backend/src/auth/recovery_rate_limiter.rs
@@ -3,6 +3,8 @@ use std::net::IpAddr;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use crate::abuse::SlidingWindow;
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -22,41 +24,6 @@ impl Default for RecoveryRateLimiterConfig {
             per_rid_max: 3,
             per_rid_window_secs: 3600,
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// SlidingWindow (private)
-// ---------------------------------------------------------------------------
-
-struct SlidingWindow {
-    timestamps: Vec<Instant>,
-}
-
-impl SlidingWindow {
-    fn new() -> Self {
-        Self {
-            timestamps: Vec::new(),
-        }
-    }
-
-    fn evict_old(&mut self, window: Duration, now: Instant) {
-        self.timestamps.retain(|t| now.duration_since(*t) < window);
-    }
-
-    fn count(&mut self, window: Duration, now: Instant) -> u32 {
-        self.evict_old(window, now);
-        self.timestamps.len() as u32
-    }
-
-    fn record(&mut self, now: Instant) {
-        self.timestamps.push(now);
-    }
-
-    fn is_stale(&self, max_window: Duration, now: Instant) -> bool {
-        self.timestamps
-            .iter()
-            .all(|t| now.duration_since(*t) >= max_window)
     }
 }
 
@@ -82,35 +49,55 @@ impl RecoveryRateLimiter {
     /// Returns true if the IP has fewer than `per_ip_max` attempts in the window.
     pub fn check_ip(&self, ip: IpAddr, now: Instant) -> bool {
         let mut map = self.ip_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
         let dur = Duration::from_secs(self.config.per_ip_window_secs);
-        window.count(dur, now) < self.config.per_ip_max
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.count(now) < self.config.per_ip_max as usize
     }
 
     /// Record a recovery attempt for the given IP.
     pub fn record_ip(&self, ip: IpAddr, now: Instant) {
         let mut map = self.ip_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
-        window.record(now);
+        let dur = Duration::from_secs(self.config.per_ip_window_secs);
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.add(now);
     }
 
     /// Returns true if the recovery_id has fewer than `per_rid_max` attempts in the window.
     pub fn check_recovery_id(&self, rid: &str, now: Instant) -> bool {
         let mut map = self.rid_windows.lock().unwrap();
+        let dur = Duration::from_secs(self.config.per_rid_window_secs);
         let window = map
             .entry(rid.to_string())
-            .or_insert_with(SlidingWindow::new);
+            .or_insert_with(|| SlidingWindow::new(dur));
+        window.count(now) < self.config.per_rid_max as usize
+    }
+
+    /// Returns seconds until the IP can retry, or `None` if under the limit.
+    pub fn seconds_until_ip(&self, ip: IpAddr, now: Instant) -> Option<u64> {
+        let mut map = self.ip_windows.lock().unwrap();
+        let dur = Duration::from_secs(self.config.per_ip_window_secs);
+        let window = map.entry(ip).or_insert_with(|| SlidingWindow::new(dur));
+        window.seconds_until_retry(self.config.per_ip_max as usize, now)
+    }
+
+    /// Returns seconds until the recovery_id can retry, or `None` if under the limit.
+    pub fn seconds_until_recovery_id(&self, rid: &str, now: Instant) -> Option<u64> {
+        let mut map = self.rid_windows.lock().unwrap();
         let dur = Duration::from_secs(self.config.per_rid_window_secs);
-        window.count(dur, now) < self.config.per_rid_max
+        let window = map
+            .entry(rid.to_string())
+            .or_insert_with(|| SlidingWindow::new(dur));
+        window.seconds_until_retry(self.config.per_rid_max as usize, now)
     }
 
     /// Record a recovery attempt for the given recovery_id.
     pub fn record_recovery_id(&self, rid: &str, now: Instant) {
         let mut map = self.rid_windows.lock().unwrap();
+        let dur = Duration::from_secs(self.config.per_rid_window_secs);
         let window = map
             .entry(rid.to_string())
-            .or_insert_with(SlidingWindow::new);
-        window.record(now);
+            .or_insert_with(|| SlidingWindow::new(dur));
+        window.add(now);
     }
 
     /// Clear all tracked state. Used by test-metrics reset endpoint.
@@ -121,20 +108,17 @@ impl RecoveryRateLimiter {
 
     /// Prune stale entries from both maps. Returns total entries removed.
     pub fn prune_stale(&self, now: Instant) -> usize {
-        let ip_dur = Duration::from_secs(self.config.per_ip_window_secs);
-        let rid_dur = Duration::from_secs(self.config.per_rid_window_secs);
-
         let mut count = 0;
         {
             let mut map = self.ip_windows.lock().unwrap();
             let before = map.len();
-            map.retain(|_, w| !w.is_stale(ip_dur, now));
+            map.retain(|_, w| w.count(now) > 0);
             count += before - map.len();
         }
         {
             let mut map = self.rid_windows.lock().unwrap();
             let before = map.len();
-            map.retain(|_, w| !w.is_stale(rid_dur, now));
+            map.retain(|_, w| w.count(now) > 0);
             count += before - map.len();
         }
         count
@@ -241,6 +225,31 @@ mod tests {
         assert_eq!(pruned, 2);
     }
 
+    #[test]
+    fn seconds_until_ip_returns_some_at_limit() {
+        let limiter = RecoveryRateLimiter::new(RecoveryRateLimiterConfig::default());
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let now = Instant::now();
+
+        for _ in 0..5 {
+            limiter.record_ip(ip, now);
+        }
+
+        assert!(limiter.seconds_until_ip(ip, now).is_some());
+    }
+
+    #[test]
+    fn seconds_until_recovery_id_returns_some_at_limit() {
+        let limiter = RecoveryRateLimiter::new(RecoveryRateLimiterConfig::default());
+        let now = Instant::now();
+
+        for _ in 0..3 {
+            limiter.record_recovery_id("wvs-ABCD-EFGH", now);
+        }
+
+        assert!(limiter.seconds_until_recovery_id("wvs-ABCD-EFGH", now).is_some());
+    }
+
     // Feature: user-identity-recovery, Property 10: Recovery rate limiter ceiling
     // **Validates: Requirements 6.1, 6.2**
     proptest! {
@@ -263,7 +272,7 @@ mod tests {
             let ip = IpAddr::V4(Ipv4Addr::new(a, b, c, d));
             let now = Instant::now();
 
-            // Record exactly per_ip_max attempts — all should be allowed
+            // Record exactly per_ip_max attempts - all should be allowed
             for _ in 0..per_ip_max {
                 prop_assert!(limiter.check_ip(ip, now));
                 limiter.record_ip(ip, now);
@@ -293,7 +302,7 @@ mod tests {
             let rid = format!("wvs-{rid_suffix}");
             let now = Instant::now();
 
-            // Record exactly per_rid_max attempts — all should be allowed
+            // Record exactly per_rid_max attempts - all should be allowed
             for _ in 0..per_rid_max {
                 prop_assert!(limiter.check_recovery_id(&rid, now));
                 limiter.record_recovery_id(&rid, now);

--- a/wavis-backend/src/auth/routes.rs
+++ b/wavis-backend/src/auth/routes.rs
@@ -30,7 +30,7 @@ use crate::ip::extract_client_ip;
 use crate::redaction::redact_token;
 use axum::Json;
 use axum::extract::{ConnectInfo, Path, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::time::Instant;
@@ -38,6 +38,8 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::error::ErrorResponse;
+
+type AuthErrorResponse = (StatusCode, HeaderMap, Json<ErrorResponse>);
 
 // ---------------------------------------------------------------------------
 // Request / Response types
@@ -141,147 +143,88 @@ pub struct ListDevicesResponse {
 // Error mapping
 // ---------------------------------------------------------------------------
 
-fn map_register_error(err: &AuthError) -> (StatusCode, Json<ErrorResponse>) {
+fn error_response(status: StatusCode, error: &str) -> AuthErrorResponse {
+    (
+        status,
+        HeaderMap::new(),
+        Json(ErrorResponse {
+            error: error.to_string(),
+        }),
+    )
+}
+
+fn map_register_error(err: &AuthError) -> AuthErrorResponse {
     match err {
-        AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
-        _ => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
+        AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
+        _ => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
     }
 }
 
-fn map_recover_error(err: &AuthError) -> (StatusCode, Json<ErrorResponse>) {
+fn map_recover_error(err: &AuthError) -> AuthErrorResponse {
     match err {
-        AuthError::PhraseVerificationFailed | AuthError::RecoveryIdNotFound => (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse {
-                error: "authentication failed".to_string(),
-            }),
-        ),
-        AuthError::DeviceRevoked => (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse {
-                error: "authentication failed".to_string(),
-            }),
-        ),
-        AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
-        _ => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
+        AuthError::PhraseVerificationFailed | AuthError::RecoveryIdNotFound => {
+            error_response(StatusCode::UNAUTHORIZED, "authentication failed")
+        }
+        AuthError::DeviceRevoked => error_response(StatusCode::UNAUTHORIZED, "authentication failed"),
+        AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
+        _ => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
     }
 }
 
-fn map_refresh_error(err: &AuthError) -> (StatusCode, Json<ErrorResponse>) {
+fn map_refresh_error(err: &AuthError) -> AuthErrorResponse {
     match err {
         AuthError::RefreshTokenInvalid
         | AuthError::TokenReuseDetected
         | AuthError::ValidationFailed
         | AuthError::TokenExpired
         | AuthError::InvalidToken
-        | AuthError::EpochMismatch => (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse {
-                error: "authentication failed".to_string(),
-            }),
-        ),
-        AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
-        _ => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
+        | AuthError::EpochMismatch => error_response(StatusCode::UNAUTHORIZED, "authentication failed"),
+        AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
+        _ => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
     }
 }
 
-fn map_pairing_error(err: &PairingError) -> (StatusCode, Json<ErrorResponse>) {
+fn map_pairing_error(err: &PairingError) -> AuthErrorResponse {
     match err {
-        PairingError::NotFound => (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: "not found".to_string(),
-            }),
-        ),
-        PairingError::Expired | PairingError::CodeMismatch => (
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse {
-                error: "authentication failed".to_string(),
-            }),
-        ),
-        PairingError::AlreadyUsed | PairingError::AlreadyApproved => (
-            StatusCode::CONFLICT,
-            Json(ErrorResponse {
-                error: "conflict".to_string(),
-            }),
-        ),
-        PairingError::NotApproved => (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse {
-                error: "forbidden".to_string(),
-            }),
-        ),
-        PairingError::LockedOut => (
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(ErrorResponse {
-                error: "too many requests".to_string(),
-            }),
-        ),
-        PairingError::DatabaseError(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
+        PairingError::NotFound => error_response(StatusCode::NOT_FOUND, "not found"),
+        PairingError::Expired | PairingError::CodeMismatch => {
+            error_response(StatusCode::UNAUTHORIZED, "authentication failed")
+        }
+        PairingError::AlreadyUsed | PairingError::AlreadyApproved => {
+            error_response(StatusCode::CONFLICT, "conflict")
+        }
+        PairingError::NotApproved => error_response(StatusCode::FORBIDDEN, "forbidden"),
+        PairingError::LockedOut => error_response(StatusCode::TOO_MANY_REQUESTS, "too many requests"),
+        PairingError::DatabaseError(_) => {
+            error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
+        }
     }
 }
 
-fn map_device_error(err: &DeviceError) -> (StatusCode, Json<ErrorResponse>) {
+fn map_device_error(err: &DeviceError) -> AuthErrorResponse {
     match err {
-        DeviceError::NotFound => (
-            StatusCode::NOT_FOUND,
-            Json(ErrorResponse {
-                error: "not found".to_string(),
-            }),
-        ),
-        DeviceError::NotOwned => (
-            StatusCode::FORBIDDEN,
-            Json(ErrorResponse {
-                error: "forbidden".to_string(),
-            }),
-        ),
-        DeviceError::DatabaseError(_) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: "internal error".to_string(),
-            }),
-        ),
+        DeviceError::NotFound => error_response(StatusCode::NOT_FOUND, "not found"),
+        DeviceError::NotOwned => error_response(StatusCode::FORBIDDEN, "forbidden"),
+        DeviceError::DatabaseError(_) => error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
     }
 }
 
-fn rate_limited_response() -> (StatusCode, Json<ErrorResponse>) {
+fn rate_limited_response(retry_after_secs: Option<u64>) -> AuthErrorResponse {
+    let mut headers = HeaderMap::new();
+    if let Some(secs) = retry_after_secs
+        && let Ok(value) = HeaderValue::from_str(&secs.to_string())
+    {
+        headers.insert(RETRY_AFTER, value);
+    }
     (
         StatusCode::TOO_MANY_REQUESTS,
+        headers,
         Json(ErrorResponse {
             error: "too many requests".to_string(),
         }),
@@ -296,13 +239,14 @@ pub async fn register_device(
     State(app_state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-) -> Result<(StatusCode, Json<RegisterResponse>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<RegisterResponse>), AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
-    if !app_state.auth_rate_limiter.check_register(client_ip, now) {
-        warn!(ip = %client_ip, "register_device rate-limited");
-        return Err(rate_limited_response());
+    let retry_after_secs = app_state.auth_rate_limiter.seconds_until_register(client_ip, now);
+    if retry_after_secs.is_some() {
+        warn!(ip = %client_ip, retry_after = retry_after_secs, "register_device rate-limited");
+        return Err(rate_limited_response(retry_after_secs));
     }
     app_state.auth_rate_limiter.record_register(client_ip, now);
 
@@ -342,13 +286,14 @@ pub async fn register(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<RegisterRequest>,
-) -> Result<(StatusCode, Json<RegisterResponse>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<RegisterResponse>), AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
-    if !app_state.auth_rate_limiter.check_register(client_ip, now) {
-        warn!(ip = %client_ip, "register rate-limited");
-        return Err(rate_limited_response());
+    let retry_after_secs = app_state.auth_rate_limiter.seconds_until_register(client_ip, now);
+    if retry_after_secs.is_some() {
+        warn!(ip = %client_ip, retry_after = retry_after_secs, "register rate-limited");
+        return Err(rate_limited_response(retry_after_secs));
     }
     app_state.auth_rate_limiter.record_register(client_ip, now);
 
@@ -392,25 +337,31 @@ pub async fn recover(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<RecoverRequest>,
-) -> Result<Json<RecoverResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<RecoverResponse>, AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
     // Per-IP rate limit BEFORE any DB lookup; always count the attempt.
-    if !app_state.recovery_rate_limiter.check_ip(client_ip, now) {
-        warn!(ip = %client_ip, "recover rate-limited (IP)");
-        return Err(rate_limited_response());
+    let retry_after_secs = app_state.recovery_rate_limiter.seconds_until_ip(client_ip, now);
+    if retry_after_secs.is_some() {
+        warn!(ip = %client_ip, retry_after = retry_after_secs, "recover rate-limited (IP)");
+        return Err(rate_limited_response(retry_after_secs));
     }
     app_state.recovery_rate_limiter.record_ip(client_ip, now);
 
     // Per-recovery_id rate limit check (pre-check only; record AFTER DB lookup
     // confirms the recovery_id exists — avoids creating a rate-limiter oracle).
-    if !app_state
+    let retry_after_secs = app_state
         .recovery_rate_limiter
-        .check_recovery_id(&body.recovery_id, now)
-    {
-        warn!(ip = %client_ip, recovery_id = %body.recovery_id, "recover rate-limited (recovery_id)");
-        return Err(rate_limited_response());
+        .seconds_until_recovery_id(&body.recovery_id, now);
+    if retry_after_secs.is_some() {
+        warn!(
+            ip = %client_ip,
+            recovery_id = %body.recovery_id,
+            retry_after = retry_after_secs,
+            "recover rate-limited (recovery_id)"
+        );
+        return Err(rate_limited_response(retry_after_secs));
     }
 
     let result = auth::recover_account(
@@ -480,14 +431,15 @@ pub async fn pair_start(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<PairStartRequest>,
-) -> Result<(StatusCode, Json<PairStartResponse>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<PairStartResponse>), AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
     // Rate-limit: 10 per IP per hour (reuse register limiter slot for pairing start).
-    if !app_state.auth_rate_limiter.check_register(client_ip, now) {
-        warn!(ip = %client_ip, "pair_start rate-limited");
-        return Err(rate_limited_response());
+    let retry_after_secs = app_state.auth_rate_limiter.seconds_until_register(client_ip, now);
+    if retry_after_secs.is_some() {
+        warn!(ip = %client_ip, retry_after = retry_after_secs, "pair_start rate-limited");
+        return Err(rate_limited_response(retry_after_secs));
     }
     app_state.auth_rate_limiter.record_register(client_ip, now);
 
@@ -521,7 +473,7 @@ pub async fn pair_approve(
     State(app_state): State<AppState>,
     user: AuthenticatedUser,
     Json(body): Json<PairApproveRequest>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, AuthErrorResponse> {
     // Rate-limit: 10 per user per hour (reuse refresh limiter keyed by user IP
     // — for MVP, we approximate per-user with the auth_rate_limiter).
     // The actual per-user enforcement is approximated since AuthRateLimiter is per-IP.
@@ -568,14 +520,15 @@ pub async fn pair_finish(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<PairFinishRequest>,
-) -> Result<Json<PairFinishResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<PairFinishResponse>, AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
     // Rate-limit: 10 per IP per hour.
-    if !app_state.auth_rate_limiter.check_register(client_ip, now) {
-        warn!(ip = %client_ip, "pair_finish rate-limited");
-        return Err(rate_limited_response());
+    let retry_after_secs = app_state.auth_rate_limiter.seconds_until_register(client_ip, now);
+    if retry_after_secs.is_some() {
+        warn!(ip = %client_ip, retry_after = retry_after_secs, "pair_finish rate-limited");
+        return Err(rate_limited_response(retry_after_secs));
     }
     app_state.auth_rate_limiter.record_register(client_ip, now);
 
@@ -612,7 +565,7 @@ pub async fn pair_finish(
 pub async fn logout_all(
     State(app_state): State<AppState>,
     user: AuthenticatedUser,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, AuthErrorResponse> {
     let result = device::logout_all(&app_state.db_pool, user.user_id).await;
 
     match result {
@@ -638,7 +591,7 @@ pub async fn logout_all(
 pub async fn list_devices(
     State(app_state): State<AppState>,
     user: AuthenticatedUser,
-) -> Result<Json<ListDevicesResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<ListDevicesResponse>, AuthErrorResponse> {
     let result = device::list_devices(&app_state.db_pool, user.user_id).await;
 
     match result {
@@ -672,7 +625,7 @@ pub async fn revoke_device(
     State(app_state): State<AppState>,
     user: AuthenticatedUser,
     Path(target_device_id): Path<Uuid>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, AuthErrorResponse> {
     let result = device::revoke_device(&app_state.db_pool, user.user_id, target_device_id).await;
 
     match result {
@@ -705,7 +658,7 @@ pub async fn rotate_phrase(
     State(app_state): State<AppState>,
     user: AuthenticatedUser,
     Json(body): Json<RotatePhraseRequest>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, AuthErrorResponse> {
     let result = auth::rotate_phrase(
         &app_state.db_pool,
         user.user_id,
@@ -718,20 +671,12 @@ pub async fn rotate_phrase(
 
     match result {
         Ok(()) => Ok(StatusCode::OK),
-        Err(AuthError::PhraseVerificationFailed) => Err((
-            StatusCode::UNAUTHORIZED,
-            Json(ErrorResponse {
-                error: "authentication failed".to_string(),
-            }),
-        )),
+        Err(AuthError::PhraseVerificationFailed) => {
+            Err(error_response(StatusCode::UNAUTHORIZED, "authentication failed"))
+        }
         Err(err) => {
             warn!(user_id = %user.user_id, error = %err, "rotate_phrase failed");
-            Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorResponse {
-                    error: "internal error".to_string(),
-                }),
-            ))
+            Err(error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error"))
         }
     }
 }
@@ -745,13 +690,14 @@ pub async fn refresh_token(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(body): Json<RefreshRequest>,
-) -> Result<Json<RefreshResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<RefreshResponse>, AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
-    if !app_state.auth_rate_limiter.check_refresh(client_ip, now) {
-        warn!(ip = %client_ip, "refresh_token rate-limited");
-        return Err(rate_limited_response());
+    let retry_after_secs = app_state.auth_rate_limiter.seconds_until_refresh(client_ip, now);
+    if retry_after_secs.is_some() {
+        warn!(ip = %client_ip, retry_after = retry_after_secs, "refresh_token rate-limited");
+        return Err(rate_limited_response(retry_after_secs));
     }
     app_state.auth_rate_limiter.record_refresh(client_ip, now);
 

--- a/wavis-backend/src/channel/channel_rate_limiter.rs
+++ b/wavis-backend/src/channel/channel_rate_limiter.rs
@@ -3,6 +3,8 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::abuse::SlidingWindow;
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -20,41 +22,6 @@ impl Default for ChannelRateLimiterConfig {
             max_per_user: 30,
             window_secs: 60,
         }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// SlidingWindow (private)
-// ---------------------------------------------------------------------------
-
-struct SlidingWindow {
-    timestamps: Vec<Instant>,
-}
-
-impl SlidingWindow {
-    fn new() -> Self {
-        Self {
-            timestamps: Vec::new(),
-        }
-    }
-
-    fn evict_old(&mut self, window: Duration, now: Instant) {
-        self.timestamps.retain(|t| now.duration_since(*t) < window);
-    }
-
-    fn count(&mut self, window: Duration, now: Instant) -> u32 {
-        self.evict_old(window, now);
-        self.timestamps.len() as u32
-    }
-
-    fn record(&mut self, now: Instant) {
-        self.timestamps.push(now);
-    }
-
-    fn is_stale(&self, max_window: Duration, now: Instant) -> bool {
-        self.timestamps
-            .iter()
-            .all(|t| now.duration_since(*t) >= max_window)
     }
 }
 
@@ -78,16 +45,25 @@ impl ChannelRateLimiter {
     /// Returns true if the request is allowed (under limit).
     pub fn check(&self, user_id: Uuid, now: Instant) -> bool {
         let mut map = self.windows.lock().unwrap();
-        let window = map.entry(user_id).or_insert_with(SlidingWindow::new);
         let dur = Duration::from_secs(self.config.window_secs);
-        window.count(dur, now) < self.config.max_per_user
+        let window = map.entry(user_id).or_insert_with(|| SlidingWindow::new(dur));
+        window.count(now) < self.config.max_per_user as usize
+    }
+
+    /// Returns seconds until the user can retry, or `None` if under the limit.
+    pub fn seconds_until_retry(&self, user_id: Uuid, now: Instant) -> Option<u64> {
+        let mut map = self.windows.lock().unwrap();
+        let dur = Duration::from_secs(self.config.window_secs);
+        let window = map.entry(user_id).or_insert_with(|| SlidingWindow::new(dur));
+        window.seconds_until_retry(self.config.max_per_user as usize, now)
     }
 
     /// Record a request.
     pub fn record(&self, user_id: Uuid, now: Instant) {
         let mut map = self.windows.lock().unwrap();
-        let window = map.entry(user_id).or_insert_with(SlidingWindow::new);
-        window.record(now);
+        let dur = Duration::from_secs(self.config.window_secs);
+        let window = map.entry(user_id).or_insert_with(|| SlidingWindow::new(dur));
+        window.add(now);
     }
 
     /// Clear all tracked state. Used by test harnesses so rate-limit
@@ -98,10 +74,9 @@ impl ChannelRateLimiter {
 
     /// Prune stale entries. Returns number of entries removed.
     pub fn prune_stale(&self, now: Instant) -> usize {
-        let dur = Duration::from_secs(self.config.window_secs);
         let mut map = self.windows.lock().unwrap();
         let before = map.len();
-        map.retain(|_, w| !w.is_stale(dur, now));
+        map.retain(|_, w| w.count(now) > 0);
         before - map.len()
     }
 }
@@ -110,6 +85,19 @@ impl ChannelRateLimiter {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+
+    #[test]
+    fn seconds_until_retry_returns_some_at_limit() {
+        let limiter = ChannelRateLimiter::new(ChannelRateLimiterConfig::default());
+        let user_id = Uuid::new_v4();
+        let now = Instant::now();
+
+        for _ in 0..30 {
+            limiter.record(user_id, now);
+        }
+
+        assert!(limiter.seconds_until_retry(user_id, now).is_some());
+    }
 
     fn arb_uuid() -> impl Strategy<Value = Uuid> {
         any::<[u8; 16]>().prop_map(Uuid::from_bytes)

--- a/wavis-backend/src/channel/routes.rs
+++ b/wavis-backend/src/channel/routes.rs
@@ -31,9 +31,17 @@ use crate::channel::channel;
 use crate::channel::channel_models::{ChannelError, ChannelRole};
 use crate::error::ErrorResponse;
 use crate::voice::voice_orchestrator;
+use axum::response::{IntoResponse, Response};
 use crate::ws::ws_dispatch::{dispatch_signals, schedule_sub_room_expiry};
 
-type ChannelErrorResponse = (StatusCode, HeaderMap, Json<ErrorResponse>);
+pub struct ChannelErrorResponse(Box<(StatusCode, HeaderMap, Json<ErrorResponse>)>);
+
+impl IntoResponse for ChannelErrorResponse {
+    fn into_response(self) -> Response {
+        let (status, headers, body) = *self.0;
+        (status, headers, body).into_response()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // Request / Response types
@@ -231,13 +239,13 @@ fn map_channel_error(
         ChannelError::DatabaseError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal error"),
     };
 
-    (
+    ChannelErrorResponse(Box::new((
         status,
         HeaderMap::new(),
         Json(ErrorResponse {
             error: message.to_string(),
         }),
-    )
+    )))
 }
 
 // ---------------------------------------------------------------------------
@@ -265,13 +273,13 @@ fn rate_limited_response(retry_after_secs: Option<u64>) -> ChannelErrorResponse 
     {
         headers.insert(RETRY_AFTER, value);
     }
-    (
+    ChannelErrorResponse(Box::new((
         StatusCode::TOO_MANY_REQUESTS,
         headers,
         Json(ErrorResponse {
             error: "too many requests".to_string(),
         }),
-    )
+    )))
 }
 
 // ---------------------------------------------------------------------------
@@ -582,35 +590,35 @@ pub async fn get_voice_status(
             error = %e,
             "voice status DB error"
         );
-        (
+        ChannelErrorResponse(Box::new((
             StatusCode::INTERNAL_SERVER_ERROR,
             HeaderMap::new(),
             Json(ErrorResponse {
                 error: "internal error".to_string(),
             }),
-        )
+        )))
     })?;
 
     match membership {
         // Not found → 403 opaque (indistinguishable from banned)
         None => {
-            return Err((
+            return Err(ChannelErrorResponse(Box::new((
                 StatusCode::FORBIDDEN,
                 HeaderMap::new(),
                 Json(ErrorResponse {
                     error: "forbidden".to_string(),
                 }),
-            ));
+            ))));
         }
         // Banned → 403 opaque (indistinguishable from not found)
         Some((_, Some(_))) => {
-            return Err((
+            return Err(ChannelErrorResponse(Box::new((
                 StatusCode::FORBIDDEN,
                 HeaderMap::new(),
                 Json(ErrorResponse {
                     error: "forbidden".to_string(),
                 }),
-            ));
+            ))));
         }
         // Non-banned member → proceed
         Some((_, None)) => {}

--- a/wavis-backend/src/channel/routes.rs
+++ b/wavis-backend/src/channel/routes.rs
@@ -20,7 +20,7 @@
 
 use axum::Json;
 use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::RETRY_AFTER};
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 use uuid::Uuid;
@@ -32,6 +32,8 @@ use crate::channel::channel_models::{ChannelError, ChannelRole};
 use crate::error::ErrorResponse;
 use crate::voice::voice_orchestrator;
 use crate::ws::ws_dispatch::{dispatch_signals, schedule_sub_room_expiry};
+
+type ChannelErrorResponse = (StatusCode, HeaderMap, Json<ErrorResponse>);
 
 // ---------------------------------------------------------------------------
 // Request / Response types
@@ -164,7 +166,7 @@ fn map_channel_error(
     err: &ChannelError,
     user_id: Uuid,
     channel_id: Option<Uuid>,
-) -> (StatusCode, Json<ErrorResponse>) {
+) -> ChannelErrorResponse {
     // Log at error level for internal failures, warn for everything else
     match err {
         ChannelError::DatabaseError(_) | ChannelError::OwnerConsistencyViolation => {
@@ -231,6 +233,7 @@ fn map_channel_error(
 
     (
         status,
+        HeaderMap::new(),
         Json(ErrorResponse {
             error: message.to_string(),
         }),
@@ -244,19 +247,31 @@ fn map_channel_error(
 fn check_rate_limit(
     state: &AppState,
     user_id: Uuid,
-) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(), ChannelErrorResponse> {
     let now = Instant::now();
-    if !state.channel_rate_limiter.check(user_id, now) {
-        tracing::warn!(user_id = %user_id, "channel rate limit exceeded");
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(ErrorResponse {
-                error: "too many requests".to_string(),
-            }),
-        ));
+    let retry_after_secs = state.channel_rate_limiter.seconds_until_retry(user_id, now);
+    if retry_after_secs.is_some() {
+        tracing::warn!(user_id = %user_id, retry_after = retry_after_secs, "channel rate limit exceeded");
+        return Err(rate_limited_response(retry_after_secs));
     }
     state.channel_rate_limiter.record(user_id, now);
     Ok(())
+}
+
+fn rate_limited_response(retry_after_secs: Option<u64>) -> ChannelErrorResponse {
+    let mut headers = HeaderMap::new();
+    if let Some(secs) = retry_after_secs
+        && let Ok(value) = HeaderValue::from_str(&secs.to_string())
+    {
+        headers.insert(RETRY_AFTER, value);
+    }
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        headers,
+        Json(ErrorResponse {
+            error: "too many requests".to_string(),
+        }),
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -268,7 +283,7 @@ pub async fn create_channel(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Json(body): Json<CreateChannelRequest>,
-) -> Result<(StatusCode, Json<CreateChannelResponse>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<CreateChannelResponse>), ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     let ch = channel::create_channel(&state.db_pool, user.user_id, &body.name)
@@ -290,7 +305,7 @@ pub async fn create_channel(
 pub async fn list_channels(
     State(state): State<AppState>,
     user: AuthenticatedUser,
-) -> Result<Json<Vec<ChannelListItemResponse>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<Vec<ChannelListItemResponse>>, ChannelErrorResponse> {
     let items = channel::list_channels(&state.db_pool, user.user_id)
         .await
         .map_err(|e| map_channel_error(&e, user.user_id, None))?;
@@ -314,7 +329,7 @@ pub async fn get_channel(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
-) -> Result<Json<ChannelDetailResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<ChannelDetailResponse>, ChannelErrorResponse> {
     let detail = channel::get_channel_detail(&state.db_pool, channel_id, user.user_id)
         .await
         .map_err(|e| map_channel_error(&e, user.user_id, Some(channel_id)))?;
@@ -345,7 +360,7 @@ pub async fn delete_channel(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     channel::delete_channel(&state.db_pool, channel_id, user.user_id)
@@ -361,7 +376,7 @@ pub async fn create_invite(
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
     Json(body): Json<CreateInviteRequest>,
-) -> Result<(StatusCode, Json<InviteResponse>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<InviteResponse>), ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     let invite = channel::create_invite(
@@ -391,7 +406,7 @@ pub async fn join_channel(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Json(body): Json<JoinChannelRequest>,
-) -> Result<Json<JoinChannelResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<JoinChannelResponse>, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     let result = channel::join_channel_by_invite(&state.db_pool, user.user_id, &body.code)
@@ -410,7 +425,7 @@ pub async fn leave_channel(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     channel::leave_channel(&state.db_pool, channel_id, user.user_id)
@@ -425,7 +440,7 @@ pub async fn revoke_invite(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path((channel_id, code)): Path<(Uuid, String)>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     channel::revoke_invite(&state.db_pool, channel_id, user.user_id, &code)
@@ -440,7 +455,7 @@ pub async fn ban_member(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path((channel_id, target_user_id)): Path<(Uuid, Uuid)>,
-) -> Result<Json<BanResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<BanResponse>, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     let result = channel::ban_member(&state.db_pool, channel_id, user.user_id, target_user_id)
@@ -507,7 +522,7 @@ pub async fn unban_member(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path((channel_id, target_user_id)): Path<(Uuid, Uuid)>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     channel::unban_member(&state.db_pool, channel_id, user.user_id, target_user_id)
@@ -523,7 +538,7 @@ pub async fn change_role(
     user: AuthenticatedUser,
     Path((channel_id, target_user_id)): Path<(Uuid, Uuid)>,
     Json(body): Json<ChangeRoleRequest>,
-) -> Result<Json<ChangeRoleResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<ChangeRoleResponse>, ChannelErrorResponse> {
     check_rate_limit(&state, user.user_id)?;
 
     let result = channel::change_role(
@@ -551,7 +566,7 @@ pub async fn get_voice_status(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
-) -> Result<Json<VoiceStatusResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<VoiceStatusResponse>, ChannelErrorResponse> {
     // 1. Verify non-banned membership
     let membership = sqlx::query_as::<_, (String, Option<chrono::DateTime<chrono::Utc>>)>(
         "SELECT role, banned_at FROM channel_memberships WHERE channel_id = $1 AND user_id = $2",
@@ -569,6 +584,7 @@ pub async fn get_voice_status(
         );
         (
             StatusCode::INTERNAL_SERVER_ERROR,
+            HeaderMap::new(),
             Json(ErrorResponse {
                 error: "internal error".to_string(),
             }),
@@ -580,6 +596,7 @@ pub async fn get_voice_status(
         None => {
             return Err((
                 StatusCode::FORBIDDEN,
+                HeaderMap::new(),
                 Json(ErrorResponse {
                     error: "forbidden".to_string(),
                 }),
@@ -589,6 +606,7 @@ pub async fn get_voice_status(
         Some((_, Some(_))) => {
             return Err((
                 StatusCode::FORBIDDEN,
+                HeaderMap::new(),
                 Json(ErrorResponse {
                     error: "forbidden".to_string(),
                 }),
@@ -647,7 +665,7 @@ pub async fn list_bans(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
-) -> Result<Json<BanListResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<BanListResponse>, ChannelErrorResponse> {
     let bans = channel::list_bans(&state.db_pool, channel_id, user.user_id)
         .await
         .map_err(|e| map_channel_error(&e, user.user_id, Some(channel_id)))?;
@@ -667,7 +685,7 @@ pub async fn list_invites(
     State(state): State<AppState>,
     user: AuthenticatedUser,
     Path(channel_id): Path<Uuid>,
-) -> Result<Json<Vec<InviteResponse>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<Vec<InviteResponse>>, ChannelErrorResponse> {
     let invites = channel::list_invites(&state.db_pool, channel_id, user.user_id)
         .await
         .map_err(|e| map_channel_error(&e, user.user_id, Some(channel_id)))?;

--- a/wavis-backend/src/diagnostics/bug_report_rate_limiter.rs
+++ b/wavis-backend/src/diagnostics/bug_report_rate_limiter.rs
@@ -4,6 +4,8 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
+use crate::abuse::SlidingWindow;
+
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
@@ -40,58 +42,6 @@ impl BugReportRateLimiterConfig {
 }
 
 // ---------------------------------------------------------------------------
-// SlidingWindow (private)
-// ---------------------------------------------------------------------------
-
-struct SlidingWindow {
-    timestamps: Vec<Instant>,
-}
-
-impl SlidingWindow {
-    fn new() -> Self {
-        Self {
-            timestamps: Vec::new(),
-        }
-    }
-
-    fn evict_old(&mut self, window: Duration, now: Instant) {
-        self.timestamps.retain(|t| now.duration_since(*t) < window);
-    }
-
-    fn count(&mut self, window: Duration, now: Instant) -> u32 {
-        self.evict_old(window, now);
-        self.timestamps.len() as u32
-    }
-
-    fn record(&mut self, now: Instant) {
-        self.timestamps.push(now);
-    }
-
-    fn is_stale(&self, max_window: Duration, now: Instant) -> bool {
-        self.timestamps
-            .iter()
-            .all(|t| now.duration_since(*t) >= max_window)
-    }
-
-    /// Returns the duration until the oldest entry expires, or `None` if under the limit.
-    fn seconds_until_retry(&mut self, window: Duration, now: Instant, max: u32) -> Option<u64> {
-        self.evict_old(window, now);
-        if (self.timestamps.len() as u32) < max {
-            return None;
-        }
-        // Find the oldest timestamp — that's the one that will expire first.
-        self.timestamps.iter().min().map(|oldest| {
-            let elapsed = now.duration_since(*oldest);
-            if elapsed >= window {
-                1 // Already expired on next tick
-            } else {
-                (window - elapsed).as_secs().max(1)
-            }
-        })
-    }
-}
-
-// ---------------------------------------------------------------------------
 // BugReportRateLimiter
 // ---------------------------------------------------------------------------
 
@@ -113,43 +63,55 @@ impl BugReportRateLimiter {
     /// Returns true if the IP has fewer than `max_requests` submissions in the window.
     pub fn check_ip(&self, ip: IpAddr, now: Instant) -> bool {
         let mut map = self.ip_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
-        window.count(self.config.window, now) < self.config.max_requests
+        let window = map
+            .entry(ip)
+            .or_insert_with(|| SlidingWindow::new(self.config.window));
+        window.count(now) < self.config.max_requests as usize
     }
 
     /// Record a bug report submission for the given IP.
     pub fn record_ip(&self, ip: IpAddr, now: Instant) {
         let mut map = self.ip_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
-        window.record(now);
+        let window = map
+            .entry(ip)
+            .or_insert_with(|| SlidingWindow::new(self.config.window));
+        window.add(now);
     }
 
     /// Returns true if the user has fewer than `max_requests` submissions in the window.
     pub fn check_user(&self, user_id: Uuid, now: Instant) -> bool {
         let mut map = self.user_windows.lock().unwrap();
-        let window = map.entry(user_id).or_insert_with(SlidingWindow::new);
-        window.count(self.config.window, now) < self.config.max_requests
+        let window = map
+            .entry(user_id)
+            .or_insert_with(|| SlidingWindow::new(self.config.window));
+        window.count(now) < self.config.max_requests as usize
     }
 
     /// Record a bug report submission for the given user.
     pub fn record_user(&self, user_id: Uuid, now: Instant) {
         let mut map = self.user_windows.lock().unwrap();
-        let window = map.entry(user_id).or_insert_with(SlidingWindow::new);
-        window.record(now);
+        let window = map
+            .entry(user_id)
+            .or_insert_with(|| SlidingWindow::new(self.config.window));
+        window.add(now);
     }
 
     /// Returns seconds until the IP can retry, or `None` if under the limit.
     pub fn seconds_until_retry_ip(&self, ip: IpAddr, now: Instant) -> Option<u64> {
         let mut map = self.ip_windows.lock().unwrap();
-        let window = map.entry(ip).or_insert_with(SlidingWindow::new);
-        window.seconds_until_retry(self.config.window, now, self.config.max_requests)
+        let window = map
+            .entry(ip)
+            .or_insert_with(|| SlidingWindow::new(self.config.window));
+        window.seconds_until_retry(self.config.max_requests as usize, now)
     }
 
     /// Returns seconds until the user can retry, or `None` if under the limit.
     pub fn seconds_until_retry_user(&self, user_id: Uuid, now: Instant) -> Option<u64> {
         let mut map = self.user_windows.lock().unwrap();
-        let window = map.entry(user_id).or_insert_with(SlidingWindow::new);
-        window.seconds_until_retry(self.config.window, now, self.config.max_requests)
+        let window = map
+            .entry(user_id)
+            .or_insert_with(|| SlidingWindow::new(self.config.window));
+        window.seconds_until_retry(self.config.max_requests as usize, now)
     }
 
     /// Prune stale entries from both maps. Returns total entries removed.
@@ -158,13 +120,13 @@ impl BugReportRateLimiter {
         {
             let mut map = self.ip_windows.lock().unwrap();
             let before = map.len();
-            map.retain(|_, w| !w.is_stale(self.config.window, now));
+            map.retain(|_, w| w.count(now) > 0);
             count += before - map.len();
         }
         {
             let mut map = self.user_windows.lock().unwrap();
             let before = map.len();
-            map.retain(|_, w| !w.is_stale(self.config.window, now));
+            map.retain(|_, w| w.count(now) > 0);
             count += before - map.len();
         }
         count
@@ -358,21 +320,21 @@ mod tests {
                         i + 1,
                         max,
                     );
-                    // Under the limit → no retry needed
+                    // Under the limit -> no retry needed
                     prop_assert!(
                         limiter.seconds_until_retry_ip(ip, now).is_none(),
                         "seconds_until_retry_ip should be None when under limit (submission {})",
                         i + 1,
                     );
                 } else {
-                    // Beyond max → must be rejected
+                    // Beyond max -> must be rejected
                     prop_assert!(
                         !limiter.check_ip(ip, now),
                         "Submission {} should be rejected (over limit {})",
                         i + 1,
                         max,
                     );
-                    // At the limit → retry info must be present
+                    // At the limit -> retry info must be present
                     let retry = limiter.seconds_until_retry_ip(ip, now);
                     prop_assert!(
                         retry.is_some(),

--- a/wavis-backend/src/diagnostics/routes.rs
+++ b/wavis-backend/src/diagnostics/routes.rs
@@ -30,13 +30,15 @@ use crate::error::ErrorResponse;
 use crate::ip::extract_client_ip;
 use axum::Json;
 use axum::extract::{ConnectInfo, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header::RETRY_AFTER};
 use base64::Engine;
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 use std::time::Instant;
 use tracing::warn;
 use uuid::Uuid;
+
+type DiagnosticsErrorResponse = (StatusCode, HeaderMap, Json<ErrorResponse>);
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -87,7 +89,7 @@ struct AuthUser {
 async fn try_extract_auth(
     headers: &HeaderMap,
     state: &AppState,
-) -> Result<Option<AuthUser>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Option<AuthUser>, DiagnosticsErrorResponse> {
     let header_value = match headers.get("authorization").and_then(|v| v.to_str().ok()) {
         Some(v) => v,
         None => return Ok(None), // No header → anonymous
@@ -128,13 +130,32 @@ async fn try_extract_auth(
     Ok(Some(AuthUser { user_id, device_id }))
 }
 
-fn auth_reject() -> (StatusCode, Json<ErrorResponse>) {
+fn error_response(status: StatusCode, error: &str) -> DiagnosticsErrorResponse {
     (
-        StatusCode::UNAUTHORIZED,
+        status,
+        HeaderMap::new(),
         Json(ErrorResponse {
-            error: "authentication failed".to_string(),
+            error: error.to_string(),
         }),
     )
+}
+
+fn rate_limited_response(retry_after_secs: u64) -> DiagnosticsErrorResponse {
+    let mut headers = HeaderMap::new();
+    if let Ok(value) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+        headers.insert(RETRY_AFTER, value);
+    }
+    (
+        StatusCode::TOO_MANY_REQUESTS,
+        headers,
+        Json(ErrorResponse {
+            error: format!("rate limit exceeded, retry after {}s", retry_after_secs),
+        }),
+    )
+}
+
+fn auth_reject() -> DiagnosticsErrorResponse {
+    error_response(StatusCode::UNAUTHORIZED, "authentication failed")
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +185,7 @@ pub async fn submit_bug_report(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(payload): Json<BugReportRequest>,
-) -> Result<(StatusCode, Json<BugReportResponse>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<BugReportResponse>), DiagnosticsErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &state.ip_config);
     let now = Instant::now();
 
@@ -178,12 +199,7 @@ pub async fn submit_bug_report(
         .seconds_until_retry_ip(client_ip, now)
     {
         warn!(ip = %client_ip, retry_after = retry_secs, "bug report rate limit exceeded (IP)");
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(ErrorResponse {
-                error: format!("rate limit exceeded, retry after {}s", retry_secs),
-            }),
-        ));
+        return Err(rate_limited_response(retry_secs));
     }
 
     // --- Rate limit: per-user_id (if authenticated) ---
@@ -197,12 +213,7 @@ pub async fn submit_bug_report(
             retry_after = retry_secs,
             "bug report rate limit exceeded (user)"
         );
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(ErrorResponse {
-                error: format!("rate limit exceeded, retry after {}s", retry_secs),
-            }),
-        ));
+        return Err(rate_limited_response(retry_secs));
     }
 
     // --- Validate payload size (decoded) ---
@@ -213,22 +224,12 @@ pub async fn submit_bug_report(
         decoded_size += estimated_decoded;
     }
     if decoded_size > MAX_DECODED_PAYLOAD_SIZE {
-        return Err((
-            StatusCode::PAYLOAD_TOO_LARGE,
-            Json(ErrorResponse {
-                error: "payload too large".to_string(),
-            }),
-        ));
+        return Err(error_response(StatusCode::PAYLOAD_TOO_LARGE, "payload too large"));
     }
 
     // --- Validate field lengths ---
     if let Some(err_msg) = validate_bug_report_fields(&payload) {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: err_msg.to_string(),
-            }),
-        ));
+        return Err(error_response(StatusCode::BAD_REQUEST, err_msg));
     }
 
     // --- Decode base64 screenshot if present ---
@@ -236,12 +237,7 @@ pub async fn submit_bug_report(
         Some(ref b64) => match base64::engine::general_purpose::STANDARD.decode(b64) {
             Ok(bytes) => Some(bytes),
             Err(_) => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse {
-                        error: "invalid screenshot encoding".to_string(),
-                    }),
-                ));
+                return Err(error_response(StatusCode::BAD_REQUEST, "invalid screenshot encoding"));
             }
         },
         None => None,
@@ -283,7 +279,7 @@ pub async fn submit_bug_report(
         Err(e) => {
             let (status, msg) = map_bug_report_error(&e);
             warn!(error = %e, "bug report submission failed");
-            Err((status, Json(ErrorResponse { error: msg })))
+            Err(error_response(status, &msg))
         }
     }
 }
@@ -329,7 +325,7 @@ pub async fn analyze_bug_report(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(payload): Json<AnalyzeRequest>,
-) -> Result<Json<AnalyzeResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<AnalyzeResponse>, DiagnosticsErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &state.ip_config);
     let now = Instant::now();
 
@@ -339,30 +335,15 @@ pub async fn analyze_bug_report(
         .seconds_until_retry_ip(client_ip, now)
     {
         warn!(ip = %client_ip, retry_after = retry_secs, "bug report analyze rate limit exceeded (IP)");
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(ErrorResponse {
-                error: format!("rate limit exceeded, retry after {}s", retry_secs),
-            }),
-        ));
+        return Err(rate_limited_response(retry_secs));
     }
 
     // Validate description length
     if payload.description.len() < 10 {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "description too short".to_string(),
-            }),
-        ));
+        return Err(error_response(StatusCode::BAD_REQUEST, "description too short"));
     }
     if payload.description.len() > MAX_BODY_LEN {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "description too long".to_string(),
-            }),
-        ));
+        return Err(error_response(StatusCode::BAD_REQUEST, "description too long"));
     }
 
     let previous = payload.previous_answers.as_deref();
@@ -380,7 +361,7 @@ pub async fn analyze_bug_report(
         Err(e) => {
             warn!(error = %e, "LLM analyze failed");
             let (status, msg) = map_llm_error(&e);
-            Err((status, Json(ErrorResponse { error: msg })))
+            Err(error_response(status, &msg))
         }
     }
 }
@@ -394,7 +375,7 @@ pub async fn generate_bug_report_body(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(payload): Json<GenerateBodyRequest>,
-) -> Result<Json<GenerateBodyResponse>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<GenerateBodyResponse>, DiagnosticsErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &state.ip_config);
     let now = Instant::now();
 
@@ -403,21 +384,11 @@ pub async fn generate_bug_report_body(
         .bug_report_rate_limiter
         .seconds_until_retry_ip(client_ip, now)
     {
-        return Err((
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(ErrorResponse {
-                error: format!("rate limit exceeded, retry after {}s", retry_secs),
-            }),
-        ));
+        return Err(rate_limited_response(retry_secs));
     }
 
     if payload.description.len() < 10 || payload.description.len() > MAX_BODY_LEN {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "invalid description length".to_string(),
-            }),
-        ));
+        return Err(error_response(StatusCode::BAD_REQUEST, "invalid description length"));
     }
 
     match state
@@ -437,7 +408,7 @@ pub async fn generate_bug_report_body(
         Err(e) => {
             warn!(error = %e, "LLM generate body failed");
             let (status, msg) = map_llm_error(&e);
-            Err((status, Json(ErrorResponse { error: msg })))
+            Err(error_response(status, &msg))
         }
     }
 }

--- a/wavis-backend/src/ws/ws.rs
+++ b/wavis-backend/src/ws/ws.rs
@@ -42,7 +42,7 @@ use axum::response::{IntoResponse, Response};
 use shared::signaling::{self, ErrorPayload, SignalingMessage};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
@@ -74,6 +74,9 @@ fn error_text(message: &str) -> String {
 
 async fn send_error_and_close(socket: &mut WebSocket, message: &str) {
     let _ = socket.send(Message::Text(error_text(message).into())).await;
+    if message == MSG_RATE_LIMIT_EXCEEDED {
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
     let _ = socket.send(Message::Close(None)).await;
 }
 

--- a/wavis-backend/src/ws/ws_rate_limit.rs
+++ b/wavis-backend/src/ws/ws_rate_limit.rs
@@ -25,7 +25,7 @@ pub struct WsRateLimitConfig {
     pub max_messages: u32,       // WS_RATE_LIMIT_MAX_MESSAGES, default: 60
     pub burst_max: u32,          // WS_RATE_LIMIT_BURST, default: 15
     pub burst_window: Duration,  // always 1 second
-    pub action_max: u32,         // ACTION_RATE_LIMIT_MAX, default: 5
+    pub action_max: u32,         // ACTION_RATE_LIMIT_MAX, default: 15
     pub action_window: Duration, // ACTION_RATE_LIMIT_WINDOW_SECS, default: 60
     pub deafen_max: u32,         // DEAFEN_RATE_LIMIT_MAX, default: 20
     pub deafen_window: Duration, // DEAFEN_RATE_LIMIT_WINDOW_SECS, default: 60
@@ -49,7 +49,7 @@ impl WsRateLimitConfig {
         let action_max = env::var("ACTION_RATE_LIMIT_MAX")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
-            .unwrap_or(5);
+            .unwrap_or(15);
         let action_window_secs = env::var("ACTION_RATE_LIMIT_WINDOW_SECS")
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
@@ -220,6 +220,21 @@ pub(crate) fn check_json_depth(text: &str, max_depth: u32) -> bool {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    use std::sync::{LazyLock, Mutex};
+
+    static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    #[test]
+    fn test_from_env_uses_updated_action_default() {
+        let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+
+        unsafe {
+            std::env::remove_var("ACTION_RATE_LIMIT_MAX");
+        }
+
+        let config = WsRateLimitConfig::from_env();
+        assert_eq!(config.action_max, 15);
+    }
 
     // Test: both KickParticipant and MuteParticipant count toward action limit (Req 3.3)
     #[test]


### PR DESCRIPTION
Threshold Tuning
Shared SlidingWindow
Retry-After Headers
UX
4a: rate_limited added to friendlyMessages in voice-room.ts.
4b: The 200ms sleep in send_error_and_close is correctly gated on MSG_RATE_LIMIT_EXCEEDED only. Frontend persists the rate-limit error through the reconnect cycle via lastRateLimitError state field, clears it on successful join, and displays a yellow banner during reconnection. The signaling indicator also changes its label. This is a solid partial fix.## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
