### PR TITLE
Require room membership for voice sharing

### DIFF
--- a/clients/shared/src/livekit_connection.rs
+++ b/clients/shared/src/livekit_connection.rs
@@ -151,7 +151,7 @@ impl RealLiveKitConnection {
             connected: Arc::new(AtomicBool::new(false)),
             room: Arc::new(Mutex::new(None)),
             published_track: Arc::new(Mutex::new(None)),
-            mic_enabled: Arc::new(AtomicBool::new(true)),
+            mic_enabled: Arc::new(AtomicBool::new(false)),
             audio_cb: Arc::new(Mutex::new(None)),
             event_task: Arc::new(Mutex::new(None)),
             capture_task: Arc::new(Mutex::new(None)),

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -652,6 +652,8 @@ pub fn media_connect(
 
     match state.runtime.block_on(async { conn.connect(&url, &token) }) {
         Ok(()) => {
+            conn.set_mic_enabled(false)
+                .map_err(|err| format!("failed to disable mic before publish: {err}"))?;
             if let Err(err) = conn.publish_audio(&AudioTrack {
                 id: "native-mic".to_string(),
             }) {

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1404,7 +1404,13 @@ export default function ActiveRoom() {
   const sharers = roomState?.participants.filter((p) => p.isSharing) ?? [];
   const watchAllScope = getWatchAllScope(roomState);
   const shareEnabled = roomState
-    ? isShareEnabled(roomState.sharePermission, isHost, roomState.machineState, roomState.mediaState)
+    ? isShareEnabled(
+        roomState.sharePermission,
+        isHost,
+        roomState.machineState,
+        roomState.mediaState,
+        roomState.joinedSubRoomId,
+      )
     : false;
   const currentShareType = roomState
     ? activeShareType(roomState.activeVideoShare, roomState.activeAudioShare)
@@ -1460,6 +1466,7 @@ export default function ActiveRoom() {
 
   /** Open custom share picker or invoke getDisplayMedia fallback based on platform. */
   const handleStartShare = async () => {
+    if (!shareEnabled) return;
     if (shareEnumerating.current) return;
     shareEnumerating.current = true;
     if (!isLinuxPlatform) setSharePickerLoading(true);

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -787,9 +787,9 @@ async function driveToConnected(mod: LiveKitModule, url = 'wss://sfu.test', toke
 
 describe('LiveKitModule lifecycle', () => {
 
-  // Feature: gui-livekit-media, Property 4: Media connected requires Room connected AND mic published
-  describe('P4: Media connected requires Room connected AND mic published', () => {
-    it('onMediaConnected fires only after BOTH Connected and LocalTrackPublished', async () => {
+  // Feature: gui-livekit-media, Property 4: Media connects listen-only before mic publication
+  describe('P4: Media connects listen-only before mic publication', () => {
+    it('onMediaConnected fires after Room connected without requiring mic publication', async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.boolean(), // true = Connected first (normal), false = LocalTrackPublished first
@@ -808,13 +808,13 @@ describe('LiveKitModule lifecycle', () => {
               // Normal flow: Connected → setMicrophoneEnabled → LocalTrackPublished
               emitRoomEvent('connected');
               await tick(); // let setMicrophoneEnabled resolve
-              expect(countConnected()).toBe(0); // Connected alone is not enough
+              expect(countConnected()).toBe(1);
               emitRoomEvent('localTrackPublished', AUDIO_PUB, mockRoom.localParticipant);
               expect(countConnected()).toBe(1);
             } else {
               // Unusual: LocalTrackPublished arrives before Connected
               emitRoomEvent('localTrackPublished', AUDIO_PUB, mockRoom.localParticipant);
-              expect(countConnected()).toBe(0); // mic ready but not connected
+              expect(countConnected()).toBe(0);
               emitRoomEvent('connected');
               await tick(); // let setMicrophoneEnabled resolve
               // After Connected, lkConnected=true. micReady was already true.
@@ -837,20 +837,21 @@ describe('LiveKitModule lifecycle', () => {
     /**
      * Validates: Requirements 3.2, 4.1
      */
-    it('Connected event alone does NOT trigger onMediaConnected', async () => {
+    it('Connected event alone triggers listen-only onMediaConnected', async () => {
       const cbs = createMockCallbacks();
       const mod = new LiveKitModule(cbs);
       await mod.connect('wss://sfu.test', 'tok-alone');
       emitRoomEvent('connected');
       await tick();
-      expect(cbs.calls.filter(c => c.method === 'onMediaConnected')).toHaveLength(0);
+      expect(cbs.calls.filter(c => c.method === 'onMediaConnected')).toHaveLength(1);
+      expect(sdkCalls.filter(c => c.method === 'setMicrophoneEnabled')).toHaveLength(0);
       mod.disconnect();
     });
   });
 
-  // Feature: gui-livekit-media, Property 5: Mic permission denied results in listen-only mode
-  describe('P5: Mic permission denied results in listen-only mode', () => {
-    it('onMediaConnected fires in listen-only when mic is denied', async () => {
+  // Feature: gui-livekit-media, Property 5: Mic permission denied is handled when publishing is requested
+  describe('P5: Mic permission denied is handled when publishing is requested', () => {
+    it('connect stays listen-only and setMicEnabled reports mic denial', async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.string({ minLength: 1, maxLength: 50 }).filter(s => s.trim().length > 0),
@@ -867,7 +868,8 @@ describe('LiveKitModule lifecycle', () => {
 
             // Connected → setMicrophoneEnabled rejects → listen-only → checkReady
             emitRoomEvent('connected');
-            await tick(); // let the rejection propagate
+            await mod.setMicEnabled(true);
+            await tick();
 
             // onMediaConnected should fire (listen-only)
             expect(cbs.calls.filter(c => c.method === 'onMediaConnected')).toHaveLength(1);
@@ -5166,6 +5168,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const { pub, mediaStreamTrack, track } = createAudioPubWithMst();
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
     emitRoomEvent('localTrackPublished', pub, mockRoom.localParticipant);
     await tick();
@@ -5182,6 +5185,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const publishCall = sdkCalls.find(c => c.method === 'publishTrack');
@@ -5203,6 +5207,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const micCall = sdkCalls.find(c => c.method === 'setMicrophoneEnabled');
@@ -5221,6 +5226,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const micCall = sdkCalls.find(c => c.method === 'setMicrophoneEnabled');
@@ -5239,6 +5245,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const micCall = sdkCalls.find(c => c.method === 'setMicrophoneEnabled');

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
@@ -221,6 +221,17 @@ async function driveToActive() {
   // Establish media so lkModule exists
   if (messageHandler) {
     messageHandler({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    messageHandler({
+      type: 'sub_room_state',
+      rooms: [
+        {
+          subRoomId: 'room-1',
+          roomNumber: 1,
+          isDefault: true,
+          participantIds: ['self-peer'],
+        },
+      ],
+    });
   }
   await tick();
 }

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -271,6 +271,16 @@ async function driveToActive(channelId = 'ch-1', channelName = 'test-room') {
   await tick();
 }
 
+async function assignSelfToSubRoom(subRoomId = 'room-1') {
+  messageHandler!({
+    type: 'sub_room_state',
+    rooms: [
+      { subRoomId, roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+    ],
+  });
+  await tick();
+}
+
 beforeEach(() => {
   resetAll();
 });
@@ -489,6 +499,142 @@ describe('VoiceRoom sub-room state', () => {
 });
 
 describe('VoiceRoom room-based effective volume isolation', () => {
+  it('disables local mic publishing and incoming audio when a snapshot moves self out of all rooms', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer', 'peer-2'] },
+      ],
+    });
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+    const volumeCallsBefore = lastLkModule!.setParticipantVolumeCalls.length;
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['peer-2'] },
+      ],
+    });
+    await tick();
+
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([false]);
+    expect(getState().joinedSubRoomId).toBeNull();
+    expect(getState().participants.find((p) => p.id === 'self-peer')).toMatchObject({
+      isMuted: true,
+      isSpeaking: false,
+      rmsLevel: 0,
+    });
+    expect(lastLkModule!.setParticipantVolumeCalls.slice(volumeCallsBefore)).toContainEqual({ id: 'peer-2', vol: 0 });
+  });
+
+  it('enables local mic publishing by default when a snapshot assigns self to a room', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+      ],
+    });
+    await tick();
+
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([true]);
+    expect(getState().joinedSubRoomId).toBe('room-1');
+    expect(getState().participants.find((p) => p.id === 'self-peer')?.isMuted).toBe(false);
+  });
+
+  it('does not reset mic publishing when self moves directly between rooms', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+        { subRoomId: 'room-2', roomNumber: 2, isDefault: false, participantIds: [] },
+      ],
+    });
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    messageHandler!({
+      type: 'sub_room_joined',
+      participantId: 'self-peer',
+      subRoomId: 'room-2',
+      source: 'explicit',
+    });
+    await tick();
+
+    expect(getState().joinedSubRoomId).toBe('room-2');
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([]);
+  });
+
+  it('disables local mic publishing when sub_room_left confirms self left the room', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+      ],
+    });
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    messageHandler!({
+      type: 'sub_room_left',
+      participantId: 'self-peer',
+      subRoomId: 'room-1',
+    });
+    await tick();
+
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([false]);
+    expect(getState().joinedSubRoomId).toBeNull();
+    expect(getState().participants.find((p) => p.id === 'self-peer')?.isMuted).toBe(true);
+  });
+
+  it('keeps mic publishing disabled when mute is toggled outside a room', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    toggleSelfMute();
+    await tick();
+    toggleSelfMute();
+    await tick();
+
+    expect(getState().joinedSubRoomId).toBeNull();
+    expect(getState().participants.find((p) => p.id === 'self-peer')?.isMuted).toBe(true);
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([false, false]);
+  });
+
   it('mutes participants outside the local joined room while preserving manual volume', async () => {
     await driveToActive('ch-subrooms', 'subroom-test');
 
@@ -993,6 +1139,7 @@ describe('Voice-room media wiring', () => {
       // Send media_token so lkModule exists
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
+      await assignSelfToSubRoom();
 
       // Host-mute self
       messageHandler!({ type: 'participant_muted', participantId: 'self-peer' });
@@ -1067,7 +1214,7 @@ describe('Voice-room media wiring', () => {
       expect(self).toBeTruthy();
       expect(self!.isMuted).toBe(true);
       expect(lastLkModule!.setMicEnabledCalls[lastLkModule!.setMicEnabledCalls.length - 1]).toBe(false);
-      expect(latestState!.events.some((e) => e.message === 'you muted microphone')).toBe(true);
+      expect(latestState!.events.some((e) => e.message === 'mute toggle ignored: join a room before using the microphone')).toBe(true);
 
       leaveRoom();
     });
@@ -1450,6 +1597,7 @@ describe('Edge case unit tests', () => {
     it('screen picker cancelled does not send StartShare', async () => {
       resetAll();
       await driveToActive();
+      await assignSelfToSubRoom();
 
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
@@ -1469,9 +1617,91 @@ describe('Edge case unit tests', () => {
       leaveRoom();
     });
 
+    it('startFallbackShare rejects when self is not in a synchronized room', async () => {
+      resetAll();
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+
+      const { startFallbackShare } = await import('../voice-room');
+      await expect(startFallbackShare()).rejects.toThrow('Join a room before sharing.');
+      expect(lastLkModule!.startScreenShareCalls).toBe(0);
+      expect(sentMessages.filter(m => m.type === 'start_share')).toHaveLength(0);
+
+      leaveRoom();
+    });
+
+    it('leaving the current sub-room stops local fallback share and uses share_stopped echo for sound', async () => {
+      resetAll();
+      await driveToActive();
+      await assignSelfToSubRoom('room-1');
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      vi.mocked(lastLkModule!.startScreenShare).mockResolvedValue(true);
+
+      const { startFallbackShare } = await import('../voice-room');
+      await startFallbackShare();
+      messageHandler!({ type: 'share_started', participantId: 'self-peer', displayName: 'TestUser' });
+      await tick();
+      sentMessages.length = 0;
+      playNotificationSoundCalls = [];
+
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [
+          { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: [] },
+        ],
+      });
+      await tick();
+
+      expect(lastLkModule!.stopScreenShareCalls).toBe(1);
+      expect(sentMessages).toContainEqual({ type: 'stop_share' });
+      expect(playNotificationSoundCalls).not.toContain('share-stop');
+
+      messageHandler!({ type: 'share_stopped', participantId: 'self-peer', displayName: 'TestUser' });
+      await tick();
+      expect(playNotificationSoundCalls).toContain('share-stop');
+      lastLkModule!.callbacks.onLocalScreenShareEnded();
+
+      leaveRoom();
+    });
+
+    it('switching directly between sub-rooms does not stop local fallback share', async () => {
+      resetAll();
+      await driveToActive();
+      await assignSelfToSubRoom('room-1');
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      vi.mocked(lastLkModule!.startScreenShare).mockResolvedValue(true);
+
+      const { startFallbackShare } = await import('../voice-room');
+      await startFallbackShare();
+      messageHandler!({ type: 'share_started', participantId: 'self-peer', displayName: 'TestUser' });
+      await tick();
+      sentMessages.length = 0;
+
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [
+          { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: [] },
+          { subRoomId: 'room-2', roomNumber: 2, isDefault: false, participantIds: ['self-peer'] },
+        ],
+      });
+      await tick();
+
+      expect(lastLkModule!.stopScreenShareCalls).toBe(0);
+      expect(sentMessages.filter(m => m.type === 'stop_share')).toHaveLength(0);
+
+      leaveRoom();
+    });
+
     it('external screen share end sends StopShare signaling', async () => {
       resetAll();
       await driveToActive();
+      await assignSelfToSubRoom();
 
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
@@ -1669,6 +1899,7 @@ describe('Feature: screen-share-quality, Property 11: Signaling message preserva
             });
           }
           await tick();
+          await assignSelfToSubRoom();
 
           // Establish media so lkModule exists
           messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
@@ -1718,6 +1949,7 @@ describe('VoiceRoom delegates startScreenShare to LiveKitModule', () => {
   it('startFallbackShare() calls startScreenShare on the LiveKitModule', async () => {
     resetAll();
     await driveToActive();
+    await assignSelfToSubRoom();
 
     // Establish media so lkModule exists
     messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-share-permission.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-share-permission.test.ts
@@ -3,32 +3,37 @@ import { isShareEnabled, shareButtonLabel } from '../voice-room';
 
 describe('isShareEnabled', () => {
   it('returns true for non-host when permission is anyone, room active, media connected', () => {
-    expect(isShareEnabled('anyone', false, 'active', 'connected')).toBe(true);
+    expect(isShareEnabled('anyone', false, 'active', 'connected', 'room-1')).toBe(true);
   });
 
   it('returns false for non-host when permission is host_only', () => {
-    expect(isShareEnabled('host_only', false, 'active', 'connected')).toBe(false);
+    expect(isShareEnabled('host_only', false, 'active', 'connected', 'room-1')).toBe(false);
   });
 
   it('returns true for host even when permission is host_only', () => {
-    expect(isShareEnabled('host_only', true, 'active', 'connected')).toBe(true);
+    expect(isShareEnabled('host_only', true, 'active', 'connected', 'room-1')).toBe(true);
+  });
+
+  it('returns false when the user has not joined a synchronized room', () => {
+    expect(isShareEnabled('anyone', false, 'active', 'connected', null)).toBe(false);
+    expect(isShareEnabled('host_only', true, 'active', 'connected', null)).toBe(false);
   });
 
   it('returns false when machineState is reconnecting, even with anyone permission', () => {
-    expect(isShareEnabled('anyone', false, 'reconnecting', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'reconnecting', 'connected', 'room-1')).toBe(false);
   });
 
   it('returns false when machineState is connecting', () => {
-    expect(isShareEnabled('anyone', false, 'connecting', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'connecting', 'connected', 'room-1')).toBe(false);
   });
 
   it('returns false when mediaState is not connected', () => {
-    expect(isShareEnabled('anyone', false, 'active', 'connecting')).toBe(false);
-    expect(isShareEnabled('anyone', false, 'active', 'disconnected')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'active', 'connecting', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'active', 'disconnected', 'room-1')).toBe(false);
   });
 
   it('returns false for host when machineState is not active', () => {
-    expect(isShareEnabled('anyone', true, 'reconnecting', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'reconnecting', 'connected', 'room-1')).toBe(false);
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
@@ -269,40 +269,40 @@ describe('Property 2: Share button enabled iff permission allows and media ready
   it('share enabled when permission is "anyone" regardless of host status (media ready)', () => {
     fc.assert(
       fc.property(fc.boolean(), (selfIsHost) => {
-        expect(isShareEnabled('anyone', selfIsHost, 'active', 'connected')).toBe(true);
+        expect(isShareEnabled('anyone', selfIsHost, 'active', 'connected', 'room-1')).toBe(true);
       }),
       { numRuns: 100 },
     );
   });
 
   it('share enabled when host_only AND selfIsHost is true (media ready)', () => {
-    expect(isShareEnabled('host_only', true, 'active', 'connected')).toBe(true);
+    expect(isShareEnabled('host_only', true, 'active', 'connected', 'room-1')).toBe(true);
   });
 
   it('share disabled when host_only AND selfIsHost is false (media ready)', () => {
-    expect(isShareEnabled('host_only', false, 'active', 'connected')).toBe(false);
+    expect(isShareEnabled('host_only', false, 'active', 'connected', 'room-1')).toBe(false);
   });
 
   it('share disabled when media is not connected, even with permission', () => {
-    expect(isShareEnabled('anyone', true, 'active', 'disconnected')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'active', 'connecting')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'active', 'failed')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'active', 'disconnected', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'active', 'connecting', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'active', 'failed', 'room-1')).toBe(false);
   });
 
   it('share disabled when machine is not active, even with permission', () => {
-    expect(isShareEnabled('anyone', true, 'idle', 'connected')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'connecting', 'connected')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'joining', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'idle', 'connected', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'connecting', 'connected', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'joining', 'connected', 'room-1')).toBe(false);
   });
 
   it('for any permission and host status, enabled iff (anyone OR selfIsHost) AND active AND connected', () => {
     fc.assert(
       fc.property(arbSharePermission, fc.boolean(), (perm, selfIsHost) => {
         const expected = (perm === 'anyone' || selfIsHost);
-        expect(isShareEnabled(perm, selfIsHost, 'active', 'connected')).toBe(expected);
+        expect(isShareEnabled(perm, selfIsHost, 'active', 'connected', 'room-1')).toBe(expected);
         // Always false when media not ready, regardless of permission
-        expect(isShareEnabled(perm, selfIsHost, 'active', 'disconnected')).toBe(false);
-        expect(isShareEnabled(perm, selfIsHost, 'idle', 'connected')).toBe(false);
+        expect(isShareEnabled(perm, selfIsHost, 'active', 'disconnected', 'room-1')).toBe(false);
+        expect(isShareEnabled(perm, selfIsHost, 'idle', 'connected', 'room-1')).toBe(false);
       }),
       { numRuns: 100 },
     );

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -728,6 +728,10 @@ export class LiveKitModule {
   private localMicTrack: LocalAudioTrack | null = null;
   /** Whether the JS-side noise suppression processor should be active on this session's mic. */
   private jsDenoise = false;
+  /** Session preference used when voice-room later opts the microphone into publishing. */
+  private sessionDenoiseEnabled = false;
+  /** True when mic publishing should use the native Rust mic bridge for this session. */
+  private useNativeMicBridgeForMic = false;
   /** True only when the JS noise suppression processor is confirmed attached to the live mic track. */
   private jsDenoiseProcessorActive = false;
   /** Active native mic bridge instance (Windows + denoiseEnabled only). */
@@ -1590,12 +1594,14 @@ export class LiveKitModule {
     this.deviceChangeListener = null;
   }
 
-  /** Connect to LiveKit SFU. Creates Room, connects, publishes mic. */
+  /** Connect to LiveKit SFU. Creates Room in listen-only mode. */
   async connect(sfuUrl: string, token: string): Promise<void> {
     try {
       // 0. Read denoise preference for this session.
       const denoiseEnabled = await getDenoiseEnabled();
       const useNativeBridge = this.shouldUseNativeMicBridge(denoiseEnabled);
+      this.sessionDenoiseEnabled = denoiseEnabled;
+      this.useNativeMicBridgeForMic = useNativeBridge;
       this.jsDenoise = this.shouldUseJsNoiseSuppression(denoiseEnabled);
       this.setNoiseSuppressionActive(false);
       console.log(
@@ -1649,45 +1655,10 @@ export class LiveKitModule {
       addListener(RoomEvent.Connected, () => {
         if (this.disposed) return;
         lkConnected = true;
+        listenOnly = true;
         // Watch for OS device changes so the routing survives plug/unplug events.
-        // Output device routing itself is applied in checkReady() after getUserMedia.
         this.startDeviceChangeWatcher();
-        if (useNativeBridge) {
-          // Windows + denoiseEnabled: capture mic in Rust through DenoiseFilter,
-          // then publish the denoised MediaStreamTrack via LiveKit.
-          this.startNativeMicBridge(denoiseEnabled)
-            .catch((err: unknown) => {
-              // Bridge failed — fall back to browser mic without denoise.
-              console.warn(LOG, 'native mic bridge failed, falling back to browser mic:', err);
-              this.callbacks.onSystemEvent(
-                `native mic bridge failed — falling back to browser mic (no denoise)`,
-              );
-              return this.room?.localParticipant.setMicrophoneEnabled(true, {
-                noiseSuppression: false,
-              });
-            })
-            .catch((err: unknown) => {
-              listenOnly = true;
-              this.callbacks.onSystemEvent(
-                `mic failed: ${err instanceof Error ? err.message : String(err)} — listen-only mode`,
-              );
-              if (DEBUG_AUDIO_OUTPUT) console.log(LOG, '[audio-output] listen-only mode — applying output device (best-effort)');
-              this.applyAudioOutputDevice();
-              checkReady();
-            });
-        } else {
-          this.room!.localParticipant.setMicrophoneEnabled(true, {
-            noiseSuppression: false,
-          }).catch((err: unknown) => {
-            listenOnly = true;
-            this.callbacks.onSystemEvent(
-              `mic permission denied: ${err instanceof Error ? err.message : String(err)} — listen-only mode`,
-            );
-            if (DEBUG_AUDIO_OUTPUT) console.log(LOG, '[audio-output] listen-only mode — applying output device (best-effort)');
-            this.applyAudioOutputDevice();
-            checkReady();
-          });
-        }
+        checkReady();
       });
 
       // b. Disconnected
@@ -2290,7 +2261,28 @@ export class LiveKitModule {
       this.localMicTrack.mediaStreamTrack.enabled = enabled;
       return;
     }
-    await this.room.localParticipant.setMicrophoneEnabled(enabled);
+    if (enabled && this.useNativeMicBridgeForMic && !this.localMicTrack) {
+      try {
+        await this.startNativeMicBridge(this.sessionDenoiseEnabled);
+        return;
+      } catch (err) {
+        console.warn(LOG, 'native mic bridge failed, falling back to browser mic:', err);
+        this.callbacks.onSystemEvent(
+          `native mic bridge failed - falling back to browser mic (no denoise)`,
+        );
+      }
+    }
+    try {
+      await this.room.localParticipant.setMicrophoneEnabled(enabled, {
+        noiseSuppression: false,
+      });
+    } catch (err) {
+      if (enabled) {
+        this.callbacks.onSystemEvent(
+          `mic permission denied: ${err instanceof Error ? err.message : String(err)} - listen-only mode`,
+        );
+      }
+    }
   }
 
   /** Set per-participant volume (0–100 → perceptual gain curve). */
@@ -3979,7 +3971,7 @@ export class LiveKitModule {
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 2048;
     const gain = ctx.createGain();
-    const desiredVol = this.desiredParticipantVolumes.get(identity) ?? 70;
+    const desiredVol = this.desiredParticipantVolumes.get(identity) ?? 0;
     gain.gain.setValueAtTime(perceptualGain(desiredVol), ctx.currentTime);
     source.connect(analyser);
     analyser.connect(gain);

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -329,11 +329,22 @@ export function computeSpeaking(
 
 /**
  * Pure function: determine if screen sharing is enabled for the current user.
- * Requires all three conditions: permission allows it (anyone OR host),
- * room is active, and LiveKit media connection is established.
+ * Requires all four conditions: permission allows it (anyone OR host),
+ * room is active, media is connected, and the user is in a synchronized room.
  */
-export function isShareEnabled(sharePermission: 'anyone' | 'host_only', selfIsHost: boolean, machineState: VoiceRoomMachineState, mediaState: MediaState): boolean {
-  return (sharePermission === 'anyone' || selfIsHost) && machineState === 'active' && mediaState === 'connected'
+export function isShareEnabled(
+  sharePermission: 'anyone' | 'host_only',
+  selfIsHost: boolean,
+  machineState: VoiceRoomMachineState,
+  mediaState: MediaState,
+  joinedSubRoomId: string | null,
+): boolean {
+  return (
+    joinedSubRoomId !== null
+    && (sharePermission === 'anyone' || selfIsHost)
+    && machineState === 'active'
+    && mediaState === 'connected'
+  );
 }
 
 /**
@@ -421,6 +432,54 @@ function applyEffectiveParticipantVolumes(): void {
   for (const participant of state.participants) {
     applyEffectiveParticipantVolume(participant);
   }
+}
+
+function selfParticipant(): RoomParticipant | undefined {
+  return state.participants.find((p) => p.id === state.selfParticipantId);
+}
+
+function silenceSelfParticipant(self: RoomParticipant): void {
+  self.isMuted = true;
+  self.isSpeaking = false;
+  self.rmsLevel = 0;
+}
+
+function setLocalMicPublishing(enabled: boolean): void {
+  lkModule?.setMicEnabled(enabled);
+}
+
+function shouldPublishLocalMic(self: RoomParticipant | undefined): boolean {
+  return (
+    state.joinedSubRoomId !== null
+    && self !== undefined
+    && !self.isMuted
+    && !self.isHostMuted
+    && !state.isDeafened
+  );
+}
+
+function reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId: string | null): void {
+  const currentJoinedSubRoomId = state.joinedSubRoomId;
+  const self = selfParticipant();
+
+  if (currentJoinedSubRoomId === null) {
+    if (self) {
+      silenceSelfParticipant(self);
+    }
+    setLocalMicPublishing(false);
+    return;
+  }
+
+  if (previousJoinedSubRoomId !== null) return;
+  if (!self || self.isHostMuted || state.isDeafened) {
+    setLocalMicPublishing(false);
+    return;
+  }
+
+  self.isMuted = false;
+  self.isSpeaking = false;
+  self.rmsLevel = 0;
+  setLocalMicPublishing(true);
 }
 
 /**
@@ -692,6 +751,7 @@ export function computeLeaveShareCleanup(
  * a helpful OS-level message. The only other throw here is when lkModule is null.
  */
 export async function startFallbackShare(): Promise<{ started: boolean; withAudio: boolean }> {
+  ensureInSubRoomForShare();
   console.log(LOG, `startFallbackShare: lkModule=${lkModule ? lkModule.constructor.name : 'null'}, mediaState=${state.mediaState}, machineState=${state.machineState}`);
   if (!lkModule) {
     throw new Error(`Screen sharing is not available (media module not initialized, mediaState=${state.mediaState})`);
@@ -939,6 +999,10 @@ function setupExternalShareHelperListeners(): void {
   if (unlistenExternalShareStarted || unlistenExternalShareStopped || unlistenExternalShareError) return;
 
   listen<{ sessionId: string }>('external-share-started', () => {
+    if (state.joinedSubRoomId === null) {
+      invoke('external_share_stop').catch(() => { });
+      return;
+    }
     externalShareHelperActive = true;
     localStopShareSent = false;
     const self = state.participants.find((p) => p.id === state.selfParticipantId);
@@ -1048,6 +1112,28 @@ function syncDerivedSubRoomState(): void {
     return;
   }
   state.joinedSubRoomId = state.participantSubRoomById[state.selfParticipantId] ?? null;
+}
+
+function ensureInSubRoomForShare(): void {
+  if (state.joinedSubRoomId !== null) return;
+  throw new Error('Join a room before sharing.');
+}
+
+function stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId: string | null): void {
+  if (!previousJoinedSubRoomId || state.joinedSubRoomId !== null) return;
+  const self = state.participants.find((p) => p.id === state.selfParticipantId);
+  const hasCustomShare = state.activeVideoShare !== null || state.activeAudioShare !== null;
+  const hasFallbackShare =
+    self?.isSharing === true
+    || externalShareHelperActive
+    || state.shareQualityInfo !== null
+    || state.shareStats !== null;
+
+  if (hasCustomShare) {
+    void stopCustomShare('all');
+  } else if (hasFallbackShare) {
+    void stopShare();
+  }
 }
 
 function syncDesiredSubRoomPreference(): void {
@@ -1232,10 +1318,8 @@ function connectMedia(sfuUrl: string, token: string): void {
       stopPeriodicMediaRetry();
       // Re-apply mute state after media reconnection — if the user was muted,
       // ensure the mic stays muted (LiveKit enables mic by default on connect).
-      const self = state.participants.find((p) => p.id === state.selfParticipantId);
-      if (self && self.isMuted && lkModule) {
-        lkModule.setMicEnabled(false);
-      }
+      const self = selfParticipant();
+      setLocalMicPublishing(shouldPublishLocalMic(self));
       // Apply persisted master volume to the media layer
       if (lkModule) {
         lkModule.setMasterVolume(state.masterVolume);
@@ -1340,6 +1424,12 @@ function connectMedia(sfuUrl: string, token: string): void {
       if (!p) return;
 
       if (identity === state.selfParticipantId) {
+        if (!isMuted && state.joinedSubRoomId === null) {
+          silenceSelfParticipant(p);
+          lkModule?.setMicEnabled(false);
+          notify();
+          return;
+        }
         // Local participant mute state changed externally (e.g. LiveKit reconnect,
         // OS-level mute). Sync UI state to match actual mic state.
         if (p.isMuted !== isMuted) {
@@ -1650,6 +1740,7 @@ function dispatchMessage(raw: unknown): void {
             : room
         ));
         syncDerivedSubRoomState();
+        reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
         playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
         applyEffectiveParticipantVolumes();
       }
@@ -1691,6 +1782,8 @@ function dispatchMessage(raw: unknown): void {
           }
         : null;
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
@@ -1736,6 +1829,8 @@ function dispatchMessage(raw: unknown): void {
           : room;
       });
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       void source;
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
@@ -1755,6 +1850,8 @@ function dispatchMessage(raw: unknown): void {
           : room
       ));
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
@@ -1763,9 +1860,12 @@ function dispatchMessage(raw: unknown): void {
     }
 
     case 'sub_room_deleted': {
+      const previousJoinedSubRoomId = state.joinedSubRoomId;
       const subRoomId = msg.subRoomId as string;
       state.subRooms = state.subRooms.filter((room) => room.id !== subRoomId);
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       if (desiredSubRoomIntent === subRoomId) {
         desiredSubRoomIntent = undefined;
       }
@@ -2576,6 +2676,19 @@ export function toggleSelfMute(): void {
     notify();
     return;
   }
+  if (state.joinedSubRoomId === null) {
+    silenceSelfParticipant(self);
+    lkModule?.setMicEnabled(false);
+    appendEvent({
+      id: makeEventId(),
+      timestamp: timestamp(),
+      type: 'system',
+      message: 'mute toggle ignored: join a room before using the microphone',
+      participantId: self.id,
+    });
+    notify();
+    return;
+  }
 
   // If deafened and trying to unmute, cancel deafen entirely
   if (state.isDeafened && self.isMuted) {
@@ -2612,9 +2725,12 @@ export function toggleSelfDeafen(): void {
     preDeafenVolume = null;
     state.masterVolume = restored;
     lkModule?.setMasterVolume(restored);
-    if (!self.isHostMuted) {
+    if (!self.isHostMuted && state.joinedSubRoomId !== null) {
       self.isMuted = false;
       lkModule?.setMicEnabled(true);
+    } else {
+      silenceSelfParticipant(self);
+      lkModule?.setMicEnabled(false);
     }
     client?.send({ type: 'self_undeafen' });
     appendEvent({
@@ -2658,6 +2774,7 @@ export function toggleSelfDeafen(): void {
 // post-share audio prompt) or startCustomShare() instead.
 
 export async function startExternalBrowserShare(): Promise<void> {
+  ensureInSubRoomForShare();
   await invoke('external_share_start');
 }
 
@@ -2668,6 +2785,7 @@ export async function startExternalBrowserShare(): Promise<void> {
  * This is the primary path for Wayland compositors (Hyprland, GNOME, KDE).
  */
 export async function startPortalShare(): Promise<boolean> {
+  ensureInSubRoomForShare();
   const result = await invoke<boolean>('screen_share_start');
   if (result) {
     // Mark self as sharing and notify peers (same as other share paths).
@@ -2700,6 +2818,7 @@ export async function startPortalShare(): Promise<boolean> {
  * rollback on partial failure, sends signaling, and opens the indicator.
  */
 export async function startCustomShare(selection: ShareSelection): Promise<void> {
+  ensureInSubRoomForShare();
   // 1. Check if the requested slot is available
   const check = canStartShare(selection, state.activeVideoShare, state.activeAudioShare);
   if (!check.allowed) {

--- a/wavis-backend/src/voice/screen_share.rs
+++ b/wavis-backend/src/voice/screen_share.rs
@@ -97,6 +97,14 @@ pub fn handle_start_share(
             }));
         }
 
+        if let Some(sub_rooms) = members.info.sub_room_state.as_ref()
+            && !sub_rooms.participant_assignments.contains_key(sender_id)
+        {
+            return ShareResult::Error(SignalingMessage::Error(ErrorPayload {
+                message: "not in room".to_string(),
+            }));
+        }
+
         // Check sender not already sharing
         if members.info.active_shares.contains(sender_id) {
             return ShareResult::Noop;
@@ -459,6 +467,45 @@ mod tests {
 
         let result = handle_start_share(&state, "room-1", "outsider", ParticipantRole::Guest);
         assert!(matches!(result, ShareResult::Error(_)));
+    }
+
+    #[test]
+    fn start_share_fails_when_sender_has_no_sub_room_assignment() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["peer-a"]);
+        state
+            .with_room_write("room-1", |members| {
+                members.info.sub_room_state = Some(crate::state::SubRoomState::new("room-one"));
+            })
+            .unwrap();
+
+        let result = handle_start_share(&state, "room-1", "peer-a", ParticipantRole::Guest);
+
+        assert!(matches!(result, ShareResult::Error(_)));
+        assert!(!get_active_shares(&state, "room-1").contains("peer-a"));
+    }
+
+    #[test]
+    fn start_share_succeeds_when_sender_has_sub_room_assignment() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["peer-a"]);
+        state
+            .with_room_write("room-1", |members| {
+                let mut sub_rooms = crate::state::SubRoomState::new("room-one");
+                sub_rooms
+                    .participant_assignments
+                    .insert("peer-a".to_string(), "room-one".to_string());
+                sub_rooms.rooms[0]
+                    .participant_ids
+                    .push("peer-a".to_string());
+                members.info.sub_room_state = Some(sub_rooms);
+            })
+            .unwrap();
+
+        let result = handle_start_share(&state, "room-1", "peer-a", ParticipantRole::Guest);
+
+        assert!(matches!(result, ShareResult::Ok(_)));
+        assert!(get_active_shares(&state, "room-1").contains("peer-a"));
     }
 
     #[test]

--- a/wavis-backend/src/voice/voice_orchestrator.rs
+++ b/wavis-backend/src/voice/voice_orchestrator.rs
@@ -35,10 +35,9 @@ use chrono::{DateTime, Utc};
 use rand::Rng;
 use shared::signaling::{
     MediaTokenPayload, ParticipantInfo, ParticipantJoinedPayload, ParticipantLeftPayload,
-    PassthroughStatePayload,
-    RoomStatePayload, SignalingMessage, SubRoomCreatedPayload, SubRoomDeletedPayload,
-    SubRoomInfoPayload, SubRoomJoinedPayload, SubRoomLeftPayload, SubRoomStatePayload,
-    WireSubRoomMembershipSource,
+    PassthroughStatePayload, RoomStatePayload, ShareStoppedPayload, SignalingMessage,
+    SubRoomCreatedPayload, SubRoomDeletedPayload, SubRoomInfoPayload, SubRoomJoinedPayload,
+    SubRoomLeftPayload, SubRoomStatePayload, WireSubRoomMembershipSource,
 };
 use sqlx::PgPool;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -234,6 +233,14 @@ fn sub_room_state_signals(room_state: &InMemoryRoomState, room_id: &str) -> Vec<
         .and_then(|info| info.sub_room_state.as_ref().map(sub_room_state_payload))
         .map(|payload| vec![OutboundSignal::broadcast_all(SignalingMessage::SubRoomState(payload))])
         .unwrap_or_default()
+}
+
+fn participant_display_name(participants: &[ParticipantInfo], participant_id: &str) -> String {
+    participants
+        .iter()
+        .find(|p| p.participant_id == participant_id)
+        .map(|p| p.display_name.clone())
+        .unwrap_or_else(|| participant_id.to_string())
 }
 
 fn ensure_room_sub_rooms(info: &mut RoomInfo) {
@@ -616,6 +623,7 @@ pub fn leave_sub_room(
 ) -> Result<SubRoomActionResult, String> {
     let mut left_sub_room_id = None;
     let mut expiry = None;
+    let mut share_stopped = None;
 
     room_state
         .with_room_write(room_id, |members| {
@@ -638,6 +646,15 @@ pub fn leave_sub_room(
             }
             expiry = schedule_empty_room_if_needed(sub_rooms, &current_room_id);
             left_sub_room_id = Some(current_room_id);
+            if members.info.active_shares.remove(participant_id) {
+                share_stopped = Some(SignalingMessage::ShareStopped(ShareStoppedPayload {
+                    participant_id: participant_id.to_string(),
+                    display_name: participant_display_name(
+                        &members.info.participants,
+                        participant_id,
+                    ),
+                }));
+            }
             Ok::<(), String>(())
         })
         .map_err(|_| "voice session not found".to_string())??;
@@ -650,6 +667,9 @@ pub fn leave_sub_room(
                 sub_room_id,
             },
         )));
+    }
+    if let Some(event) = share_stopped {
+        signals.push(OutboundSignal::broadcast_all(event));
     }
     signals.extend(sub_room_state_signals(room_state, room_id));
     Ok(SubRoomActionResult { signals, expiry })
@@ -1288,6 +1308,55 @@ mod tests {
             .find(|room| room.sub_room_id == "room-2")
             .expect("room-2 exists");
         assert!(room.delete_at.is_some());
+    }
+
+    #[test]
+    fn leaving_sub_room_clears_active_share() {
+        let state = sub_room_test_state();
+        let _ = create_sub_room(&state, "voice-room").expect("create sub room");
+        let _ = join_sub_room(&state, "voice-room", "room-2", "peer-a");
+        state
+            .with_room_write("voice-room", |members| {
+                members.info.active_shares.insert("peer-a".to_string());
+            })
+            .unwrap();
+
+        let result = leave_sub_room(&state, "voice-room", "peer-a").expect("leave sub room");
+
+        let info = state.get_room_info("voice-room").expect("room exists");
+        assert!(!info.active_shares.contains("peer-a"));
+        assert!(result.signals.iter().any(|signal| {
+            matches!(
+                &signal.msg,
+                SignalingMessage::ShareStopped(payload)
+                    if payload.participant_id == "peer-a"
+                        && payload.display_name == "Peer A"
+            )
+        }));
+    }
+
+    #[test]
+    fn joining_another_sub_room_preserves_active_share() {
+        let state = sub_room_test_state();
+        let _ = create_sub_room(&state, "voice-room").expect("create room-2");
+        let _ = create_sub_room(&state, "voice-room").expect("create room-3");
+        let _ = join_sub_room(&state, "voice-room", "room-2", "peer-a");
+        state
+            .with_room_write("voice-room", |members| {
+                members.info.active_shares.insert("peer-a".to_string());
+            })
+            .unwrap();
+
+        let result = join_sub_room(&state, "voice-room", "room-3", "peer-a").expect("move rooms");
+
+        let info = state.get_room_info("voice-room").expect("room exists");
+        assert!(info.active_shares.contains("peer-a"));
+        assert!(
+            !result
+                .signals
+                .iter()
+                .any(|signal| matches!(signal.msg, SignalingMessage::ShareStopped(_)))
+        );
     }
 
     fn arb_channel_role() -> impl Strategy<Value = ChannelRole> {


### PR DESCRIPTION
## Summary
- gate microphone publishing and share starts on joined sub-room membership
- stop active shares when a participant leaves their sub-room
- enforce server-side share start rejection for participants without sub-room assignments

## Tests
- cargo test --workspace
- cargo clippy --workspace -- -D warnings