### PR TITLE
fix for megacrash

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -484,6 +484,38 @@
       }
     },
 
+    // ─── CI Legs (used by "Full CI Check" compound) ───────────
+    // These are shell-based launch configs so they appear in Run & Debug.
+    // Each runs one verification step; the compound above runs all three.
+
+    // Leg 1: Clippy lint — workspace-wide, all targets, deny warnings.
+    // Catches lint violations, unused imports, and clippy-level issues.
+    {
+      "type": "node-terminal",
+      "request": "launch",
+      "name": "CI: Clippy (workspace)",
+      "command": "cargo clippy --workspace --all-targets --all-features -- -D warnings",
+      "cwd": "${workspaceFolder}"
+    },
+    // Leg 2: Cargo test — workspace-wide, all features.
+    // Runs every Rust unit + integration test across all crates.
+    {
+      "type": "node-terminal",
+      "request": "launch",
+      "name": "CI: Cargo Test (workspace)",
+      "command": "cargo test --workspace --all-features",
+      "cwd": "${workspaceFolder}"
+    },
+    // Leg 3: npm test — GUI client Vitest suite.
+    // Runs the TypeScript/React test suite for wavis-gui.
+    {
+      "type": "node-terminal",
+      "request": "launch",
+      "name": "CI: npm Test (GUI)",
+      "command": "npm test",
+      "cwd": "${workspaceFolder}/clients/wavis-gui"
+    },
+
     // ─── Workspace-Wide ─────────────────────────────────────────
     // NOTE: "Test Entire Workspace" is a Task, not a launch config,
     //       because --workspace produces binaries for every crate.
@@ -492,6 +524,25 @@
 
   // ─── Compound Launch Configurations ─────────────────────────
   "compounds": [
+    // ── Full CI Check ───────────────────────────────────────
+    // Runs Clippy, Cargo Test, and npm Test in parallel.
+    // Appears in the Run & Debug dropdown as "▶ Full CI Check".
+    // Each leg opens its own integrated terminal so output is separate.
+    // Equivalent to the one-liner:
+    //   clippy --workspace | cargo test --workspace | npm test (parallel)
+    {
+      "name": "Full CI Check",
+      "configurations": [
+        "CI: Clippy (workspace)",
+        "CI: Cargo Test (workspace)",
+        "CI: npm Test (GUI)"
+      ],
+      "stopAll": false,
+      "presentation": {
+        "group": "ci",
+        "order": 0
+      }
+    },
     {
       "name": "Backend + CLI Client (P2P)",
       "configurations": ["Run Backend", "Run CLI Test Client (server)"],

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2452,8 +2452,8 @@ export function initSession(
   client.onStatusChange((status) => {
     if (status === 'disconnected') {
       stopColdStartRetry();
-      if (state.machineState === 'active') {
-        // Connection dropped during active session — start reconnecting.
+      if (state.machineState === 'active' || state.machineState === 'joining') {
+        // Connection dropped during active session or mid-join — start reconnecting.
         // Do NOT tear down LiveKit media — it connects directly to the SFU,
         // independent of the signaling WS. Tearing it down causes an
         // unnecessary audio/screenshare interruption during WS reconnects

--- a/clients/wavis-gui/src/shared/websocket.ts
+++ b/clients/wavis-gui/src/shared/websocket.ts
@@ -18,10 +18,9 @@ export type WsMessageHandler = (message: unknown) => void;
 
 const LOG_PREFIX = '[wavis:ws]';
 
-/** Keepalive ping interval (ms). Prevents idle-timeout disconnects from
- *  reverse proxies (e.g. CloudFront default 600s). 5 minutes is well
- *  within typical proxy idle windows. */
-const KEEPALIVE_INTERVAL_MS = 5 * 60 * 1000;
+/** Keepalive ping interval (ms). CloudFront VPC origin_read_timeout is 60s;
+ *  ping every 30s to stay safely within that window. */
+const KEEPALIVE_INTERVAL_MS = 30_000;
 
 /** Slow periodic retry interval (ms) after fast reconnect attempts are exhausted. */
 const PERIODIC_RETRY_INTERVAL_MS = 30_000;


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
