### PR TITLE
Require room membership for voice sharing

### DIFF
--- a/clients/shared/src/livekit_connection.rs
+++ b/clients/shared/src/livekit_connection.rs
@@ -151,7 +151,7 @@ impl RealLiveKitConnection {
             connected: Arc::new(AtomicBool::new(false)),
             room: Arc::new(Mutex::new(None)),
             published_track: Arc::new(Mutex::new(None)),
-            mic_enabled: Arc::new(AtomicBool::new(true)),
+            mic_enabled: Arc::new(AtomicBool::new(false)),
             audio_cb: Arc::new(Mutex::new(None)),
             event_task: Arc::new(Mutex::new(None)),
             capture_task: Arc::new(Mutex::new(None)),

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -652,6 +652,8 @@ pub fn media_connect(
 
     match state.runtime.block_on(async { conn.connect(&url, &token) }) {
         Ok(()) => {
+            conn.set_mic_enabled(false)
+                .map_err(|err| format!("failed to disable mic before publish: {err}"))?;
             if let Err(err) = conn.publish_audio(&AudioTrack {
                 id: "native-mic".to_string(),
             }) {

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1404,7 +1404,13 @@ export default function ActiveRoom() {
   const sharers = roomState?.participants.filter((p) => p.isSharing) ?? [];
   const watchAllScope = getWatchAllScope(roomState);
   const shareEnabled = roomState
-    ? isShareEnabled(roomState.sharePermission, isHost, roomState.machineState, roomState.mediaState)
+    ? isShareEnabled(
+        roomState.sharePermission,
+        isHost,
+        roomState.machineState,
+        roomState.mediaState,
+        roomState.joinedSubRoomId,
+      )
     : false;
   const currentShareType = roomState
     ? activeShareType(roomState.activeVideoShare, roomState.activeAudioShare)
@@ -1460,6 +1466,7 @@ export default function ActiveRoom() {
 
   /** Open custom share picker or invoke getDisplayMedia fallback based on platform. */
   const handleStartShare = async () => {
+    if (!shareEnabled) return;
     if (shareEnumerating.current) return;
     shareEnumerating.current = true;
     if (!isLinuxPlatform) setSharePickerLoading(true);

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -787,9 +787,9 @@ async function driveToConnected(mod: LiveKitModule, url = 'wss://sfu.test', toke
 
 describe('LiveKitModule lifecycle', () => {
 
-  // Feature: gui-livekit-media, Property 4: Media connected requires Room connected AND mic published
-  describe('P4: Media connected requires Room connected AND mic published', () => {
-    it('onMediaConnected fires only after BOTH Connected and LocalTrackPublished', async () => {
+  // Feature: gui-livekit-media, Property 4: Media connects listen-only before mic publication
+  describe('P4: Media connects listen-only before mic publication', () => {
+    it('onMediaConnected fires after Room connected without requiring mic publication', async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.boolean(), // true = Connected first (normal), false = LocalTrackPublished first
@@ -808,13 +808,13 @@ describe('LiveKitModule lifecycle', () => {
               // Normal flow: Connected → setMicrophoneEnabled → LocalTrackPublished
               emitRoomEvent('connected');
               await tick(); // let setMicrophoneEnabled resolve
-              expect(countConnected()).toBe(0); // Connected alone is not enough
+              expect(countConnected()).toBe(1);
               emitRoomEvent('localTrackPublished', AUDIO_PUB, mockRoom.localParticipant);
               expect(countConnected()).toBe(1);
             } else {
               // Unusual: LocalTrackPublished arrives before Connected
               emitRoomEvent('localTrackPublished', AUDIO_PUB, mockRoom.localParticipant);
-              expect(countConnected()).toBe(0); // mic ready but not connected
+              expect(countConnected()).toBe(0);
               emitRoomEvent('connected');
               await tick(); // let setMicrophoneEnabled resolve
               // After Connected, lkConnected=true. micReady was already true.
@@ -837,20 +837,21 @@ describe('LiveKitModule lifecycle', () => {
     /**
      * Validates: Requirements 3.2, 4.1
      */
-    it('Connected event alone does NOT trigger onMediaConnected', async () => {
+    it('Connected event alone triggers listen-only onMediaConnected', async () => {
       const cbs = createMockCallbacks();
       const mod = new LiveKitModule(cbs);
       await mod.connect('wss://sfu.test', 'tok-alone');
       emitRoomEvent('connected');
       await tick();
-      expect(cbs.calls.filter(c => c.method === 'onMediaConnected')).toHaveLength(0);
+      expect(cbs.calls.filter(c => c.method === 'onMediaConnected')).toHaveLength(1);
+      expect(sdkCalls.filter(c => c.method === 'setMicrophoneEnabled')).toHaveLength(0);
       mod.disconnect();
     });
   });
 
-  // Feature: gui-livekit-media, Property 5: Mic permission denied results in listen-only mode
-  describe('P5: Mic permission denied results in listen-only mode', () => {
-    it('onMediaConnected fires in listen-only when mic is denied', async () => {
+  // Feature: gui-livekit-media, Property 5: Mic permission denied is handled when publishing is requested
+  describe('P5: Mic permission denied is handled when publishing is requested', () => {
+    it('connect stays listen-only and setMicEnabled reports mic denial', async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.string({ minLength: 1, maxLength: 50 }).filter(s => s.trim().length > 0),
@@ -867,7 +868,8 @@ describe('LiveKitModule lifecycle', () => {
 
             // Connected → setMicrophoneEnabled rejects → listen-only → checkReady
             emitRoomEvent('connected');
-            await tick(); // let the rejection propagate
+            await mod.setMicEnabled(true);
+            await tick();
 
             // onMediaConnected should fire (listen-only)
             expect(cbs.calls.filter(c => c.method === 'onMediaConnected')).toHaveLength(1);
@@ -5166,6 +5168,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const { pub, mediaStreamTrack, track } = createAudioPubWithMst();
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
     emitRoomEvent('localTrackPublished', pub, mockRoom.localParticipant);
     await tick();
@@ -5182,6 +5185,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const publishCall = sdkCalls.find(c => c.method === 'publishTrack');
@@ -5203,6 +5207,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const micCall = sdkCalls.find(c => c.method === 'setMicrophoneEnabled');
@@ -5221,6 +5226,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const micCall = sdkCalls.find(c => c.method === 'setMicrophoneEnabled');
@@ -5239,6 +5245,7 @@ describe('JS-side noise suppression (Windows/macOS)', () => {
     const mod = new LiveKitModule(createMockCallbacks());
     await mod.connect('wss://sfu.test', 'tok');
     emitRoomEvent('connected');
+    await mod.setMicEnabled(true);
     await tick();
 
     const micCall = sdkCalls.find(c => c.method === 'setMicrophoneEnabled');

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
@@ -221,6 +221,17 @@ async function driveToActive() {
   // Establish media so lkModule exists
   if (messageHandler) {
     messageHandler({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    messageHandler({
+      type: 'sub_room_state',
+      rooms: [
+        {
+          subRoomId: 'room-1',
+          roomNumber: 1,
+          isDefault: true,
+          participantIds: ['self-peer'],
+        },
+      ],
+    });
   }
   await tick();
 }

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -271,6 +271,16 @@ async function driveToActive(channelId = 'ch-1', channelName = 'test-room') {
   await tick();
 }
 
+async function assignSelfToSubRoom(subRoomId = 'room-1') {
+  messageHandler!({
+    type: 'sub_room_state',
+    rooms: [
+      { subRoomId, roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+    ],
+  });
+  await tick();
+}
+
 beforeEach(() => {
   resetAll();
 });
@@ -489,6 +499,142 @@ describe('VoiceRoom sub-room state', () => {
 });
 
 describe('VoiceRoom room-based effective volume isolation', () => {
+  it('disables local mic publishing and incoming audio when a snapshot moves self out of all rooms', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer', 'peer-2'] },
+      ],
+    });
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+    const volumeCallsBefore = lastLkModule!.setParticipantVolumeCalls.length;
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['peer-2'] },
+      ],
+    });
+    await tick();
+
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([false]);
+    expect(getState().joinedSubRoomId).toBeNull();
+    expect(getState().participants.find((p) => p.id === 'self-peer')).toMatchObject({
+      isMuted: true,
+      isSpeaking: false,
+      rmsLevel: 0,
+    });
+    expect(lastLkModule!.setParticipantVolumeCalls.slice(volumeCallsBefore)).toContainEqual({ id: 'peer-2', vol: 0 });
+  });
+
+  it('enables local mic publishing by default when a snapshot assigns self to a room', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+      ],
+    });
+    await tick();
+
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([true]);
+    expect(getState().joinedSubRoomId).toBe('room-1');
+    expect(getState().participants.find((p) => p.id === 'self-peer')?.isMuted).toBe(false);
+  });
+
+  it('does not reset mic publishing when self moves directly between rooms', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+        { subRoomId: 'room-2', roomNumber: 2, isDefault: false, participantIds: [] },
+      ],
+    });
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    messageHandler!({
+      type: 'sub_room_joined',
+      participantId: 'self-peer',
+      subRoomId: 'room-2',
+      source: 'explicit',
+    });
+    await tick();
+
+    expect(getState().joinedSubRoomId).toBe('room-2');
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([]);
+  });
+
+  it('disables local mic publishing when sub_room_left confirms self left the room', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+
+    messageHandler!({
+      type: 'sub_room_state',
+      rooms: [
+        { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] },
+      ],
+    });
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    messageHandler!({
+      type: 'sub_room_left',
+      participantId: 'self-peer',
+      subRoomId: 'room-1',
+    });
+    await tick();
+
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([false]);
+    expect(getState().joinedSubRoomId).toBeNull();
+    expect(getState().participants.find((p) => p.id === 'self-peer')?.isMuted).toBe(true);
+  });
+
+  it('keeps mic publishing disabled when mute is toggled outside a room', async () => {
+    await driveToActive('ch-subrooms', 'subroom-test');
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+    lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    lastLkModule!.setMicEnabledCalls = [];
+
+    toggleSelfMute();
+    await tick();
+    toggleSelfMute();
+    await tick();
+
+    expect(getState().joinedSubRoomId).toBeNull();
+    expect(getState().participants.find((p) => p.id === 'self-peer')?.isMuted).toBe(true);
+    expect(lastLkModule!.setMicEnabledCalls).toEqual([false, false]);
+  });
+
   it('mutes participants outside the local joined room while preserving manual volume', async () => {
     await driveToActive('ch-subrooms', 'subroom-test');
 
@@ -993,6 +1139,7 @@ describe('Voice-room media wiring', () => {
       // Send media_token so lkModule exists
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
+      await assignSelfToSubRoom();
 
       // Host-mute self
       messageHandler!({ type: 'participant_muted', participantId: 'self-peer' });
@@ -1067,7 +1214,7 @@ describe('Voice-room media wiring', () => {
       expect(self).toBeTruthy();
       expect(self!.isMuted).toBe(true);
       expect(lastLkModule!.setMicEnabledCalls[lastLkModule!.setMicEnabledCalls.length - 1]).toBe(false);
-      expect(latestState!.events.some((e) => e.message === 'you muted microphone')).toBe(true);
+      expect(latestState!.events.some((e) => e.message === 'mute toggle ignored: join a room before using the microphone')).toBe(true);
 
       leaveRoom();
     });
@@ -1450,6 +1597,7 @@ describe('Edge case unit tests', () => {
     it('screen picker cancelled does not send StartShare', async () => {
       resetAll();
       await driveToActive();
+      await assignSelfToSubRoom();
 
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
@@ -1469,9 +1617,91 @@ describe('Edge case unit tests', () => {
       leaveRoom();
     });
 
+    it('startFallbackShare rejects when self is not in a synchronized room', async () => {
+      resetAll();
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+
+      const { startFallbackShare } = await import('../voice-room');
+      await expect(startFallbackShare()).rejects.toThrow('Join a room before sharing.');
+      expect(lastLkModule!.startScreenShareCalls).toBe(0);
+      expect(sentMessages.filter(m => m.type === 'start_share')).toHaveLength(0);
+
+      leaveRoom();
+    });
+
+    it('leaving the current sub-room stops local fallback share and uses share_stopped echo for sound', async () => {
+      resetAll();
+      await driveToActive();
+      await assignSelfToSubRoom('room-1');
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      vi.mocked(lastLkModule!.startScreenShare).mockResolvedValue(true);
+
+      const { startFallbackShare } = await import('../voice-room');
+      await startFallbackShare();
+      messageHandler!({ type: 'share_started', participantId: 'self-peer', displayName: 'TestUser' });
+      await tick();
+      sentMessages.length = 0;
+      playNotificationSoundCalls = [];
+
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [
+          { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: [] },
+        ],
+      });
+      await tick();
+
+      expect(lastLkModule!.stopScreenShareCalls).toBe(1);
+      expect(sentMessages).toContainEqual({ type: 'stop_share' });
+      expect(playNotificationSoundCalls).not.toContain('share-stop');
+
+      messageHandler!({ type: 'share_stopped', participantId: 'self-peer', displayName: 'TestUser' });
+      await tick();
+      expect(playNotificationSoundCalls).toContain('share-stop');
+      lastLkModule!.callbacks.onLocalScreenShareEnded();
+
+      leaveRoom();
+    });
+
+    it('switching directly between sub-rooms does not stop local fallback share', async () => {
+      resetAll();
+      await driveToActive();
+      await assignSelfToSubRoom('room-1');
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      vi.mocked(lastLkModule!.startScreenShare).mockResolvedValue(true);
+
+      const { startFallbackShare } = await import('../voice-room');
+      await startFallbackShare();
+      messageHandler!({ type: 'share_started', participantId: 'self-peer', displayName: 'TestUser' });
+      await tick();
+      sentMessages.length = 0;
+
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [
+          { subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: [] },
+          { subRoomId: 'room-2', roomNumber: 2, isDefault: false, participantIds: ['self-peer'] },
+        ],
+      });
+      await tick();
+
+      expect(lastLkModule!.stopScreenShareCalls).toBe(0);
+      expect(sentMessages.filter(m => m.type === 'stop_share')).toHaveLength(0);
+
+      leaveRoom();
+    });
+
     it('external screen share end sends StopShare signaling', async () => {
       resetAll();
       await driveToActive();
+      await assignSelfToSubRoom();
 
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
@@ -1669,6 +1899,7 @@ describe('Feature: screen-share-quality, Property 11: Signaling message preserva
             });
           }
           await tick();
+          await assignSelfToSubRoom();
 
           // Establish media so lkModule exists
           messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
@@ -1718,6 +1949,7 @@ describe('VoiceRoom delegates startScreenShare to LiveKitModule', () => {
   it('startFallbackShare() calls startScreenShare on the LiveKitModule', async () => {
     resetAll();
     await driveToActive();
+    await assignSelfToSubRoom();
 
     // Establish media so lkModule exists
     messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-share-permission.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-share-permission.test.ts
@@ -3,32 +3,37 @@ import { isShareEnabled, shareButtonLabel } from '../voice-room';
 
 describe('isShareEnabled', () => {
   it('returns true for non-host when permission is anyone, room active, media connected', () => {
-    expect(isShareEnabled('anyone', false, 'active', 'connected')).toBe(true);
+    expect(isShareEnabled('anyone', false, 'active', 'connected', 'room-1')).toBe(true);
   });
 
   it('returns false for non-host when permission is host_only', () => {
-    expect(isShareEnabled('host_only', false, 'active', 'connected')).toBe(false);
+    expect(isShareEnabled('host_only', false, 'active', 'connected', 'room-1')).toBe(false);
   });
 
   it('returns true for host even when permission is host_only', () => {
-    expect(isShareEnabled('host_only', true, 'active', 'connected')).toBe(true);
+    expect(isShareEnabled('host_only', true, 'active', 'connected', 'room-1')).toBe(true);
+  });
+
+  it('returns false when the user has not joined a synchronized room', () => {
+    expect(isShareEnabled('anyone', false, 'active', 'connected', null)).toBe(false);
+    expect(isShareEnabled('host_only', true, 'active', 'connected', null)).toBe(false);
   });
 
   it('returns false when machineState is reconnecting, even with anyone permission', () => {
-    expect(isShareEnabled('anyone', false, 'reconnecting', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'reconnecting', 'connected', 'room-1')).toBe(false);
   });
 
   it('returns false when machineState is connecting', () => {
-    expect(isShareEnabled('anyone', false, 'connecting', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'connecting', 'connected', 'room-1')).toBe(false);
   });
 
   it('returns false when mediaState is not connected', () => {
-    expect(isShareEnabled('anyone', false, 'active', 'connecting')).toBe(false);
-    expect(isShareEnabled('anyone', false, 'active', 'disconnected')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'active', 'connecting', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', false, 'active', 'disconnected', 'room-1')).toBe(false);
   });
 
   it('returns false for host when machineState is not active', () => {
-    expect(isShareEnabled('anyone', true, 'reconnecting', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'reconnecting', 'connected', 'room-1')).toBe(false);
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
@@ -269,40 +269,40 @@ describe('Property 2: Share button enabled iff permission allows and media ready
   it('share enabled when permission is "anyone" regardless of host status (media ready)', () => {
     fc.assert(
       fc.property(fc.boolean(), (selfIsHost) => {
-        expect(isShareEnabled('anyone', selfIsHost, 'active', 'connected')).toBe(true);
+        expect(isShareEnabled('anyone', selfIsHost, 'active', 'connected', 'room-1')).toBe(true);
       }),
       { numRuns: 100 },
     );
   });
 
   it('share enabled when host_only AND selfIsHost is true (media ready)', () => {
-    expect(isShareEnabled('host_only', true, 'active', 'connected')).toBe(true);
+    expect(isShareEnabled('host_only', true, 'active', 'connected', 'room-1')).toBe(true);
   });
 
   it('share disabled when host_only AND selfIsHost is false (media ready)', () => {
-    expect(isShareEnabled('host_only', false, 'active', 'connected')).toBe(false);
+    expect(isShareEnabled('host_only', false, 'active', 'connected', 'room-1')).toBe(false);
   });
 
   it('share disabled when media is not connected, even with permission', () => {
-    expect(isShareEnabled('anyone', true, 'active', 'disconnected')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'active', 'connecting')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'active', 'failed')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'active', 'disconnected', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'active', 'connecting', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'active', 'failed', 'room-1')).toBe(false);
   });
 
   it('share disabled when machine is not active, even with permission', () => {
-    expect(isShareEnabled('anyone', true, 'idle', 'connected')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'connecting', 'connected')).toBe(false);
-    expect(isShareEnabled('anyone', true, 'joining', 'connected')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'idle', 'connected', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'connecting', 'connected', 'room-1')).toBe(false);
+    expect(isShareEnabled('anyone', true, 'joining', 'connected', 'room-1')).toBe(false);
   });
 
   it('for any permission and host status, enabled iff (anyone OR selfIsHost) AND active AND connected', () => {
     fc.assert(
       fc.property(arbSharePermission, fc.boolean(), (perm, selfIsHost) => {
         const expected = (perm === 'anyone' || selfIsHost);
-        expect(isShareEnabled(perm, selfIsHost, 'active', 'connected')).toBe(expected);
+        expect(isShareEnabled(perm, selfIsHost, 'active', 'connected', 'room-1')).toBe(expected);
         // Always false when media not ready, regardless of permission
-        expect(isShareEnabled(perm, selfIsHost, 'active', 'disconnected')).toBe(false);
-        expect(isShareEnabled(perm, selfIsHost, 'idle', 'connected')).toBe(false);
+        expect(isShareEnabled(perm, selfIsHost, 'active', 'disconnected', 'room-1')).toBe(false);
+        expect(isShareEnabled(perm, selfIsHost, 'idle', 'connected', 'room-1')).toBe(false);
       }),
       { numRuns: 100 },
     );

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -728,6 +728,10 @@ export class LiveKitModule {
   private localMicTrack: LocalAudioTrack | null = null;
   /** Whether the JS-side noise suppression processor should be active on this session's mic. */
   private jsDenoise = false;
+  /** Session preference used when voice-room later opts the microphone into publishing. */
+  private sessionDenoiseEnabled = false;
+  /** True when mic publishing should use the native Rust mic bridge for this session. */
+  private useNativeMicBridgeForMic = false;
   /** True only when the JS noise suppression processor is confirmed attached to the live mic track. */
   private jsDenoiseProcessorActive = false;
   /** Active native mic bridge instance (Windows + denoiseEnabled only). */
@@ -1590,12 +1594,14 @@ export class LiveKitModule {
     this.deviceChangeListener = null;
   }
 
-  /** Connect to LiveKit SFU. Creates Room, connects, publishes mic. */
+  /** Connect to LiveKit SFU. Creates Room in listen-only mode. */
   async connect(sfuUrl: string, token: string): Promise<void> {
     try {
       // 0. Read denoise preference for this session.
       const denoiseEnabled = await getDenoiseEnabled();
       const useNativeBridge = this.shouldUseNativeMicBridge(denoiseEnabled);
+      this.sessionDenoiseEnabled = denoiseEnabled;
+      this.useNativeMicBridgeForMic = useNativeBridge;
       this.jsDenoise = this.shouldUseJsNoiseSuppression(denoiseEnabled);
       this.setNoiseSuppressionActive(false);
       console.log(
@@ -1649,45 +1655,10 @@ export class LiveKitModule {
       addListener(RoomEvent.Connected, () => {
         if (this.disposed) return;
         lkConnected = true;
+        listenOnly = true;
         // Watch for OS device changes so the routing survives plug/unplug events.
-        // Output device routing itself is applied in checkReady() after getUserMedia.
         this.startDeviceChangeWatcher();
-        if (useNativeBridge) {
-          // Windows + denoiseEnabled: capture mic in Rust through DenoiseFilter,
-          // then publish the denoised MediaStreamTrack via LiveKit.
-          this.startNativeMicBridge(denoiseEnabled)
-            .catch((err: unknown) => {
-              // Bridge failed — fall back to browser mic without denoise.
-              console.warn(LOG, 'native mic bridge failed, falling back to browser mic:', err);
-              this.callbacks.onSystemEvent(
-                `native mic bridge failed — falling back to browser mic (no denoise)`,
-              );
-              return this.room?.localParticipant.setMicrophoneEnabled(true, {
-                noiseSuppression: false,
-              });
-            })
-            .catch((err: unknown) => {
-              listenOnly = true;
-              this.callbacks.onSystemEvent(
-                `mic failed: ${err instanceof Error ? err.message : String(err)} — listen-only mode`,
-              );
-              if (DEBUG_AUDIO_OUTPUT) console.log(LOG, '[audio-output] listen-only mode — applying output device (best-effort)');
-              this.applyAudioOutputDevice();
-              checkReady();
-            });
-        } else {
-          this.room!.localParticipant.setMicrophoneEnabled(true, {
-            noiseSuppression: false,
-          }).catch((err: unknown) => {
-            listenOnly = true;
-            this.callbacks.onSystemEvent(
-              `mic permission denied: ${err instanceof Error ? err.message : String(err)} — listen-only mode`,
-            );
-            if (DEBUG_AUDIO_OUTPUT) console.log(LOG, '[audio-output] listen-only mode — applying output device (best-effort)');
-            this.applyAudioOutputDevice();
-            checkReady();
-          });
-        }
+        checkReady();
       });
 
       // b. Disconnected
@@ -2290,7 +2261,28 @@ export class LiveKitModule {
       this.localMicTrack.mediaStreamTrack.enabled = enabled;
       return;
     }
-    await this.room.localParticipant.setMicrophoneEnabled(enabled);
+    if (enabled && this.useNativeMicBridgeForMic && !this.localMicTrack) {
+      try {
+        await this.startNativeMicBridge(this.sessionDenoiseEnabled);
+        return;
+      } catch (err) {
+        console.warn(LOG, 'native mic bridge failed, falling back to browser mic:', err);
+        this.callbacks.onSystemEvent(
+          `native mic bridge failed - falling back to browser mic (no denoise)`,
+        );
+      }
+    }
+    try {
+      await this.room.localParticipant.setMicrophoneEnabled(enabled, {
+        noiseSuppression: false,
+      });
+    } catch (err) {
+      if (enabled) {
+        this.callbacks.onSystemEvent(
+          `mic permission denied: ${err instanceof Error ? err.message : String(err)} - listen-only mode`,
+        );
+      }
+    }
   }
 
   /** Set per-participant volume (0–100 → perceptual gain curve). */
@@ -3979,7 +3971,7 @@ export class LiveKitModule {
     const analyser = ctx.createAnalyser();
     analyser.fftSize = 2048;
     const gain = ctx.createGain();
-    const desiredVol = this.desiredParticipantVolumes.get(identity) ?? 70;
+    const desiredVol = this.desiredParticipantVolumes.get(identity) ?? 0;
     gain.gain.setValueAtTime(perceptualGain(desiredVol), ctx.currentTime);
     source.connect(analyser);
     analyser.connect(gain);

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -329,11 +329,22 @@ export function computeSpeaking(
 
 /**
  * Pure function: determine if screen sharing is enabled for the current user.
- * Requires all three conditions: permission allows it (anyone OR host),
- * room is active, and LiveKit media connection is established.
+ * Requires all four conditions: permission allows it (anyone OR host),
+ * room is active, media is connected, and the user is in a synchronized room.
  */
-export function isShareEnabled(sharePermission: 'anyone' | 'host_only', selfIsHost: boolean, machineState: VoiceRoomMachineState, mediaState: MediaState): boolean {
-  return (sharePermission === 'anyone' || selfIsHost) && machineState === 'active' && mediaState === 'connected'
+export function isShareEnabled(
+  sharePermission: 'anyone' | 'host_only',
+  selfIsHost: boolean,
+  machineState: VoiceRoomMachineState,
+  mediaState: MediaState,
+  joinedSubRoomId: string | null,
+): boolean {
+  return (
+    joinedSubRoomId !== null
+    && (sharePermission === 'anyone' || selfIsHost)
+    && machineState === 'active'
+    && mediaState === 'connected'
+  );
 }
 
 /**
@@ -421,6 +432,54 @@ function applyEffectiveParticipantVolumes(): void {
   for (const participant of state.participants) {
     applyEffectiveParticipantVolume(participant);
   }
+}
+
+function selfParticipant(): RoomParticipant | undefined {
+  return state.participants.find((p) => p.id === state.selfParticipantId);
+}
+
+function silenceSelfParticipant(self: RoomParticipant): void {
+  self.isMuted = true;
+  self.isSpeaking = false;
+  self.rmsLevel = 0;
+}
+
+function setLocalMicPublishing(enabled: boolean): void {
+  lkModule?.setMicEnabled(enabled);
+}
+
+function shouldPublishLocalMic(self: RoomParticipant | undefined): boolean {
+  return (
+    state.joinedSubRoomId !== null
+    && self !== undefined
+    && !self.isMuted
+    && !self.isHostMuted
+    && !state.isDeafened
+  );
+}
+
+function reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId: string | null): void {
+  const currentJoinedSubRoomId = state.joinedSubRoomId;
+  const self = selfParticipant();
+
+  if (currentJoinedSubRoomId === null) {
+    if (self) {
+      silenceSelfParticipant(self);
+    }
+    setLocalMicPublishing(false);
+    return;
+  }
+
+  if (previousJoinedSubRoomId !== null) return;
+  if (!self || self.isHostMuted || state.isDeafened) {
+    setLocalMicPublishing(false);
+    return;
+  }
+
+  self.isMuted = false;
+  self.isSpeaking = false;
+  self.rmsLevel = 0;
+  setLocalMicPublishing(true);
 }
 
 /**
@@ -692,6 +751,7 @@ export function computeLeaveShareCleanup(
  * a helpful OS-level message. The only other throw here is when lkModule is null.
  */
 export async function startFallbackShare(): Promise<{ started: boolean; withAudio: boolean }> {
+  ensureInSubRoomForShare();
   console.log(LOG, `startFallbackShare: lkModule=${lkModule ? lkModule.constructor.name : 'null'}, mediaState=${state.mediaState}, machineState=${state.machineState}`);
   if (!lkModule) {
     throw new Error(`Screen sharing is not available (media module not initialized, mediaState=${state.mediaState})`);
@@ -939,6 +999,10 @@ function setupExternalShareHelperListeners(): void {
   if (unlistenExternalShareStarted || unlistenExternalShareStopped || unlistenExternalShareError) return;
 
   listen<{ sessionId: string }>('external-share-started', () => {
+    if (state.joinedSubRoomId === null) {
+      invoke('external_share_stop').catch(() => { });
+      return;
+    }
     externalShareHelperActive = true;
     localStopShareSent = false;
     const self = state.participants.find((p) => p.id === state.selfParticipantId);
@@ -1048,6 +1112,28 @@ function syncDerivedSubRoomState(): void {
     return;
   }
   state.joinedSubRoomId = state.participantSubRoomById[state.selfParticipantId] ?? null;
+}
+
+function ensureInSubRoomForShare(): void {
+  if (state.joinedSubRoomId !== null) return;
+  throw new Error('Join a room before sharing.');
+}
+
+function stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId: string | null): void {
+  if (!previousJoinedSubRoomId || state.joinedSubRoomId !== null) return;
+  const self = state.participants.find((p) => p.id === state.selfParticipantId);
+  const hasCustomShare = state.activeVideoShare !== null || state.activeAudioShare !== null;
+  const hasFallbackShare =
+    self?.isSharing === true
+    || externalShareHelperActive
+    || state.shareQualityInfo !== null
+    || state.shareStats !== null;
+
+  if (hasCustomShare) {
+    void stopCustomShare('all');
+  } else if (hasFallbackShare) {
+    void stopShare();
+  }
 }
 
 function syncDesiredSubRoomPreference(): void {
@@ -1232,10 +1318,8 @@ function connectMedia(sfuUrl: string, token: string): void {
       stopPeriodicMediaRetry();
       // Re-apply mute state after media reconnection — if the user was muted,
       // ensure the mic stays muted (LiveKit enables mic by default on connect).
-      const self = state.participants.find((p) => p.id === state.selfParticipantId);
-      if (self && self.isMuted && lkModule) {
-        lkModule.setMicEnabled(false);
-      }
+      const self = selfParticipant();
+      setLocalMicPublishing(shouldPublishLocalMic(self));
       // Apply persisted master volume to the media layer
       if (lkModule) {
         lkModule.setMasterVolume(state.masterVolume);
@@ -1340,6 +1424,12 @@ function connectMedia(sfuUrl: string, token: string): void {
       if (!p) return;
 
       if (identity === state.selfParticipantId) {
+        if (!isMuted && state.joinedSubRoomId === null) {
+          silenceSelfParticipant(p);
+          lkModule?.setMicEnabled(false);
+          notify();
+          return;
+        }
         // Local participant mute state changed externally (e.g. LiveKit reconnect,
         // OS-level mute). Sync UI state to match actual mic state.
         if (p.isMuted !== isMuted) {
@@ -1650,6 +1740,7 @@ function dispatchMessage(raw: unknown): void {
             : room
         ));
         syncDerivedSubRoomState();
+        reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
         playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
         applyEffectiveParticipantVolumes();
       }
@@ -1691,6 +1782,8 @@ function dispatchMessage(raw: unknown): void {
           }
         : null;
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
@@ -1736,6 +1829,8 @@ function dispatchMessage(raw: unknown): void {
           : room;
       });
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       void source;
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
@@ -1755,6 +1850,8 @@ function dispatchMessage(raw: unknown): void {
           : room
       ));
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
@@ -1763,9 +1860,12 @@ function dispatchMessage(raw: unknown): void {
     }
 
     case 'sub_room_deleted': {
+      const previousJoinedSubRoomId = state.joinedSubRoomId;
       const subRoomId = msg.subRoomId as string;
       state.subRooms = state.subRooms.filter((room) => room.id !== subRoomId);
       syncDerivedSubRoomState();
+      stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       if (desiredSubRoomIntent === subRoomId) {
         desiredSubRoomIntent = undefined;
       }
@@ -2576,6 +2676,19 @@ export function toggleSelfMute(): void {
     notify();
     return;
   }
+  if (state.joinedSubRoomId === null) {
+    silenceSelfParticipant(self);
+    lkModule?.setMicEnabled(false);
+    appendEvent({
+      id: makeEventId(),
+      timestamp: timestamp(),
+      type: 'system',
+      message: 'mute toggle ignored: join a room before using the microphone',
+      participantId: self.id,
+    });
+    notify();
+    return;
+  }
 
   // If deafened and trying to unmute, cancel deafen entirely
   if (state.isDeafened && self.isMuted) {
@@ -2612,9 +2725,12 @@ export function toggleSelfDeafen(): void {
     preDeafenVolume = null;
     state.masterVolume = restored;
     lkModule?.setMasterVolume(restored);
-    if (!self.isHostMuted) {
+    if (!self.isHostMuted && state.joinedSubRoomId !== null) {
       self.isMuted = false;
       lkModule?.setMicEnabled(true);
+    } else {
+      silenceSelfParticipant(self);
+      lkModule?.setMicEnabled(false);
     }
     client?.send({ type: 'self_undeafen' });
     appendEvent({
@@ -2658,6 +2774,7 @@ export function toggleSelfDeafen(): void {
 // post-share audio prompt) or startCustomShare() instead.
 
 export async function startExternalBrowserShare(): Promise<void> {
+  ensureInSubRoomForShare();
   await invoke('external_share_start');
 }
 
@@ -2668,6 +2785,7 @@ export async function startExternalBrowserShare(): Promise<void> {
  * This is the primary path for Wayland compositors (Hyprland, GNOME, KDE).
  */
 export async function startPortalShare(): Promise<boolean> {
+  ensureInSubRoomForShare();
   const result = await invoke<boolean>('screen_share_start');
   if (result) {
     // Mark self as sharing and notify peers (same as other share paths).
@@ -2700,6 +2818,7 @@ export async function startPortalShare(): Promise<boolean> {
  * rollback on partial failure, sends signaling, and opens the indicator.
  */
 export async function startCustomShare(selection: ShareSelection): Promise<void> {
+  ensureInSubRoomForShare();
   // 1. Check if the requested slot is available
   const check = canStartShare(selection, state.activeVideoShare, state.activeAudioShare);
   if (!check.allowed) {

--- a/infrastructure/environments/dev-ecs/cloudfront.tf
+++ b/infrastructure/environments/dev-ecs/cloudfront.tf
@@ -35,7 +35,7 @@ resource "aws_cloudfront_distribution" "backend" {
 
     custom_header {
       name  = "X-Origin-Verify"
-      value = data.aws_ssm_parameter.secrets["CF_ORIGIN_SECRET"].value
+      value = aws_ssm_parameter.secrets["CF_ORIGIN_SECRET"].value
     }
   }
 
@@ -54,7 +54,7 @@ resource "aws_cloudfront_distribution" "backend" {
 
     custom_header {
       name  = "X-Origin-Verify"
-      value = data.aws_ssm_parameter.secrets["CF_ORIGIN_SECRET"].value
+      value = aws_ssm_parameter.secrets["CF_ORIGIN_SECRET"].value
     }
   }
 

--- a/infrastructure/environments/dev-ecs/deploy-pipeline-iam.tf
+++ b/infrastructure/environments/dev-ecs/deploy-pipeline-iam.tf
@@ -18,7 +18,7 @@ resource "aws_iam_role" "github_livekit_deploy" {
           "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
         }
         StringLike = {
-          "token.actions.githubusercontent.com:sub" = "repo:example/wavis:*"
+          "token.actions.githubusercontent.com:sub" = "repo:Davalf99/wavis:*"
         }
       }
     }]
@@ -69,7 +69,7 @@ resource "aws_iam_role" "github_backend_deploy" {
           "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
         }
         StringLike = {
-          "token.actions.githubusercontent.com:sub" = "repo:example/wavis:*"
+          "token.actions.githubusercontent.com:sub" = "repo:TommasoRibaudo/wavis-public:*"
         }
       }
     }]

--- a/infrastructure/environments/dev-ecs/ecs_backend.tf
+++ b/infrastructure/environments/dev-ecs/ecs_backend.tf
@@ -158,7 +158,7 @@ resource "aws_ecs_task_definition" "backend" {
         ]
       )
       secrets = [
-        for key, parameter in data.aws_ssm_parameter.secrets : {
+        for key, parameter in aws_ssm_parameter.secrets : {
           name      = key
           valueFrom = parameter.arn
         }

--- a/infrastructure/environments/dev-ecs/main.tf
+++ b/infrastructure/environments/dev-ecs/main.tf
@@ -46,7 +46,7 @@ locals {
     SFU_JWT_ISSUER                    = "wavis-backend"
     SFU_TOKEN_TTL_SECS                = "600"
     REFRESH_TOKEN_TTL_DAYS            = "180"
-    GITHUB_BUG_REPORT_REPO            = "example/wavis"
+    GITHUB_BUG_REPORT_REPO            = "Davalf99/wavis"
     BUG_REPORT_RATE_LIMIT_MAX         = "5"
     BUG_REPORT_RATE_LIMIT_WINDOW_SECS = "3600"
     BUG_REPORT_LLM_MODEL              = "claude-sonnet-4-20250514"

--- a/infrastructure/environments/dev-ecs/migrate-ssm-ownership.ps1
+++ b/infrastructure/environments/dev-ecs/migrate-ssm-ownership.ps1
@@ -1,0 +1,149 @@
+# migrate-ssm-ownership.ps1
+#
+# Transfers SSM parameter ownership from the legacy dev/ (EC2) Terraform
+# environment to dev-ecs/. Run this ONCE before destroying the dev/ environment.
+#
+# Usage:
+#   cd infrastructure\environments\dev-ecs
+#   .\migrate-ssm-ownership.ps1
+
+$ErrorActionPreference = "Continue"
+
+Write-Host "=== SSM Ownership Migration: dev -> dev-ecs ===" -ForegroundColor Cyan
+Write-Host ""
+
+# Step 1: Import SSM secrets into dev-ecs state
+Write-Host "-- Step 1: Importing SSM secrets into dev-ecs state --" -ForegroundColor Yellow
+
+$secrets = @(
+    "AUTH_JWT_SECRET"
+    "AUTH_REFRESH_PEPPER"
+    "PHRASE_ENCRYPTION_KEY"
+    "PAIRING_CODE_PEPPER"
+    "SFU_JWT_SECRET"
+    "LIVEKIT_API_KEY"
+    "LIVEKIT_API_SECRET"
+    "RDS_MASTER_PASSWORD"
+    "CF_ORIGIN_SECRET"
+    "GITHUB_BUG_REPORT_TOKEN"
+    "GITHUB_DEPLOY_KEY"
+    "BUG_REPORT_LLM_API_KEY"
+)
+
+foreach ($key in $secrets) {
+    Write-Host "  Importing aws_ssm_parameter.secrets[$key]..."
+    terraform import "aws_ssm_parameter.secrets[\`"$key\`"]" "/wavis/dev/$key" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  Warning: import failed or already in state, continuing" -ForegroundColor DarkYellow
+    }
+}
+
+# Step 2: Import SSM existing_config into dev-ecs state
+Write-Host ""
+Write-Host "-- Step 2: Importing SSM existing_config into dev-ecs state --" -ForegroundColor Yellow
+
+$existingConfig = @(
+    "REQUIRE_TLS"
+    "TRUST_PROXY_HEADERS"
+    "RUST_LOG"
+    "POSTGRES_USER"
+    "POSTGRES_DB"
+    "GITHUB_BUG_REPORT_REPO"
+    "BUG_REPORT_RATE_LIMIT_MAX"
+    "BUG_REPORT_RATE_LIMIT_WINDOW_SECS"
+    "BUG_REPORT_LLM_MODEL"
+    "LIVEKIT_HOST"
+    "LIVEKIT_PUBLIC_HOST"
+)
+
+foreach ($key in $existingConfig) {
+    Write-Host "  Importing aws_ssm_parameter.existing_config[$key]..."
+    terraform import "aws_ssm_parameter.existing_config[\`"$key\`"]" "/wavis/dev/$key" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  Warning: import failed or already in state, continuing" -ForegroundColor DarkYellow
+    }
+}
+
+# Step 3: Remove SSM parameters from dev state
+Write-Host ""
+Write-Host "-- Step 3: Removing SSM parameters from dev state --" -ForegroundColor Yellow
+
+$devSecrets = @(
+    "AUTH_JWT_SECRET"
+    "AUTH_REFRESH_PEPPER"
+    "PHRASE_ENCRYPTION_KEY"
+    "PAIRING_CODE_PEPPER"
+    "SFU_JWT_SECRET"
+    "LIVEKIT_API_KEY"
+    "LIVEKIT_API_SECRET"
+    "DATABASE_URL"
+    "POSTGRES_PASSWORD"
+    "CF_ORIGIN_SECRET"
+    "GITHUB_DEPLOY_KEY"
+    "GITHUB_BUG_REPORT_TOKEN"
+)
+
+foreach ($key in $devSecrets) {
+    Write-Host "  Removing aws_ssm_parameter.secrets[$key] from dev state..."
+    terraform -chdir="..\dev" state rm "aws_ssm_parameter.secrets[\`"$key\`"]" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  Warning: not in state, skipping" -ForegroundColor DarkYellow
+    }
+}
+
+$devConfig = @(
+    "LIVEKIT_HOST"
+    "LIVEKIT_PUBLIC_HOST"
+    "REQUIRE_TLS"
+    "TRUST_PROXY_HEADERS"
+    "POSTGRES_USER"
+    "POSTGRES_DB"
+    "RUST_LOG"
+    "GITHUB_BUG_REPORT_REPO"
+    "BUG_REPORT_RATE_LIMIT_MAX"
+    "BUG_REPORT_RATE_LIMIT_WINDOW_SECS"
+)
+
+foreach ($key in $devConfig) {
+    Write-Host "  Removing aws_ssm_parameter.config[$key] from dev state..."
+    terraform -chdir="..\dev" state rm "aws_ssm_parameter.config[\`"$key\`"]" 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  Warning: not in state, skipping" -ForegroundColor DarkYellow
+    }
+}
+
+# Step 4: Remove shared LiveKit resources from dev state
+Write-Host ""
+Write-Host "-- Step 4: Removing shared LiveKit resources from dev state --" -ForegroundColor Yellow
+
+$livekitResources = @(
+    "aws_instance.livekit[0]"
+    "aws_security_group.livekit[0]"
+    "aws_iam_role.livekit[0]"
+    "aws_iam_instance_profile.livekit[0]"
+    "aws_iam_role_policy.livekit_ssm_session_manager[0]"
+    "aws_iam_role_policy.livekit_ssm_read[0]"
+    "aws_vpc_security_group_ingress_rule.livekit_http[0]"
+    "aws_vpc_security_group_ingress_rule.livekit_ice_tcp[0]"
+    "aws_vpc_security_group_ingress_rule.livekit_ice_media_udp[0]"
+    "aws_vpc_security_group_ingress_rule.livekit_from_backend[0]"
+    "aws_vpc_security_group_egress_rule.livekit_all_out[0]"
+)
+
+foreach ($res in $livekitResources) {
+    Write-Host "  Removing $res from dev state..."
+    terraform -chdir="..\dev" state rm $res 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "  Warning: not in state, skipping" -ForegroundColor DarkYellow
+    }
+}
+
+Write-Host ""
+Write-Host "=== Migration complete ===" -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  1. terraform plan              # in dev-ecs - verify no destructive changes"
+Write-Host "  2. cd ..\dev; terraform init -reconfigure; terraform plan"
+Write-Host "     # should show only destroy of EC2 + CloudFront + SGs"
+Write-Host "  3. Remove prevent_destroy from dev\ec2.tf and dev\cloudfront.tf"
+Write-Host "     Then: terraform destroy"

--- a/infrastructure/environments/dev-ecs/migrate-ssm-ownership.sh
+++ b/infrastructure/environments/dev-ecs/migrate-ssm-ownership.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# migrate-ssm-ownership.sh
+#
+# Transfers SSM parameter ownership from the legacy dev/ (EC2) Terraform
+# environment to dev-ecs/. Run this ONCE before destroying the dev/ environment.
+#
+# Steps:
+#   1. Import existing SSM parameters into dev-ecs state
+#   2. Remove SSM parameters from dev state (so destroy won't delete them)
+#   3. Remove the LiveKit instance from dev state (shared with dev-ecs)
+#   4. Remove prevent_destroy resources from dev state
+#
+# Prerequisites:
+#   - AWS credentials configured
+#   - Terraform initialized in both environments
+#
+# Usage:
+#   cd infrastructure/environments/dev-ecs
+#   bash migrate-ssm-ownership.sh
+
+set -euo pipefail
+
+SSM_PREFIX="/wavis/dev"
+DEV_DIR="../dev"
+ECS_DIR="."
+REGION="us-east-2"
+
+echo "=== SSM Ownership Migration: dev → dev-ecs ==="
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 1: Import SSM secrets into dev-ecs state
+# ─────────────────────────────────────────────────────────────────────
+echo "── Step 1: Importing SSM secrets into dev-ecs state ──"
+
+SECRETS=(
+  AUTH_JWT_SECRET
+  AUTH_REFRESH_PEPPER
+  PHRASE_ENCRYPTION_KEY
+  PAIRING_CODE_PEPPER
+  SFU_JWT_SECRET
+  LIVEKIT_API_KEY
+  LIVEKIT_API_SECRET
+  RDS_MASTER_PASSWORD
+  CF_ORIGIN_SECRET
+  GITHUB_BUG_REPORT_TOKEN
+  GITHUB_DEPLOY_KEY
+  BUG_REPORT_LLM_API_KEY
+)
+
+for key in "${SECRETS[@]}"; do
+  echo "  Importing aws_ssm_parameter.secrets[\"${key}\"]..."
+  terraform -chdir="$ECS_DIR" import \
+    "aws_ssm_parameter.secrets[\"${key}\"]" \
+    "${SSM_PREFIX}/${key}" || echo "  ⚠ Already in state or not found, skipping"
+done
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 2: Import SSM existing_config into dev-ecs state
+# ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "── Step 2: Importing SSM existing_config into dev-ecs state ──"
+
+# These are the config keys NOT in managed_config_keys (i.e. existing_config)
+EXISTING_CONFIG_KEYS=(
+  REQUIRE_TLS
+  TRUST_PROXY_HEADERS
+  RUST_LOG
+  POSTGRES_USER
+  POSTGRES_DB
+  GITHUB_BUG_REPORT_REPO
+  BUG_REPORT_RATE_LIMIT_MAX
+  BUG_REPORT_RATE_LIMIT_WINDOW_SECS
+  BUG_REPORT_LLM_MODEL
+  LIVEKIT_HOST
+  LIVEKIT_PUBLIC_HOST
+)
+
+for key in "${EXISTING_CONFIG_KEYS[@]}"; do
+  echo "  Importing aws_ssm_parameter.existing_config[\"${key}\"]..."
+  terraform -chdir="$ECS_DIR" import \
+    "aws_ssm_parameter.existing_config[\"${key}\"]" \
+    "${SSM_PREFIX}/${key}" || echo "  ⚠ Already in state or not found, skipping"
+done
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 3: Remove SSM parameters from dev state
+# ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "── Step 3: Removing SSM parameters from dev state ──"
+
+# Remove all secret SSM params from dev state
+DEV_SECRETS=(
+  AUTH_JWT_SECRET
+  AUTH_REFRESH_PEPPER
+  PHRASE_ENCRYPTION_KEY
+  PAIRING_CODE_PEPPER
+  SFU_JWT_SECRET
+  LIVEKIT_API_KEY
+  LIVEKIT_API_SECRET
+  DATABASE_URL
+  POSTGRES_PASSWORD
+  CF_ORIGIN_SECRET
+  GITHUB_DEPLOY_KEY
+  GITHUB_BUG_REPORT_TOKEN
+)
+
+for key in "${DEV_SECRETS[@]}"; do
+  echo "  Removing aws_ssm_parameter.secrets[\"${key}\"] from dev state..."
+  terraform -chdir="$DEV_DIR" state rm \
+    "aws_ssm_parameter.secrets[\"${key}\"]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+done
+
+# Remove all config SSM params from dev state
+DEV_CONFIG_KEYS=(
+  LIVEKIT_HOST
+  LIVEKIT_PUBLIC_HOST
+  REQUIRE_TLS
+  TRUST_PROXY_HEADERS
+  POSTGRES_USER
+  POSTGRES_DB
+  RUST_LOG
+  GITHUB_BUG_REPORT_REPO
+  BUG_REPORT_RATE_LIMIT_MAX
+  BUG_REPORT_RATE_LIMIT_WINDOW_SECS
+)
+
+for key in "${DEV_CONFIG_KEYS[@]}"; do
+  echo "  Removing aws_ssm_parameter.config[\"${key}\"] from dev state..."
+  terraform -chdir="$DEV_DIR" state rm \
+    "aws_ssm_parameter.config[\"${key}\"]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+done
+
+# ─────────────────────────────────────────────────────────────────────
+# Step 4: Remove shared LiveKit instance from dev state (if present)
+# ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "── Step 4: Removing shared LiveKit resources from dev state ──"
+
+# The LiveKit instance may be managed by dev/ with livekit_deployment_mode=separate.
+# dev-ecs references it via existing_livekit_instance_id. Remove from dev state
+# so destroy won't terminate it.
+echo "  Removing aws_instance.livekit[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_instance.livekit[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+echo "  Removing aws_security_group.livekit[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_security_group.livekit[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+echo "  Removing aws_iam_role.livekit[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_iam_role.livekit[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+echo "  Removing aws_iam_instance_profile.livekit[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_iam_instance_profile.livekit[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+echo "  Removing aws_iam_role_policy.livekit_ssm_session_manager[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_iam_role_policy.livekit_ssm_session_manager[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+echo "  Removing aws_iam_role_policy.livekit_ssm_read[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_iam_role_policy.livekit_ssm_read[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+# LiveKit security group ingress/egress rules
+for rule in livekit_http livekit_ice_tcp livekit_ice_media_udp livekit_from_backend; do
+  echo "  Removing aws_vpc_security_group_ingress_rule.${rule}[0] from dev state..."
+  terraform -chdir="$DEV_DIR" state rm \
+    "aws_vpc_security_group_ingress_rule.${rule}[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+done
+
+echo "  Removing aws_vpc_security_group_egress_rule.livekit_all_out[0] from dev state..."
+terraform -chdir="$DEV_DIR" state rm \
+  "aws_vpc_security_group_egress_rule.livekit_all_out[0]" 2>/dev/null || echo "  ⚠ Not in state, skipping"
+
+echo ""
+echo "=== Migration complete ==="
+echo ""
+echo "Next steps:"
+echo "  1. cd infrastructure/environments/dev-ecs"
+echo "     terraform plan    # Verify no destructive changes"
+echo ""
+echo "  2. cd infrastructure/environments/dev"
+echo "     terraform plan    # Should show only destroy of EC2 + CloudFront + SGs"
+echo ""
+echo "  3. Remove prevent_destroy from dev/ec2.tf and dev/cloudfront.tf"
+echo "     Then: terraform destroy"

--- a/infrastructure/environments/dev-ecs/rds.tf
+++ b/infrastructure/environments/dev-ecs/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "postgres" {
   storage_encrypted         = true
   db_name                   = var.rds_db_name
   username                  = var.rds_master_username
-  password                  = data.aws_ssm_parameter.secrets["RDS_MASTER_PASSWORD"].value
+  password                  = aws_ssm_parameter.secrets["RDS_MASTER_PASSWORD"].value
   port                      = 5432
   multi_az                  = var.rds_multi_az
   publicly_accessible       = false

--- a/infrastructure/environments/dev-ecs/ssm.tf
+++ b/infrastructure/environments/dev-ecs/ssm.tf
@@ -1,14 +1,43 @@
-data "aws_ssm_parameter" "secrets" {
+# ---------- SSM Parameter Store ----------
+#
+# Secrets and config parameters under /wavis/dev/.
+# These were originally created by the legacy dev/ (EC2) Terraform environment
+# and read here as data sources. They are now owned by dev-ecs as resources
+# so the legacy environment can be safely destroyed.
+#
+# IMPORTANT: All secret resources use `ignore_changes = [value]` so Terraform
+# will not overwrite the real values in AWS with the placeholder defaults below.
+# The placeholder values are only used if the parameter doesn't exist yet.
+#
+# Migration: after applying this change, run the import commands in
+# infrastructure/environments/dev-ecs/migrate-ssm-ownership.sh
+
+resource "aws_ssm_parameter" "secrets" {
   for_each = local.secrets
 
-  name            = "${local.ssm_prefix}/${each.key}"
-  with_decryption = true
+  name  = "${local.ssm_prefix}/${each.key}"
+  type  = "SecureString"
+  value = each.value
+  tags  = local.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
-data "aws_ssm_parameter" "existing_config" {
+# Config parameters that were previously read-only data sources.
+# Now managed as resources so dev-ecs fully owns the SSM namespace.
+resource "aws_ssm_parameter" "existing_config" {
   for_each = local.existing_config
 
-  name = "${local.ssm_prefix}/${each.key}"
+  name  = "${local.ssm_prefix}/${each.key}"
+  type  = "String"
+  value = each.value
+  tags  = local.tags
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "config" {

--- a/infrastructure/environments/dev/cloudfront.tf
+++ b/infrastructure/environments/dev/cloudfront.tf
@@ -190,7 +190,7 @@ resource "aws_cloudfront_distribution" "wavis" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    # prevent_destroy removed for teardown
     ignore_changes  = [origin]
   }
 }

--- a/infrastructure/environments/dev/ec2.tf
+++ b/infrastructure/environments/dev/ec2.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "wavis" {
   })
 
   lifecycle {
-    prevent_destroy = true
+    # prevent_destroy removed for teardown
 
     # Don't replace the instance if AMI or user_data changes —
     # we handle OS updates in-place via SSH/SSM.

--- a/tools/smoke/smoke.py
+++ b/tools/smoke/smoke.py
@@ -211,10 +211,15 @@ async def livekit_connect_probe(sfu_url: str, token: str, expected_room_id: str)
 
 
 async def run_smoke():
+    sfu_available = True
+
     try:
         r = httpx.get(f"{BACKEND_URL}/health", timeout=TIMEOUT)
         assert r.status_code == 200, f"HTTP {r.status_code}"
+        sfu_available = r.json().get("sfu", {}).get("available", True)
         ok("1_https_health")
+        if not sfu_available:
+            warn("1_https_health_sfu", f"SFU unavailable per /health: {r.json().get('sfu', {}).get('reason', 'unknown')} — voice tests will be warnings")
     except Exception as e:
         fail("1_https_health", str(e))
         return
@@ -416,7 +421,20 @@ async def run_smoke():
     member_media_token = None
     cleanup_leave_sent = False
 
-    if access_token and second_access_token and channel_id:
+    VOICE_TESTS = [
+        "15_owner_join_voice", "16_member_join_voice", "17_participant_joined",
+        "18_voice_status_active", "19_channel_token_structure", "21_leave_disconnect",
+    ]
+
+    if not (access_token and second_access_token and channel_id):
+        for name in VOICE_TESTS:
+            fail(name, "skipped - missing channel voice prerequisites")
+        warn("20_livekit_connect", "skipped - missing channel voice prerequisites")
+    elif not sfu_available:
+        for name in VOICE_TESTS:
+            warn(name, "SFU unavailable - skipped")
+        warn("20_livekit_connect", "SFU unavailable - skipped")
+    else:
         try:
             async with (
                 websockets.connect(WS_URL, open_timeout=TIMEOUT) as ws1,
@@ -582,16 +600,10 @@ async def run_smoke():
             fail("19_channel_token_structure", f"websocket setup failed: {reason}")
             fail("21_leave_disconnect", f"websocket setup failed: {reason}")
             warn("20_livekit_connect", f"skipped - websocket setup failed before LiveKit probe: {reason}")
-    else:
-        fail("15_owner_join_voice", "skipped - missing channel voice prerequisites")
-        fail("16_member_join_voice", "skipped - missing channel voice prerequisites")
-        fail("17_participant_joined", "skipped - missing channel voice prerequisites")
-        fail("18_voice_status_active", "skipped - missing channel voice prerequisites")
-        fail("19_channel_token_structure", "skipped - missing channel voice prerequisites")
-        fail("21_leave_disconnect", "skipped - missing channel voice prerequisites")
-        warn("20_livekit_connect", "skipped - missing channel voice prerequisites")
 
-    if access_token and channel_id and cleanup_leave_sent:
+    if not sfu_available:
+        warn("22_voice_status_inactive", "SFU unavailable - skipped")
+    elif access_token and channel_id and cleanup_leave_sent:
         try:
             await asyncio.sleep(0.2)
             r = httpx.get(
@@ -616,7 +628,7 @@ async def run_smoke():
     else:
         fail("22_voice_status_inactive", "skipped - leave/disconnect cleanup preconditions failed")
 
-    # Tests 23-26: isolated ban-eject scenario using fresh WS connections.
+    # Tests 23–26: isolated ban-eject scenario using fresh WS connections.
     ban_channel_id = None
     ban_invite_code = None
 
@@ -662,7 +674,11 @@ async def run_smoke():
     else:
         fail("23_ban_eject_setup", "skipped - missing owner access token")
 
-    if access_token and second_access_token and second_user_id and ban_channel_id:
+    if access_token and second_access_token and second_user_id and ban_channel_id and not sfu_available:
+        warn("24_ban_eject_join_voice", "SFU unavailable - skipped")
+        warn("25_ban_eject", "SFU unavailable - skipped")
+        warn("26_banned_rejoin_rejected", "SFU unavailable - skipped")
+    elif access_token and second_access_token and second_user_id and ban_channel_id:
         ban_owner_joined = None
         ban_member_joined = None
         try:

--- a/wavis-backend/src/chat/chat_persistence.rs
+++ b/wavis-backend/src/chat/chat_persistence.rs
@@ -122,7 +122,7 @@ pub async fn purge_expired_messages(
           WHERE created_at < now() - make_interval(hours => $1) \
           LIMIT $2)",
     )
-    .bind(retention_hours as f64)
+    .bind(retention_hours as i64)
     .bind(batch_size)
     .execute(pool)
     .await?;

--- a/wavis-backend/src/voice/screen_share.rs
+++ b/wavis-backend/src/voice/screen_share.rs
@@ -97,6 +97,14 @@ pub fn handle_start_share(
             }));
         }
 
+        if let Some(sub_rooms) = members.info.sub_room_state.as_ref()
+            && !sub_rooms.participant_assignments.contains_key(sender_id)
+        {
+            return ShareResult::Error(SignalingMessage::Error(ErrorPayload {
+                message: "not in room".to_string(),
+            }));
+        }
+
         // Check sender not already sharing
         if members.info.active_shares.contains(sender_id) {
             return ShareResult::Noop;
@@ -459,6 +467,45 @@ mod tests {
 
         let result = handle_start_share(&state, "room-1", "outsider", ParticipantRole::Guest);
         assert!(matches!(result, ShareResult::Error(_)));
+    }
+
+    #[test]
+    fn start_share_fails_when_sender_has_no_sub_room_assignment() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["peer-a"]);
+        state
+            .with_room_write("room-1", |members| {
+                members.info.sub_room_state = Some(crate::state::SubRoomState::new("room-one"));
+            })
+            .unwrap();
+
+        let result = handle_start_share(&state, "room-1", "peer-a", ParticipantRole::Guest);
+
+        assert!(matches!(result, ShareResult::Error(_)));
+        assert!(!get_active_shares(&state, "room-1").contains("peer-a"));
+    }
+
+    #[test]
+    fn start_share_succeeds_when_sender_has_sub_room_assignment() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["peer-a"]);
+        state
+            .with_room_write("room-1", |members| {
+                let mut sub_rooms = crate::state::SubRoomState::new("room-one");
+                sub_rooms
+                    .participant_assignments
+                    .insert("peer-a".to_string(), "room-one".to_string());
+                sub_rooms.rooms[0]
+                    .participant_ids
+                    .push("peer-a".to_string());
+                members.info.sub_room_state = Some(sub_rooms);
+            })
+            .unwrap();
+
+        let result = handle_start_share(&state, "room-1", "peer-a", ParticipantRole::Guest);
+
+        assert!(matches!(result, ShareResult::Ok(_)));
+        assert!(get_active_shares(&state, "room-1").contains("peer-a"));
     }
 
     #[test]

--- a/wavis-backend/src/voice/voice_orchestrator.rs
+++ b/wavis-backend/src/voice/voice_orchestrator.rs
@@ -35,10 +35,9 @@ use chrono::{DateTime, Utc};
 use rand::Rng;
 use shared::signaling::{
     MediaTokenPayload, ParticipantInfo, ParticipantJoinedPayload, ParticipantLeftPayload,
-    PassthroughStatePayload,
-    RoomStatePayload, SignalingMessage, SubRoomCreatedPayload, SubRoomDeletedPayload,
-    SubRoomInfoPayload, SubRoomJoinedPayload, SubRoomLeftPayload, SubRoomStatePayload,
-    WireSubRoomMembershipSource,
+    PassthroughStatePayload, RoomStatePayload, ShareStoppedPayload, SignalingMessage,
+    SubRoomCreatedPayload, SubRoomDeletedPayload, SubRoomInfoPayload, SubRoomJoinedPayload,
+    SubRoomLeftPayload, SubRoomStatePayload, WireSubRoomMembershipSource,
 };
 use sqlx::PgPool;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -234,6 +233,14 @@ fn sub_room_state_signals(room_state: &InMemoryRoomState, room_id: &str) -> Vec<
         .and_then(|info| info.sub_room_state.as_ref().map(sub_room_state_payload))
         .map(|payload| vec![OutboundSignal::broadcast_all(SignalingMessage::SubRoomState(payload))])
         .unwrap_or_default()
+}
+
+fn participant_display_name(participants: &[ParticipantInfo], participant_id: &str) -> String {
+    participants
+        .iter()
+        .find(|p| p.participant_id == participant_id)
+        .map(|p| p.display_name.clone())
+        .unwrap_or_else(|| participant_id.to_string())
 }
 
 fn ensure_room_sub_rooms(info: &mut RoomInfo) {
@@ -616,6 +623,7 @@ pub fn leave_sub_room(
 ) -> Result<SubRoomActionResult, String> {
     let mut left_sub_room_id = None;
     let mut expiry = None;
+    let mut share_stopped = None;
 
     room_state
         .with_room_write(room_id, |members| {
@@ -638,6 +646,15 @@ pub fn leave_sub_room(
             }
             expiry = schedule_empty_room_if_needed(sub_rooms, &current_room_id);
             left_sub_room_id = Some(current_room_id);
+            if members.info.active_shares.remove(participant_id) {
+                share_stopped = Some(SignalingMessage::ShareStopped(ShareStoppedPayload {
+                    participant_id: participant_id.to_string(),
+                    display_name: participant_display_name(
+                        &members.info.participants,
+                        participant_id,
+                    ),
+                }));
+            }
             Ok::<(), String>(())
         })
         .map_err(|_| "voice session not found".to_string())??;
@@ -650,6 +667,9 @@ pub fn leave_sub_room(
                 sub_room_id,
             },
         )));
+    }
+    if let Some(event) = share_stopped {
+        signals.push(OutboundSignal::broadcast_all(event));
     }
     signals.extend(sub_room_state_signals(room_state, room_id));
     Ok(SubRoomActionResult { signals, expiry })
@@ -1288,6 +1308,55 @@ mod tests {
             .find(|room| room.sub_room_id == "room-2")
             .expect("room-2 exists");
         assert!(room.delete_at.is_some());
+    }
+
+    #[test]
+    fn leaving_sub_room_clears_active_share() {
+        let state = sub_room_test_state();
+        let _ = create_sub_room(&state, "voice-room").expect("create sub room");
+        let _ = join_sub_room(&state, "voice-room", "room-2", "peer-a");
+        state
+            .with_room_write("voice-room", |members| {
+                members.info.active_shares.insert("peer-a".to_string());
+            })
+            .unwrap();
+
+        let result = leave_sub_room(&state, "voice-room", "peer-a").expect("leave sub room");
+
+        let info = state.get_room_info("voice-room").expect("room exists");
+        assert!(!info.active_shares.contains("peer-a"));
+        assert!(result.signals.iter().any(|signal| {
+            matches!(
+                &signal.msg,
+                SignalingMessage::ShareStopped(payload)
+                    if payload.participant_id == "peer-a"
+                        && payload.display_name == "Peer A"
+            )
+        }));
+    }
+
+    #[test]
+    fn joining_another_sub_room_preserves_active_share() {
+        let state = sub_room_test_state();
+        let _ = create_sub_room(&state, "voice-room").expect("create room-2");
+        let _ = create_sub_room(&state, "voice-room").expect("create room-3");
+        let _ = join_sub_room(&state, "voice-room", "room-2", "peer-a");
+        state
+            .with_room_write("voice-room", |members| {
+                members.info.active_shares.insert("peer-a".to_string());
+            })
+            .unwrap();
+
+        let result = join_sub_room(&state, "voice-room", "room-3", "peer-a").expect("move rooms");
+
+        let info = state.get_room_info("voice-room").expect("room exists");
+        assert!(info.active_shares.contains("peer-a"));
+        assert!(
+            !result
+                .signals
+                .iter()
+                .any(|signal| matches!(signal.msg, SignalingMessage::ShareStopped(_)))
+        );
     }
 
     fn arb_channel_role() -> impl Strategy<Value = ChannelRole> {

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -2173,7 +2173,16 @@ pub(crate) async fn dispatch_message(
 
                             Some(COLD_START_ESTIMATED_WAIT_SECS)
                         } else {
-                            None
+                            // No EC2 controller — SFU is down and we cannot start it.
+                            // Drop the lock before sending so we don't hold it across I/O.
+                            drop(health_w);
+                            ctx.app_state.connections.send_to(
+                                ctx.peer_id,
+                                &SignalingMessage::Error(ErrorPayload {
+                                    message: "SFU unavailable".to_string(),
+                                }),
+                            );
+                            return DispatchOutcome::Continue;
                         }
                     }
                 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
