### PR TITLE
Play disconnect sound for active session loss

### DIFF
--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -29,6 +29,9 @@ let messageHandler: ((msg: unknown) => void) | null;
 /** The status change handler registered via client.onStatusChange(). */
 let statusChangeHandler: ((status: string) => void) | null;
 
+/** The most recently created mock SignalingClient instance. */
+let lastSignalingClient: Record<string, unknown> | null;
+
 /** Whether connectWithAuth should reject. */
 let connectShouldFail: boolean;
 let playNotificationSoundCalls: string[];
@@ -110,6 +113,7 @@ vi.mock('../livekit-media', () => ({
 
 vi.mock('@shared/websocket', () => ({
   SignalingClient: vi.fn(function (this: Record<string, unknown>) {
+    lastSignalingClient = this;
     this.status = 'disconnected';
     this.send = vi.fn((msg: Record<string, unknown>) => { sentMessages.push(msg); });
     this.onMessage = vi.fn((handler: (msg: unknown) => void) => {
@@ -239,6 +243,7 @@ function resetAll() {
   sentMessages = [];
   messageHandler = null;
   statusChangeHandler = null;
+  lastSignalingClient = null;
   connectShouldFail = false;
   mockMaxRetries = 10;
   playNotificationSoundCalls = [];
@@ -876,7 +881,7 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
     expect(playNotificationSoundCalls).toEqual(['join']);
   });
 
-  it('does not play leave sound for explicit whole-session leave', async () => {
+  it('plays leave sound for explicit whole-session leave', async () => {
     await driveToActive('ch-sounds', 'room-sounds');
 
     messageHandler!({
@@ -890,8 +895,73 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
 
     leaveRoom();
 
-    expect(playNotificationSoundCalls).toEqual([]);
+    expect(playNotificationSoundCalls).toEqual(['leave']);
     expect(sentMessages).toContainEqual({ type: 'leave' });
+  });
+
+  it('plays one leave sound when the local participant is kicked', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    messageHandler!({
+      type: 'participant_kicked',
+      participantId: 'self-peer',
+    });
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('plays one leave sound when the local session is displaced', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    messageHandler!({ type: 'session_displaced' });
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('plays one leave sound when signaling reconnect exhaustion ends an active session', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    statusChangeHandler!('disconnected');
+    await tick();
+    expect(getState().machineState).toBe('reconnecting');
+
+    if (lastSignalingClient) {
+      lastSignalingClient.status = 'disconnected';
+      lastSignalingClient.reconnectTimer = null;
+      lastSignalingClient.periodicRetryTimer = null;
+    }
+    statusChangeHandler!('disconnected');
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('does not play leave sound for initial connection failure before room membership', async () => {
+    connectShouldFail = true;
+    initSession('ch-sounds', 'room-sounds', 'owner', (s) => { latestState = s; });
+    await tick();
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual([]);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('plays one leave sound when duplicate terminal paths arrive for the same session', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    messageHandler!({
+      type: 'participant_kicked',
+      participantId: 'self-peer',
+    });
+    messageHandler!({ type: 'session_displaced' });
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -949,6 +949,8 @@ const MAX_AUTH_REFRESH_RETRIES = 2;
 let authRefreshRetries = 0;
 let wasReconnecting = false;
 let unsubTokenRefresh: (() => void) | null = null;
+let localSessionJoined = false;
+let localDisconnectSoundPlayed = false;
 // TODO: proactiveReconnecting flag — wire into onStatusChange to suppress
 // the "already reconnecting → connection lost" path during token-refresh reconnects.
 
@@ -957,6 +959,19 @@ let unsubTokenRefresh: (() => void) | null = null;
  * late-arriving events (share_stopped, etc.) can still resolve display names.
  */
 const displayNameCache = new Map<string, string>();
+
+function playLocalDisconnectSoundOnce(): void {
+  const wasInLocalSession =
+    localSessionJoined ||
+    !!state.selfParticipantId ||
+    !!state.roomId ||
+    state.machineState === 'active' ||
+    state.machineState === 'reconnecting';
+
+  if (!wasInLocalSession || localDisconnectSoundPlayed) return;
+  localDisconnectSoundPlayed = true;
+  void playNotificationSound('leave');
+}
 
 /* ─── Share Picker Data (Tauri event handshake) ─────────────────── */
 
@@ -1565,6 +1580,7 @@ function dispatchMessage(raw: unknown): void {
           if (result.status !== 'success' || !client) {
             console.warn(LOG, 'token refresh failed after auth_failed:', result.status);
             state.error = (msg.reason as string) || 'Authentication failed';
+            playLocalDisconnectSoundOnce();
             state.machineState = 'idle';
             notify();
             return;
@@ -1574,6 +1590,7 @@ function dispatchMessage(raw: unknown): void {
             client.reconnectWithNewToken(toWsUrl(serverUrl)).catch((err) => {
               console.error(LOG, 'reconnect after refresh failed:', err);
               state.error = 'Authentication failed';
+              playLocalDisconnectSoundOnce();
               state.machineState = 'idle';
               notify();
             });
@@ -1586,17 +1603,23 @@ function dispatchMessage(raw: unknown): void {
       if (client) {
         client.disconnect();
       }
+      playLocalDisconnectSoundOnce();
       state.machineState = 'idle';
       notify();
       break;
     }
 
     case 'joined': {
+      const joinedActiveSession = state.machineState !== 'idle';
       stopColdStartRetry();
       state.serverStartingEstimatedWaitSecs = null;
       state.lastRateLimitError = null;
       state.selfParticipantId = msg.peerId as string;
       state.roomId = msg.roomId as string;
+      if (joinedActiveSession) {
+        localSessionJoined = true;
+        localDisconnectSoundPlayed = false;
+      }
       syncDerivedSubRoomState();
       syncDesiredSubRoomPreference();
       state.sharePermission = (msg.sharePermission as string) === 'host_only' ? 'host_only' : 'anyone';
@@ -1677,6 +1700,7 @@ function dispatchMessage(raw: unknown): void {
       console.warn(LOG, `join_rejected reason=${rawReason} channelId=${state.channelId}`);
       if (state.machineState === 'server_starting') {
         stopColdStartRetry();
+        playLocalDisconnectSoundOnce();
         state.machineState = 'idle';
         state.serverStartingEstimatedWaitSecs = null;
         state.rejectionReason = (msg.reason as string) || 'Server failed to start';
@@ -1697,6 +1721,7 @@ function dispatchMessage(raw: unknown): void {
         client.disconnect();
       }
       client = null;
+      playLocalDisconnectSoundOnce();
       state.machineState = 'idle';
       notify();
       break;
@@ -1963,6 +1988,7 @@ function dispatchMessage(raw: unknown): void {
           client.disconnect();
         }
         client = null;
+        playLocalDisconnectSoundOnce();
         state.machineState = 'idle';
       }
       notify();
@@ -1990,6 +2016,7 @@ function dispatchMessage(raw: unknown): void {
         client.disconnect();
       }
       client = null;
+      playLocalDisconnectSoundOnce();
       state.machineState = 'idle';
       stopColdStartRetry();
       stopPeriodicMediaRetry();
@@ -2423,6 +2450,8 @@ export function initSession(
     machineState: 'connecting',
     screenShareStreams: new Map(),
   };
+  localSessionJoined = false;
+  localDisconnectSoundPlayed = false;
   desiredSubRoomIntent = undefined;
 
   // Push initial state to the component
@@ -2479,6 +2508,7 @@ export function initSession(
           appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'system', message: 'signaling reconnect failed — session lost' });
           state.error = 'Connection lost';
           state.lastRateLimitError = null;
+          playLocalDisconnectSoundOnce();
           state.machineState = 'idle';
           notify();
         }
@@ -2513,6 +2543,7 @@ export function initSession(
         console.error(LOG, 'connect failed:', err);
         if (client !== thisClient) return;
         state.error = 'Connection failed';
+        playLocalDisconnectSoundOnce();
         state.machineState = 'idle';
         notify();
       });
@@ -2521,6 +2552,8 @@ export function initSession(
 }
 
 export function leaveRoom(): void {
+  playLocalDisconnectSoundOnce();
+
   // Clean up custom share captures (best-effort, fire-and-forget)
   if (state.activeVideoShare || state.activeAudioShare) {
     if (lkModule && lkModule instanceof LiveKitModule) {


### PR DESCRIPTION
## Summary
- play the leave notification once when an active local voice session ends from explicit leave, kick, displacement, auth failure, or reconnect exhaustion
- keep initial connection failures silent before room membership
- add coverage for duplicate terminal paths and reconnect exhaustion

## Tests
- npm.cmd run test
- npm.cmd run build
- cargo test --workspace
- cargo clippy --workspace -- -D warnings