### PR TITLE
feat(gui): last channel persistence and channel switcher UI

### DIFF
--- a/clients/wavis-gui/src/features/channels/ChannelSwitcherPanel.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelSwitcherPanel.tsx
@@ -1,0 +1,96 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { type Channel, fetchChannels } from './channels';
+import { fetchVoiceStatusWithFallback } from './channel-detail';
+import { ChannelRoleBadge } from './ChannelRoleBadge';
+import { usePolling } from '@shared/hooks/usePolling';
+
+const POLL_MS = 15_000;
+
+interface ChannelSwitcherPanelProps {
+  onChannelSelect: (ch: Channel) => void;
+  onClose: () => void;
+  currentChannelId?: string;
+}
+
+export function ChannelSwitcherPanel({ onChannelSelect, onClose, currentChannelId }: ChannelSwitcherPanelProps) {
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [voiceStatus, setVoiceStatus] = useState<Map<string, { active: boolean; participantCount: number }>>(new Map());
+  const requestInFlightRef = useRef(false);
+
+  const loadChannels = useCallback(async (showLoading: boolean) => {
+    if (showLoading) setLoading(true);
+    requestInFlightRef.current = true;
+    try {
+      const result = await fetchChannels();
+      setChannels(result);
+      const ids = result.map((ch) => ch.id);
+      fetchVoiceStatusWithFallback(ids).then((status) => {
+        setVoiceStatus(status);
+      }).catch(() => { /* silent */ });
+    } catch {
+      // silent — switcher is non-critical
+    } finally {
+      requestInFlightRef.current = false;
+      if (showLoading) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadChannels(true);
+  }, [loadChannels]);
+
+  usePolling(() => {
+    if (requestInFlightRef.current) return;
+    loadChannels(false);
+  }, POLL_MS);
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex items-center justify-between">
+        <div className="font-bold text-sm">CHANNELS</div>
+        <button
+          onClick={onClose}
+          className="text-wavis-text-secondary hover:text-wavis-text transition-colors text-xs px-1"
+          aria-label="Close channel switcher"
+        >[x]</button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 space-y-1">
+        {loading && (
+          <div className="text-wavis-text-secondary text-xs">loading...</div>
+        )}
+        {!loading && channels.length === 0 && (
+          <div className="text-wavis-text-secondary text-xs">no channels</div>
+        )}
+        {!loading && channels.map((ch) => {
+          const isCurrent = ch.id === currentChannelId;
+          return (
+            <div
+              key={ch.id}
+              onClick={() => { if (!isCurrent) onChannelSelect(ch); }}
+              className={`flex items-center justify-between gap-3 px-3 py-2 border transition-colors cursor-pointer ${
+                isCurrent
+                  ? 'border-wavis-accent bg-wavis-accent/8 cursor-default'
+                  : 'border-wavis-text-secondary hover:border-wavis-accent'
+              }`}
+            >
+              <span className="min-w-0 truncate text-sm">{ch.name}</span>
+              <div className="flex items-center gap-2 shrink-0">
+                {voiceStatus.get(ch.id)?.active && (
+                  <span className="text-wavis-accent text-xs flex items-center gap-1">
+                    <span>●</span>
+                    <span>{voiceStatus.get(ch.id)?.participantCount}</span>
+                  </span>
+                )}
+                <ChannelRoleBadge role={ch.role} variant="list" />
+                {isCurrent && (
+                  <span className="text-wavis-accent text-[0.625rem]">current</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/clients/wavis-gui/src/features/channels/ChannelsList.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelsList.tsx
@@ -18,6 +18,7 @@ import { ErrorPanel } from '@shared/ErrorPanel';
 import { EmptyState } from '@shared/EmptyState';
 import { LoadingBlock } from '@shared/LoadingBlock';
 import { usePolling } from '@shared/hooks/usePolling';
+import { setLastChannel } from '@features/settings/settings-store';
 
 /* Constants */
 const POLL_MS = 15_000;
@@ -233,7 +234,10 @@ export default function ChannelsList() {
               {channels.map((ch) => (
                 <div
                   key={ch.id}
-                  onClick={() => navigate('/room', { state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role } })}
+                  onClick={() => {
+                    void setLastChannel(ch.id, ch.name, ch.role);
+                    navigate('/room', { state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role } });
+                  }}
                   className="flex items-center justify-between gap-4 px-3 sm:px-4 py-3 bg-wavis-panel border border-wavis-text-secondary hover:border-wavis-accent transition-colors text-left mb-1 cursor-pointer"
                 >
                   <span className="min-w-0 truncate">{ch.name}</span>

--- a/clients/wavis-gui/src/features/channels/InitialRedirect.tsx
+++ b/clients/wavis-gui/src/features/channels/InitialRedirect.tsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { getLastChannel } from '@features/settings/settings-store';
+import ChannelsList from './ChannelsList';
+
+/**
+ * Index route component that redirects returning users to their last channel's
+ * room view. New users (no stored channel) see the ChannelsList as before.
+ */
+export default function InitialRedirect() {
+  const navigate = useNavigate();
+  const [showChannelsList, setShowChannelsList] = useState(false);
+
+  useEffect(() => {
+    getLastChannel().then((ch) => {
+      if (ch) {
+        navigate('/room', {
+          state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role },
+          replace: true,
+        });
+      } else {
+        setShowChannelsList(true);
+      }
+    });
+  }, [navigate]);
+
+  if (!showChannelsList) return null;
+  return <ChannelsList />;
+}

--- a/clients/wavis-gui/src/features/settings/settings-store.ts
+++ b/clients/wavis-gui/src/features/settings/settings-store.ts
@@ -8,6 +8,7 @@
 
 import { load } from '@tauri-apps/plugin-store';
 import { PROFILE_COLORS } from '@shared/colors';
+import type { ChannelRole } from '@features/channels/channels';
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -57,6 +58,9 @@ export const STORE_KEYS = {
   notificationVolume: 'wavis_notification_volume',
   soundVolumes: 'wavis_notification_sound_volumes',
   inputVolume: 'wavis_input_volume',
+  lastChannelId: 'wavis_last_channel_id',
+  lastChannelName: 'wavis_last_channel_name',
+  lastChannelRole: 'wavis_last_channel_role',
 } as const;
 
 export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
@@ -288,4 +292,32 @@ export async function setChannelVolumes(channelId: string, prefs: ChannelVolumeP
   const all = await getStoreValue<Record<string, ChannelVolumePrefs>>(STORE_KEYS.channelVolumes, {});
   all[channelId] = prefs;
   return setStoreValue(STORE_KEYS.channelVolumes, all);
+}
+
+// ─── Last Channel (hub redirect) ───────────────────────────────────
+
+export async function getLastChannel(): Promise<{ id: string; name: string; role: ChannelRole } | null> {
+  const [id, name, role] = await Promise.all([
+    getStoreValue<string | null>(STORE_KEYS.lastChannelId, null),
+    getStoreValue<string | null>(STORE_KEYS.lastChannelName, null),
+    getStoreValue<string | null>(STORE_KEYS.lastChannelRole, null),
+  ]);
+  if (!id || !name || !role) return null;
+  return { id, name, role: role as ChannelRole };
+}
+
+export async function setLastChannel(id: string, name: string, role: ChannelRole): Promise<void> {
+  await Promise.all([
+    setStoreValue(STORE_KEYS.lastChannelId, id),
+    setStoreValue(STORE_KEYS.lastChannelName, name),
+    setStoreValue(STORE_KEYS.lastChannelRole, role),
+  ]);
+}
+
+export async function clearLastChannel(): Promise<void> {
+  await Promise.all([
+    setStoreValue(STORE_KEYS.lastChannelId, null),
+    setStoreValue(STORE_KEYS.lastChannelName, null),
+    setStoreValue(STORE_KEYS.lastChannelRole, null),
+  ]);
 }

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import { useBlocker, useLocation, useNavigate } from 'react-router';
 import type { ChannelRole } from '@features/channels/channels';
+import type { Channel } from '@features/channels/channels';
+import { ChannelSwitcherPanel } from '@features/channels/ChannelSwitcherPanel';
 import type {
   VoiceRoomState,
   VoiceRoomMachineState,
@@ -59,6 +61,7 @@ import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { startSending, stopSending, stopSendingForWindow, stopAllSending, resendStream } from '@features/screen-share/screen-share-viewer';
 import { getWatchAllHotkey } from '@features/settings/settings-store';
+import { setLastChannel, clearLastChannel } from '@features/settings/settings-store';
 
 const DEBUG_SHARE_VIEW = import.meta.env.VITE_DEBUG_SCREEN_SHARE_VIEW === 'true';
 const DEBUG_SHARE_AUDIO = import.meta.env.VITE_DEBUG_SHARE_AUDIO === 'true';
@@ -273,7 +276,7 @@ export default function ActiveRoom() {
   const [roomState, setRoomState] = useState<VoiceRoomState | null>(null);
   const [countdownNowMs, setCountdownNowMs] = useState(() => Date.now());
 
-  const [leaving, setLeaving] = useState(false);
+  const [, setLeaving] = useState(false);
   const [cliInput, setCliInput] = useState('');
   const [chatInput, setChatInput] = useState('');
   const logEndRef = useRef<HTMLDivElement>(null);
@@ -311,6 +314,7 @@ export default function ActiveRoom() {
   const cliDraftRef = useRef('');
 
   const [showSettings, setShowSettings] = useState(false);
+  const [channelSwitcherOpen, setChannelSwitcherOpen] = useState(false);
 
   // Transient chat error display (auto-dismiss after 5s)
   const [chatError, setChatError] = useState<string | null>(null);
@@ -457,6 +461,13 @@ export default function ActiveRoom() {
       if (chatErrorTimerRef.current) clearTimeout(chatErrorTimerRef.current);
     };
   }, []);
+
+  // Clear persisted last channel when kicked (so next launch falls back to ChannelsList)
+  useEffect(() => {
+    if (roomState?.error === 'You were kicked') {
+      void clearLastChannel();
+    }
+  }, [roomState?.error]);
 
   // Tray event wiring: dispatch tray menu actions to voice room
   useEffect(() => {
@@ -1717,7 +1728,7 @@ export default function ActiveRoom() {
             <div className="text-wavis-danger mb-4">{roomState.error}</div>
             <div className="flex gap-4 justify-center">
               <button className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast" onClick={() => { initRef.current = false; initSession(channelId, channelName, channelRole, setRoomState); initRef.current = true; }}>/retry</button>
-              <button className="text-xs text-wavis-danger border border-wavis-danger py-0.5 px-1 text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg" onClick={() => navigateAwayFromRoom('/', true)}>/leave</button>
+              <button className="text-xs text-wavis-danger border border-wavis-danger py-0.5 px-1 text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg" onClick={() => { void clearLastChannel(); navigateAwayFromRoom('/', true); }}>/leave</button>
             </div>
           </div>
         </div>
@@ -1728,8 +1739,12 @@ export default function ActiveRoom() {
   // Kicked state
   if (roomState.error === 'You were kicked') {
     return (
-      <div className="h-full flex items-center justify-center bg-wavis-bg font-mono text-wavis-danger">
-        you were kicked from the room
+      <div className="h-full flex flex-col items-center justify-center bg-wavis-bg font-mono text-wavis-danger gap-4">
+        <span>you were kicked from the room</span>
+        <button
+          className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast"
+          onClick={() => navigateAwayFromRoom('/', false)}
+        >/back</button>
       </div>
     );
   }
@@ -1738,6 +1753,14 @@ export default function ActiveRoom() {
   const handleLeave = () => {
     setLeaving(true);
     navigateAwayFromRoom('/', true);
+  };
+
+  const handleChannelSwitch = async (ch: Channel) => {
+    await setLastChannel(ch.id, ch.name, ch.role);
+    setChannelSwitcherOpen(false);
+    allowNavigationRef.current = true;
+    leaveRoom();
+    navigate('/room', { state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role } });
   };
 
   const handleSendChat = () => {
@@ -1900,25 +1923,36 @@ export default function ActiveRoom() {
   const statusBadge = combinedStatusBadge(roomState.machineState, roomState.mediaState);
 
   const roomHeader = (
-    <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex flex-col justify-center gap-0.5 overflow-hidden">
-      <div className="flex items-center gap-2">
-        <StatusDot color={sigDot.color} label={sigDot.label} />
-        <StatusDot color={mediaDot.color} label={mediaDot.label} />
-        {(() => {
-          const badge = connectionModeBadgeText(showSecrets, roomState.connectionMode);
-          return badge ? <span className="text-[0.625rem] text-wavis-purple">[{badge}]</span> : null;
-        })()}
-        <span className="text-sm" style={{ color: statusBadge.color }}>{statusBadge.text}</span>
-        <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.participants.length}/6</span>
-        <span className="text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
-        <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.networkStats.packetLossPercent.toFixed(1)}% loss</span>
+    <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex items-center gap-3 overflow-hidden">
+      <div className="flex-1 flex flex-col justify-center gap-0.5 min-w-0">
+        <div className="flex items-center gap-2">
+          <StatusDot color={sigDot.color} label={sigDot.label} />
+          <StatusDot color={mediaDot.color} label={mediaDot.label} />
+          {(() => {
+            const badge = connectionModeBadgeText(showSecrets, roomState.connectionMode);
+            return badge ? <span className="text-[0.625rem] text-wavis-purple">[{badge}]</span> : null;
+          })()}
+          <span className="text-sm" style={{ color: statusBadge.color }}>{statusBadge.text}</span>
+          <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.participants.length}/6</span>
+          <span className="text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
+          <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.networkStats.packetLossPercent.toFixed(1)}% loss</span>
+        </div>
+        <div
+          className={`font-bold truncate min-w-0${roomState.channelName.length > 20 ? ' text-xs' : ' text-sm'}`}
+          title={roomState.channelName}
+        >
+          {roomState.channelName}
+        </div>
       </div>
-      <div
-        className={`font-bold truncate min-w-0${roomState.channelName.length > 20 ? ' text-xs' : ' text-sm'}`}
-        title={roomState.channelName}
-      >
-        {roomState.channelName}
-      </div>
+      <button
+        onClick={() => setChannelSwitcherOpen((v) => !v)}
+        className={`shrink-0 border px-2 py-1 text-xs transition-colors ${
+          channelSwitcherOpen
+            ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
+            : 'border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent'
+        }`}
+        title="Change channel"
+      >{channelSwitcherOpen ? '<' : '>'}</button>
     </div>
   );
 
@@ -2360,7 +2394,6 @@ export default function ActiveRoom() {
             })()}
             <div className="mt-4 flex flex-col gap-1">
               <button onClick={() => setShowSettings(true)} className="w-full text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-xs text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast">/settings</button>
-              <button onClick={handleLeave} disabled={leaving} className="w-full text-wavis-danger border border-wavis-danger py-0.5 px-1 text-xs text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg disabled:opacity-40 disabled:cursor-not-allowed">{leaving ? 'leaving...' : '/leave'}</button>
             </div>
           </div>
         </div>
@@ -2521,13 +2554,21 @@ export default function ActiveRoom() {
             <span className="shrink-0 text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={() => setChannelSwitcherOpen((v) => !v)}
+              className={`px-2 py-1.5 border text-[0.625rem] transition-colors ${
+                channelSwitcherOpen
+                  ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
+                  : 'border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent'
+              }`}
+              title="Change channel"
+            >{channelSwitcherOpen ? '<' : '>'}</button>
             <button onClick={toggleSelfMute} disabled={selfP?.isHostMuted} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center disabled:opacity-40 disabled:cursor-not-allowed ${selfP?.isMuted ? 'border-wavis-danger text-wavis-danger bg-wavis-danger/8 hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
               {selfP?.isMuted ? '/unmute' : '/mute'}
             </button>
             <button onClick={toggleSelfDeafen} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center ${roomState.isDeafened ? 'border-wavis-purple text-wavis-purple hover:bg-wavis-purple hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
               {roomState.isDeafened ? '/undeafen' : '/deafen'}
             </button>
-            <button onClick={handleLeave} className="px-2 py-1.5 border border-wavis-danger text-wavis-danger text-[0.625rem] transition-colors text-center hover:bg-wavis-danger hover:text-wavis-bg">/leave</button>
           </div>
         </div>
 
@@ -2555,6 +2596,12 @@ export default function ActiveRoom() {
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
           {showSettings ? (
             <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} />
+          ) : channelSwitcherOpen ? (
+            <ChannelSwitcherPanel
+              onChannelSelect={handleChannelSwitch}
+              onClose={() => setChannelSwitcherOpen(false)}
+              currentChannelId={channelId}
+            />
           ) : (
             <>
               {mobileTab === 'participants' && <div className="flex flex-col flex-1 min-h-0">{participantsSections}{youBar}</div>}
@@ -2575,7 +2622,13 @@ export default function ActiveRoom() {
           {youBar}
         </div>
         <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
-          {showSettings ? <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} /> : chatPanel}
+          {showSettings ? <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} /> : channelSwitcherOpen ? (
+            <ChannelSwitcherPanel
+              onChannelSelect={handleChannelSwitch}
+              onClose={() => setChannelSwitcherOpen(false)}
+              currentChannelId={channelId}
+            />
+          ) : chatPanel}
         </div>
         <div className="w-80 border-l border-wavis-text-secondary flex flex-col">
           {logPanel}

--- a/clients/wavis-gui/src/routes.ts
+++ b/clients/wavis-gui/src/routes.ts
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from 'react-router';
 import DeviceSetup from '@features/auth/DeviceSetup';
 import AuthGate from '@features/auth/AuthGate';
-import ChannelsList from '@features/channels/ChannelsList';
+import InitialRedirect from '@features/channels/InitialRedirect';
 
 /** Helper to add HydrateFallback to lazy-loaded routes. In React Router v7 with CSR,
  * lazy routes briefly enter a "hydrating" state while the dynamic import resolves.
@@ -80,7 +80,7 @@ export const router = createBrowserRouter([
     path: '/',
     Component: AuthGate,
     children: [
-      { index: true, Component: ChannelsList },
+      { index: true, Component: InitialRedirect },
       {
         path: 'channel/:channelId',
         lazy: async () => {

--- a/infrastructure/environments/dev-ecs/ecs_backend.tf
+++ b/infrastructure/environments/dev-ecs/ecs_backend.tf
@@ -18,6 +18,7 @@ resource "aws_ecr_repository" "backend" {
 resource "aws_cloudwatch_log_group" "backend" {
   name              = "/aws/ecs/${local.project}-${local.env}-backend"
   retention_in_days = var.backend_log_retention_days
+  log_group_class   = "INFREQUENT_ACCESS"
   tags              = local.tags
 }
 
@@ -30,6 +31,18 @@ resource "aws_ecs_cluster" "backend" {
   }
 
   tags = local.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "backend" {
+  cluster_name = aws_ecs_cluster.backend.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+    base              = 0
+  }
 }
 
 resource "aws_lb" "backend" {
@@ -190,10 +203,15 @@ resource "aws_ecs_service" "backend" {
   cluster                           = aws_ecs_cluster.backend.id
   task_definition                   = aws_ecs_task_definition.backend.arn
   desired_count                     = var.backend_desired_count
-  launch_type                       = "FARGATE"
   health_check_grace_period_seconds = var.backend_health_check_grace_period_seconds
   enable_execute_command            = true
   wait_for_steady_state             = false
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+    base              = 0
+  }
 
   deployment_circuit_breaker {
     enable   = true


### PR DESCRIPTION
This PR introduces UX improvements for returning users and better channel navigation.

### GUI Changes
- **Last Channel Persistence**: Automatically redirects users to their last active channel on startup via a new \InitialRedirect\ component.
- **Channel Switcher Panel**: Implements a new panel (\ChannelSwitcherPanel\) for quick channel switching within an active room, accessible via a toggle in the header.
- **Settings Store**: Added \getLastChannel\, \setLastChannel\, and \clearLastChannel\ helpers.
- **Room UI**: Updated layout to accommodate the switcher and improved feedback for kicked users.

### Infrastructure Changes
- **ECS Backend**: Configured to use **Fargate Spot** for significant cost reduction in development.
- **Logging**: Set CloudWatch log group class to \INFREQUENT_ACCESS\ for better cost management.

### Verification
- GUI: \
pm run build\ passed.
- Infrastructure: \	erraform validate\ passed.