### PR TITLE
Fix chat colors for profile updates

### DIFF
--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { type ReactNode, useState, useEffect, useRef, useCallback } from 'react';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import { useBlocker, useLocation, useNavigate } from 'react-router';
 import type { ChannelRole } from '@features/channels/channels';
@@ -56,6 +56,7 @@ import type { OccupiedSlots } from '@features/screen-share/SharePicker';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { LogicalSize } from '@tauri-apps/api/dpi';
+import { open } from '@tauri-apps/plugin-shell';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../components/ui/tooltip';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
@@ -142,6 +143,54 @@ function formatTime(isoString: string): string {
   } catch {
     return '??:??:??';
   }
+}
+
+const CHAT_LINK_RE = /(https?:\/\/[^\s<]+|www\.[^\s<]+)/gi;
+const TRAILING_LINK_PUNCTUATION_RE = /[.,!?;:)\]]+$/;
+
+function normalizeChatLink(raw: string): string {
+  return raw.toLowerCase().startsWith('www.') ? `https://${raw}` : raw;
+}
+
+function splitChatLink(raw: string): { hrefText: string; trailingText: string } {
+  const trailingText = raw.match(TRAILING_LINK_PUNCTUATION_RE)?.[0] ?? '';
+  return trailingText
+    ? { hrefText: raw.slice(0, -trailingText.length), trailingText }
+    : { hrefText: raw, trailingText: '' };
+}
+
+function renderChatText(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(CHAT_LINK_RE)) {
+    const raw = match[0];
+    const index = match.index ?? 0;
+    if (index > lastIndex) nodes.push(text.slice(lastIndex, index));
+
+    const { hrefText, trailingText } = splitChatLink(raw);
+    const href = normalizeChatLink(hrefText);
+    nodes.push(
+      <a
+        key={`link-${index}-${hrefText}`}
+        href={href}
+        className="text-wavis-accent underline underline-offset-2 break-all hover:opacity-80"
+        onClick={(event) => {
+          event.preventDefault();
+          void open(href);
+        }}
+        rel="noreferrer"
+        title={href}
+      >
+        {hrefText}
+      </a>,
+    );
+    if (trailingText) nodes.push(trailingText);
+    lastIndex = index + raw.length;
+  }
+
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
+  return nodes;
 }
 
 function getUserColor(participants: RoomParticipant[], participantId?: string): string {
@@ -1993,7 +2042,6 @@ export default function ActiveRoom() {
           style={{ cursor: isSelf ? 'default' : 'pointer' }}
         >
           {isSelf ? <span className="text-xs text-wavis-accent inline-block w-6 text-center flex-none">&gt;</span> : <span className="text-[0.625rem] text-wavis-text-secondary inline-block w-6 text-center flex-none">{expandedUser === p.id ? '[-]' : '[+]'}</span>}
-          {p.role === 'host' && <span className="text-xs text-wavis-text-secondary">[HOST]</span>}
           <span style={{
             color: p.color,
             animation: p.isSpeaking && !p.isMuted ? 'pulse 3s ease-in-out infinite' : 'none',
@@ -2057,14 +2105,14 @@ export default function ActiveRoom() {
               </div>
             )}
             {isHost && (
-              <>
-                <button onClick={() => kickParticipant(p.id)} className="block w-full text-left border border-wavis-danger text-wavis-danger px-3 py-2 transition-colors hover:opacity-70">/kick {p.displayName}</button>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <button onClick={() => kickParticipant(p.id)} className="text-xs text-center border border-wavis-danger text-wavis-danger px-1 py-0.5 transition-colors hover:opacity-70">/kick</button>
                 {p.isHostMuted
-                  ? <button onClick={() => unmuteParticipant(p.id)} className="block w-full text-left border border-wavis-accent text-wavis-accent px-3 py-2 transition-colors hover:opacity-70">/unmute {p.displayName}</button>
-                  : !p.isMuted && <button onClick={() => muteParticipant(p.id)} className="block w-full text-left border px-3 py-2 transition-colors hover:opacity-70" style={{ color: 'var(--wavis-warn)', borderColor: 'var(--wavis-warn)' }}>/mute {p.displayName}</button>
+                  ? <button onClick={() => unmuteParticipant(p.id)} className="text-xs text-center border border-wavis-accent text-wavis-accent px-1 py-0.5 transition-colors hover:opacity-70">/unmute</button>
+                  : !p.isMuted && <button onClick={() => muteParticipant(p.id)} className="text-xs text-center border px-1 py-0.5 transition-colors hover:opacity-70" style={{ color: 'var(--wavis-warn)', borderColor: 'var(--wavis-warn)' }}>/mute</button>
                 }
-                {p.isSharing && <button onClick={() => stopParticipantShare(p.id)} className="block w-full text-left border border-wavis-danger text-wavis-danger px-3 py-2 transition-colors hover:opacity-70">/revoke {p.displayName}</button>}
-              </>
+                {p.isSharing && <button onClick={() => stopParticipantShare(p.id)} className="text-xs text-center border border-wavis-danger text-wavis-danger px-1 py-0.5 transition-colors hover:opacity-70">/revoke</button>}
+              </div>
             )}
           </div>
         )}
@@ -2270,7 +2318,6 @@ export default function ActiveRoom() {
         </button>
         <button onClick={() => toggleSection('you')} className="bg-transparent outline-none py-1 px-1 text-left flex items-center gap-2 hover:opacity-80">
           <span style={{ color: selfP?.color }}>{selfP?.displayName}</span>
-          {selfP?.role === 'host' && <span className="text-[0.625rem] text-wavis-text-secondary">[HOST]</span>}
         </button>
         {!expandedSections.you && (
           <div className="ml-auto flex items-center leading-none text-xs">
@@ -2455,7 +2502,7 @@ export default function ActiveRoom() {
             <div key={item.message.id} className="break-all">
               <span className="text-wavis-text-secondary">[{formatTime(item.message.timestamp)}]</span>{' '}
               <span style={{ color: item.message.color }}>{item.message.displayName}</span>
-              <span>: {item.message.text}</span>
+              <span>: {renderChatText(item.message.text)}</span>
             </div>
           )
         )}
@@ -2545,30 +2592,13 @@ export default function ActiveRoom() {
       {/* ═══ MOBILE LAYOUT (< md) ═══ */}
       <div className="flex flex-col flex-1 overflow-hidden md:hidden">
         {/* Compact header */}
-        <div className="flex items-center justify-between px-3 py-2 border-b border-wavis-text-secondary bg-wavis-panel">
+        <div className="flex items-center px-3 py-2 border-b border-wavis-text-secondary bg-wavis-panel">
           <div className="flex items-center gap-2 min-w-0">
             <StatusDot color={sigDot.color} label={sigDot.label} />
             <StatusDot color={mediaDot.color} label={mediaDot.label} />
             <span className="truncate text-sm">{roomState.channelName}</span>
             <span className="shrink-0 text-[0.625rem] text-wavis-text-secondary">{roomState.participants.length}/6</span>
             <span className="shrink-0 text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={() => setChannelSwitcherOpen((v) => !v)}
-              className={`px-2 py-1.5 border text-[0.625rem] transition-colors ${
-                channelSwitcherOpen
-                  ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
-                  : 'border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent'
-              }`}
-              title="Change channel"
-            >{channelSwitcherOpen ? '<' : '>'}</button>
-            <button onClick={toggleSelfMute} disabled={selfP?.isHostMuted} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center disabled:opacity-40 disabled:cursor-not-allowed ${selfP?.isMuted ? 'border-wavis-danger text-wavis-danger bg-wavis-danger/8 hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
-              {selfP?.isMuted ? '/unmute' : '/mute'}
-            </button>
-            <button onClick={toggleSelfDeafen} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center ${roomState.isDeafened ? 'border-wavis-purple text-wavis-purple hover:bg-wavis-purple hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
-              {roomState.isDeafened ? '/undeafen' : '/deafen'}
-            </button>
           </div>
         </div>
 

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -50,6 +50,7 @@ import {
   startPortalShare,
   setPendingSharePickerData,
   buildChatDisplayItems,
+  resolveChatMessageDisplayColor,
 } from './voice-room';
 import type { ShareSelection, EnumerationResult } from '@features/screen-share/share-types';
 import type { OccupiedSlots } from '@features/screen-share/SharePicker';
@@ -2501,7 +2502,7 @@ export default function ActiveRoom() {
           ) : (
             <div key={item.message.id} className="break-all">
               <span className="text-wavis-text-secondary">[{formatTime(item.message.timestamp)}]</span>{' '}
-              <span style={{ color: item.message.color }}>{item.message.displayName}</span>
+              <span style={{ color: resolveChatMessageDisplayColor(item.message, roomState.participants) }}>{item.message.displayName}</span>
               <span>: {renderChatText(item.message.text)}</span>
             </div>
           )

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
@@ -438,6 +438,7 @@ import {
   computeSinceCursor,
   buildChatDisplayItems,
   shouldPlayChatNotification,
+  resolveChatMessageDisplayColor,
 } from '../voice-room';
 import type { ChatMessage } from '../voice-room';
 
@@ -559,6 +560,18 @@ describe('Property 6: Receive appends with 200-message cap', () => {
 // **Validates: Requirements 3.2**
 
 describe('Property 7: Color resolution from participant list', () => {
+  const message = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+    id: 'msg-1',
+    messageId: 'message-1',
+    timestamp: '2026-05-05T00:00:00Z',
+    participantId: 'peer-1',
+    userId: undefined,
+    displayName: 'Alice',
+    color: '#123456',
+    text: 'hello',
+    ...overrides,
+  });
+
   it('when participantId matches a participant, color equals that participant color', () => {
     fc.assert(
       fc.property(
@@ -580,9 +593,10 @@ describe('Property 7: Color resolution from participant list', () => {
               volume: 70,
             },
           ];
-          // Simulate the color resolution logic from dispatchMessage
-          const participant = participants.find((p) => p.id === peerId);
-          const resolvedColor = participant?.color ?? '';
+          const resolvedColor = resolveChatMessageDisplayColor(
+            message({ participantId: peerId, color: TERMINAL_COLORS[0] }),
+            participants,
+          );
           expect(resolvedColor).toBe(TERMINAL_COLORS[colorIdx]);
         },
       ),
@@ -590,7 +604,7 @@ describe('Property 7: Color resolution from participant list', () => {
     );
   });
 
-  it('when participantId not found, color is empty string', () => {
+  it('uses stored message color when no current participant matches', () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 1, maxLength: 20 }),
@@ -612,12 +626,102 @@ describe('Property 7: Color resolution from participant list', () => {
           ];
           // Only test when unknownId differs from the known peer
           if (unknownId === 'known-peer') return;
-          const participant = participants.find((p) => p.id === unknownId);
-          const resolvedColor = participant?.color ?? '';
-          expect(resolvedColor).toBe('');
+          const resolvedColor = resolveChatMessageDisplayColor(
+            message({ participantId: unknownId, color: '#ABCDEF' }),
+            participants,
+          );
+          expect(resolvedColor).toBe('#ABCDEF');
         },
       ),
       { numRuns: 100 },
+    );
+  });
+
+  it('messages recolor when a matching participant color changes', () => {
+    const chatMessage = message({ participantId: 'peer-1', color: '#111111' });
+    const before: RoomParticipant[] = [{
+      id: 'peer-1',
+      displayName: 'Alice',
+      color: '#222222',
+      role: 'guest',
+      isSpeaking: false,
+      isMuted: false,
+      isHostMuted: false,
+      isDeafened: false,
+      isSharing: false,
+      rmsLevel: 0,
+      volume: 70,
+    }];
+    const after = before.map((p) => ({ ...p, color: '#333333' }));
+
+    expect(resolveChatMessageDisplayColor(chatMessage, before)).toBe('#222222');
+    expect(resolveChatMessageDisplayColor(chatMessage, after)).toBe('#333333');
+  });
+
+  it('userId match takes precedence over stale participantId', () => {
+    const participants: RoomParticipant[] = [
+      {
+        id: 'old-peer',
+        userId: 'someone-else',
+        displayName: 'Stale',
+        color: '#111111',
+        role: 'guest',
+        isSpeaking: false,
+        isMuted: false,
+        isHostMuted: false,
+        isDeafened: false,
+        isSharing: false,
+        rmsLevel: 0,
+        volume: 70,
+      },
+      {
+        id: 'new-peer',
+        userId: 'user-1',
+        displayName: 'Alice',
+        color: '#44AA88',
+        role: 'guest',
+        isSpeaking: false,
+        isMuted: false,
+        isHostMuted: false,
+        isDeafened: false,
+        isSharing: false,
+        rmsLevel: 0,
+        volume: 70,
+      },
+    ];
+
+    expect(resolveChatMessageDisplayColor(
+      message({ participantId: 'old-peer', userId: 'user-1', color: '#999999' }),
+      participants,
+    )).toBe('#44AA88');
+  });
+
+  it('legacy messages without userId still recolor by participantId', () => {
+    const participants: RoomParticipant[] = [{
+      id: 'legacy-peer',
+      displayName: 'Legacy',
+      color: '#AA7744',
+      role: 'guest',
+      isSpeaking: false,
+      isMuted: false,
+      isHostMuted: false,
+      isDeafened: false,
+      isSharing: false,
+      rmsLevel: 0,
+      volume: 70,
+    }];
+
+    expect(resolveChatMessageDisplayColor(
+      message({ participantId: 'legacy-peer', userId: undefined, color: '#999999' }),
+      participants,
+    )).toBe('#AA7744');
+  });
+
+  it('hash fallback is stable when no participant and no stored color match', () => {
+    const chatMessage = message({ participantId: 'peer-fallback', userId: 'user-fallback', color: '' });
+
+    expect(resolveChatMessageDisplayColor(chatMessage, [])).toBe(
+      colorFor({ userId: 'user-fallback', id: 'peer-fallback' }),
     );
   });
 });
@@ -1018,6 +1122,23 @@ describe('Property 6: Client merge, dedup, and cap', () => {
       }),
       { numRuns: 100 },
     );
+  });
+
+  it('history merge preserves optional userId', () => {
+    const merged = mergeHistoryMessages(
+      [{
+        messageId: 'history-1',
+        participantId: 'old-peer',
+        userId: 'user-1',
+        displayName: 'Alice',
+        text: 'from history',
+        timestamp: '2026-05-05T00:00:00Z',
+      }],
+      [],
+    );
+
+    expect(merged[0].userId).toBe('user-1');
+    expect(merged[0].color).toBe(colorFor({ userId: 'user-1', id: 'old-peer' }));
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -94,6 +94,7 @@ export interface ChatMessage {
   messageId?: string;
   timestamp: string;
   participantId: string;
+  userId?: string;
   displayName: string;
   color: string;
   text: string;
@@ -314,6 +315,21 @@ export function colorFor(participant: { userId?: string; id: string }): string {
     h = Math.imul(h, 16777619);
   }
   return TERMINAL_COLORS[Math.abs(h) % TERMINAL_COLORS.length];
+}
+
+export function resolveChatMessageDisplayColor(
+  message: Pick<ChatMessage, 'participantId' | 'userId' | 'color'>,
+  participants: Array<Pick<RoomParticipant, 'id' | 'userId' | 'color'>>,
+): string {
+  if (message.userId) {
+    const userMatch = participants.find((p) => p.userId === message.userId);
+    if (userMatch?.color) return userMatch.color;
+  }
+
+  const participantMatch = participants.find((p) => p.id === message.participantId);
+  if (participantMatch?.color) return participantMatch.color;
+
+  return message.color || colorFor({ userId: message.userId, id: message.participantId });
 }
 
 /**
@@ -561,7 +577,7 @@ export function shouldPlayChatNotification(
  * Exported for property testing.
  */
 export function mergeHistoryMessages(
-  historyPayload: Array<{ messageId: string; participantId: string; displayName: string; text: string; timestamp: string }>,
+  historyPayload: Array<{ messageId: string; participantId: string; userId?: string; displayName: string; text: string; timestamp: string }>,
   existingMessages: ChatMessage[],
 ): ChatMessage[] {
   // Build set of existing messageIds for dedup (skip entries without messageId)
@@ -578,8 +594,9 @@ export function mergeHistoryMessages(
       messageId: h.messageId,
       timestamp: h.timestamp,
       participantId: h.participantId,
+      userId: h.userId,
       displayName: h.displayName,
-      color: colorFor({ id: h.participantId }),
+      color: colorFor({ userId: h.userId, id: h.participantId }),
       text: h.text,
       isHistory: true,
     }));
@@ -2375,6 +2392,7 @@ function dispatchMessage(raw: unknown): void {
         messageId: (msg.messageId as string) || undefined,
         timestamp: msg.timestamp as string,
         participantId: msg.participantId as string,
+        userId: (msg.userId as string) || undefined,
         displayName: msg.displayName as string,
         color: participant?.color ?? '',
         text: msg.text as string,
@@ -2395,6 +2413,7 @@ function dispatchMessage(raw: unknown): void {
       const historyPayload = messages.map((m) => ({
         messageId: m.messageId as string,
         participantId: m.participantId as string,
+        userId: (m.userId as string) || undefined,
         displayName: m.displayName as string,
         text: m.text as string,
         timestamp: m.timestamp as string,

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -757,7 +757,11 @@ pub struct SubRoomInfoPayload {
     pub participant_ids: Vec<String>,
     /// When the room is scheduled for auto-deletion, expressed as epoch milliseconds.
     /// Absent for ROOM 1 and any non-empty room.
-    #[serde(rename = "deleteAtMs", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "deleteAtMs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub delete_at_ms: Option<u64>,
 }
 
@@ -867,6 +871,9 @@ pub struct ChatMessagePayload {
     /// Participant identifier for the sender.
     #[serde(rename = "participantId")]
     pub participant_id: String,
+    /// Stable authenticated user identifier for the sender, when available.
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
     /// Display name for the sender at the time the message was emitted.
     #[serde(rename = "displayName")]
     pub display_name: String,
@@ -898,6 +905,9 @@ pub struct ChatHistoryMessagePayload {
     /// Participant identifier for the original sender.
     #[serde(rename = "participantId")]
     pub participant_id: String,
+    /// Stable authenticated user identifier for the original sender, when available.
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
     /// Display name captured with the historical message.
     #[serde(rename = "displayName")]
     pub display_name: String,

--- a/shared/src/signaling/proptest_support.rs
+++ b/shared/src/signaling/proptest_support.rs
@@ -709,11 +709,13 @@ impl Arbitrary for PassthroughStatePayload {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (any::<String>(), any::<String>(), any::<String>())
-            .prop_map(|(source_sub_room_id, target_sub_room_id, label)| PassthroughStatePayload {
-                source_sub_room_id,
-                target_sub_room_id,
-                label,
-            })
+            .prop_map(
+                |(source_sub_room_id, target_sub_room_id, label)| PassthroughStatePayload {
+                    source_sub_room_id,
+                    target_sub_room_id,
+                    label,
+                },
+            )
             .boxed()
     }
 }
@@ -748,12 +750,18 @@ impl Arbitrary for SubRoomJoinedPayload {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<String>(), any::<String>(), any::<WireSubRoomMembershipSource>())
-            .prop_map(|(participant_id, sub_room_id, source)| SubRoomJoinedPayload {
-                participant_id,
-                sub_room_id,
-                source,
-            })
+        (
+            any::<String>(),
+            any::<String>(),
+            any::<WireSubRoomMembershipSource>(),
+        )
+            .prop_map(
+                |(participant_id, sub_room_id, source)| SubRoomJoinedPayload {
+                    participant_id,
+                    sub_room_id,
+                    source,
+                },
+            )
             .boxed()
     }
 }
@@ -812,18 +820,22 @@ impl Arbitrary for ChatMessagePayload {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<String>(),
+            prop::option::of(any::<String>()),
             any::<String>(),
             any::<String>(),
             any::<String>(),
             prop::option::of(any::<String>()),
         )
             .prop_map(
-                |(participant_id, display_name, text, timestamp, message_id)| ChatMessagePayload {
-                    participant_id,
-                    display_name,
-                    text,
-                    timestamp,
-                    message_id,
+                |(participant_id, user_id, display_name, text, timestamp, message_id)| {
+                    ChatMessagePayload {
+                        participant_id,
+                        user_id,
+                        display_name,
+                        text,
+                        timestamp,
+                        message_id,
+                    }
                 },
             )
             .boxed()
@@ -848,15 +860,17 @@ impl Arbitrary for ChatHistoryMessagePayload {
         (
             any::<String>(),
             any::<String>(),
+            prop::option::of(any::<String>()),
             any::<String>(),
             any::<String>(),
             any::<String>(),
         )
             .prop_map(
-                |(message_id, participant_id, display_name, text, timestamp)| {
+                |(message_id, participant_id, user_id, display_name, text, timestamp)| {
                     ChatHistoryMessagePayload {
                         message_id,
                         participant_id,
+                        user_id,
                         display_name,
                         text,
                         timestamp,

--- a/shared/src/signaling/tests.rs
+++ b/shared/src/signaling/tests.rs
@@ -1,6 +1,49 @@
 use super::*;
 use proptest::prelude::*;
 
+#[test]
+fn chat_payloads_serialize_optional_user_id_as_user_id() {
+    let chat = SignalingMessage::ChatMessage(ChatMessagePayload {
+        participant_id: "peer-1".to_string(),
+        user_id: Some("user-1".to_string()),
+        display_name: "Alice".to_string(),
+        text: "hello".to_string(),
+        timestamp: "2026-05-05T00:00:00Z".to_string(),
+        message_id: Some("message-1".to_string()),
+    });
+    let json = to_json(&chat).unwrap();
+    assert!(json.contains(r#""userId":"user-1""#));
+    assert!(!json.contains("user_id"));
+
+    let history = SignalingMessage::ChatHistoryResponse(ChatHistoryResponsePayload {
+        messages: vec![ChatHistoryMessagePayload {
+            message_id: "message-1".to_string(),
+            participant_id: "peer-1".to_string(),
+            user_id: Some("user-1".to_string()),
+            display_name: "Alice".to_string(),
+            text: "hello".to_string(),
+            timestamp: "2026-05-05T00:00:00Z".to_string(),
+        }],
+    });
+    let history_json = to_json(&history).unwrap();
+    assert!(history_json.contains(r#""userId":"user-1""#));
+    assert!(!history_json.contains("user_id"));
+}
+
+#[test]
+fn chat_payloads_omit_absent_user_id() {
+    let chat = SignalingMessage::ChatMessage(ChatMessagePayload {
+        participant_id: "peer-1".to_string(),
+        user_id: None,
+        display_name: "Alice".to_string(),
+        text: "hello".to_string(),
+        timestamp: "2026-05-05T00:00:00Z".to_string(),
+        message_id: Some("message-1".to_string()),
+    });
+    let json = to_json(&chat).unwrap();
+    assert!(!json.contains("userId"));
+}
+
 // --- Unit tests for invite lifecycle messages ---
 
 #[test]
@@ -248,6 +291,7 @@ proptest! {
         );
         let original = SignalingMessage::ChatMessage(ChatMessagePayload {
             participant_id,
+            user_id: Some("user-123".to_string()),
             display_name,
             text,
             timestamp,

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -259,7 +259,11 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
         }
         SignalingMessage::LeaveSubRoom(_) => {}
         SignalingMessage::SetPassthrough(p) => {
-            check("targetSubRoomId", &p.target_sub_room_id, MAX_SUB_ROOM_ID_LEN)?;
+            check(
+                "targetSubRoomId",
+                &p.target_sub_room_id,
+                MAX_SUB_ROOM_ID_LEN,
+            )?;
         }
         SignalingMessage::ClearPassthrough(_) => {}
         SignalingMessage::SubRoomState(p) => {
@@ -270,8 +274,16 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
                 }
             }
             if let Some(passthrough) = &p.passthrough {
-                check("sourceSubRoomId", &passthrough.source_sub_room_id, MAX_SUB_ROOM_ID_LEN)?;
-                check("targetSubRoomId", &passthrough.target_sub_room_id, MAX_SUB_ROOM_ID_LEN)?;
+                check(
+                    "sourceSubRoomId",
+                    &passthrough.source_sub_room_id,
+                    MAX_SUB_ROOM_ID_LEN,
+                )?;
+                check(
+                    "targetSubRoomId",
+                    &passthrough.target_sub_room_id,
+                    MAX_SUB_ROOM_ID_LEN,
+                )?;
             }
         }
         SignalingMessage::SubRoomCreated(p) => {
@@ -828,6 +840,7 @@ mod tests {
                 .map(|i| ChatHistoryMessagePayload {
                     message_id: format!("msg-{}", i),
                     participant_id: format!("peer-{}", i),
+                    user_id: None,
                     display_name: format!("user-{}", i),
                     text: long_str(text_len),
                     timestamp: "2025-01-15T10:00:00Z".to_string(),

--- a/wavis-backend/migrations/015_add_chat_message_user_id.sql
+++ b/wavis-backend/migrations/015_add_chat_message_user_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_messages
+    ADD COLUMN IF NOT EXISTS user_id TEXT;

--- a/wavis-backend/src/chat/chat.rs
+++ b/wavis-backend/src/chat/chat.rs
@@ -7,12 +7,14 @@ use shared::signaling::{
 pub fn handle_chat_send(
     text: &str,
     participant_id: &str,
+    user_id: Option<&str>,
     display_name: &str,
     timestamp: &str,
     message_id: &str,
 ) -> Vec<OutboundSignal> {
     let msg = SignalingMessage::ChatMessage(ChatMessagePayload {
         participant_id: participant_id.to_string(),
+        user_id: user_id.map(ToString::to_string),
         display_name: display_name.to_string(),
         text: text.to_string(),
         timestamp: timestamp.to_string(),
@@ -28,6 +30,7 @@ pub fn build_history_response(rows: Vec<ChatMessageRow>) -> SignalingMessage {
         .map(|row| ChatHistoryMessagePayload {
             message_id: row.message_id.to_string(),
             participant_id: row.participant_id,
+            user_id: row.user_id,
             display_name: row.display_name,
             text: row.text,
             timestamp: row.created_at.to_rfc3339(),
@@ -69,7 +72,14 @@ mod tests {
     /// perform fallback — that responsibility belongs to the handler (ws.rs).
     #[test]
     fn empty_display_name_passed_through() {
-        let signals = handle_chat_send("hello", "peer-abc", "", "2025-01-15T10:30:00Z", "msg-001");
+        let signals = handle_chat_send(
+            "hello",
+            "peer-abc",
+            None,
+            "",
+            "2025-01-15T10:30:00Z",
+            "msg-001",
+        );
         assert_eq!(signals.len(), 1);
         match &signals[0].msg {
             SignalingMessage::ChatMessage(p) => {
@@ -80,6 +90,42 @@ mod tests {
                 assert_eq!(p.participant_id, "peer-abc");
             }
             other => panic!("expected ChatMessage, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn history_response_preserves_nullable_user_id() {
+        let created_at = chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let with_user = uuid::Uuid::new_v4();
+        let without_user = uuid::Uuid::new_v4();
+
+        let response = build_history_response(vec![
+            ChatMessageRow {
+                message_id: with_user,
+                participant_id: "peer-1".to_string(),
+                user_id: Some("user-1".to_string()),
+                display_name: "Alice".to_string(),
+                text: "hello".to_string(),
+                created_at,
+            },
+            ChatMessageRow {
+                message_id: without_user,
+                participant_id: "peer-2".to_string(),
+                user_id: None,
+                display_name: "Bob".to_string(),
+                text: "hi".to_string(),
+                created_at,
+            },
+        ]);
+
+        match response {
+            SignalingMessage::ChatHistoryResponse(payload) => {
+                assert_eq!(payload.messages[0].user_id.as_deref(), Some("user-1"));
+                assert_eq!(payload.messages[1].user_id, None);
+            }
+            other => panic!("expected ChatHistoryResponse, got {:?}", other),
         }
     }
 
@@ -95,7 +141,8 @@ mod tests {
             timestamp in arb_timestamp(),
             message_id in arb_nonempty_string(64),
         ) {
-            let signals = handle_chat_send(&text, &participant_id, &display_name, &timestamp, &message_id);
+            let user_id = Some("user-abc");
+            let signals = handle_chat_send(&text, &participant_id, user_id, &display_name, &timestamp, &message_id);
 
             // Exactly one signal returned.
             prop_assert_eq!(signals.len(), 1, "expected exactly 1 signal, got {}", signals.len());
@@ -112,6 +159,7 @@ mod tests {
             match &signal.msg {
                 SignalingMessage::ChatMessage(payload) => {
                     prop_assert_eq!(&payload.participant_id, &participant_id);
+                    prop_assert_eq!(payload.user_id.as_deref(), user_id);
                     prop_assert_eq!(&payload.display_name, &display_name);
                     prop_assert_eq!(&payload.text, &text);
                     prop_assert_eq!(&payload.timestamp, &timestamp);

--- a/wavis-backend/src/chat/chat_persistence.rs
+++ b/wavis-backend/src/chat/chat_persistence.rs
@@ -28,32 +28,39 @@ use uuid::Uuid;
 pub struct ChatMessageRow {
     pub message_id: Uuid,
     pub participant_id: String,
+    pub user_id: Option<String>,
     pub display_name: String,
     pub text: String,
     pub created_at: DateTime<Utc>,
 }
 
+pub struct InsertChatMessageParams<'a> {
+    pub message_id: Uuid,
+    pub channel_id: Option<Uuid>,
+    pub room_id: &'a str,
+    pub participant_id: &'a str,
+    pub user_id: Option<&'a str>,
+    pub display_name: &'a str,
+    pub text: &'a str,
+}
+
 /// Insert a chat message into Postgres. Best-effort — caller handles errors.
 pub async fn insert_chat_message(
     pool: &PgPool,
-    message_id: Uuid,
-    channel_id: Option<Uuid>,
-    room_id: &str,
-    participant_id: &str,
-    display_name: &str,
-    text: &str,
+    params: InsertChatMessageParams<'_>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO chat_messages (message_id, channel_id, room_id, \
-         participant_id, display_name, text) \
-         VALUES ($1, $2, $3, $4, $5, $6)",
+         participant_id, user_id, display_name, text) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
     )
-    .bind(message_id)
-    .bind(channel_id)
-    .bind(room_id)
-    .bind(participant_id)
-    .bind(display_name)
-    .bind(text)
+    .bind(params.message_id)
+    .bind(params.channel_id)
+    .bind(params.room_id)
+    .bind(params.participant_id)
+    .bind(params.user_id)
+    .bind(params.display_name)
+    .bind(params.text)
     .execute(pool)
     .await?;
     Ok(())
@@ -69,7 +76,7 @@ pub async fn fetch_history_by_channel(
     limit: i64,
 ) -> Result<Vec<ChatMessageRow>, sqlx::Error> {
     sqlx::query_as::<_, ChatMessageRow>(
-        "SELECT message_id, participant_id, display_name, text, created_at \
+        "SELECT message_id, participant_id, user_id, display_name, text, created_at \
          FROM chat_messages \
          WHERE channel_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2) \
          ORDER BY created_at ASC \
@@ -92,7 +99,7 @@ pub async fn fetch_history_by_room(
     limit: i64,
 ) -> Result<Vec<ChatMessageRow>, sqlx::Error> {
     sqlx::query_as::<_, ChatMessageRow>(
-        "SELECT message_id, participant_id, display_name, text, created_at \
+        "SELECT message_id, participant_id, user_id, display_name, text, created_at \
          FROM chat_messages \
          WHERE room_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2) \
          ORDER BY created_at ASC \
@@ -178,6 +185,7 @@ mod tests {
             arb_optional_channel_id(),                                      // channel_id
             arb_nonempty_string(100),                                       // room_id
             arb_nonempty_string(50),                                        // participant_id
+            prop::option::of(arb_nonempty_string(50)),                      // user_id
             arb_nonempty_string(50),                                        // display_name
             arb_chat_text(),                                                // text
         );
@@ -186,7 +194,7 @@ mod tests {
         runner
             .run(
                 &strategy,
-                |(message_id, channel_id, room_id, participant_id, display_name, text)| {
+                |(message_id, channel_id, room_id, participant_id, user_id, display_name, text)| {
                     let rt = tokio::runtime::Handle::current();
                     let pool = pool.clone();
                     rt.block_on(async {
@@ -194,12 +202,15 @@ mod tests {
 
                         insert_chat_message(
                             &pool,
-                            message_id,
-                            channel_id,
-                            &room_id,
-                            &participant_id,
-                            &display_name,
-                            &text,
+                            InsertChatMessageParams {
+                                message_id,
+                                channel_id,
+                                room_id: &room_id,
+                                participant_id: &participant_id,
+                                user_id: user_id.as_deref(),
+                                display_name: &display_name,
+                                text: &text,
+                            },
                         )
                         .await
                         .expect("insert should succeed");
@@ -225,6 +236,7 @@ mod tests {
 
                         // Verify all fields match
                         prop_assert_eq!(&row.participant_id, &participant_id);
+                        prop_assert_eq!(&row.user_id, &user_id);
                         prop_assert_eq!(&row.display_name, &display_name);
                         prop_assert_eq!(&row.text, &text);
 
@@ -315,12 +327,15 @@ mod tests {
                                 all_message_ids.push(mid);
                                 insert_chat_message(
                                     &pool,
-                                    mid,
-                                    Some(channel_id),
-                                    room_id,
-                                    participant_id,
-                                    display_name,
-                                    text,
+                                    InsertChatMessageParams {
+                                        message_id: mid,
+                                        channel_id: Some(channel_id),
+                                        room_id,
+                                        participant_id,
+                                        user_id: None,
+                                        display_name,
+                                        text,
+                                    },
                                 )
                                 .await
                                 .expect("insert should succeed");
@@ -366,12 +381,15 @@ mod tests {
                                     .push(mid);
                                 insert_chat_message(
                                     &pool,
-                                    mid,
-                                    None, // null channel_id
-                                    room_id,
-                                    participant_id,
-                                    display_name,
-                                    text,
+                                    InsertChatMessageParams {
+                                        message_id: mid,
+                                        channel_id: None,
+                                        room_id,
+                                        participant_id,
+                                        user_id: None,
+                                        display_name,
+                                        text,
+                                    },
                                 )
                                 .await
                                 .expect("insert should succeed");
@@ -472,12 +490,15 @@ mod tests {
                             let text = format!("msg-{}", i);
                             insert_chat_message(
                                 &pool,
-                                mid,
-                                channel_id,
-                                &room_id,
-                                &participant_id,
-                                &display_name,
-                                &text,
+                                InsertChatMessageParams {
+                                    message_id: mid,
+                                    channel_id,
+                                    room_id: &room_id,
+                                    participant_id: &participant_id,
+                                    user_id: None,
+                                    display_name: &display_name,
+                                    text: &text,
+                                },
                             )
                             .await
                             .expect("insert should succeed");
@@ -589,12 +610,15 @@ mod tests {
                             let text = format!("msg-{}", i);
                             insert_chat_message(
                                 &pool,
-                                mid,
-                                channel_id,
-                                &room_id,
-                                &participant_id,
-                                &display_name,
-                                &text,
+                                InsertChatMessageParams {
+                                    message_id: mid,
+                                    channel_id,
+                                    room_id: &room_id,
+                                    participant_id: &participant_id,
+                                    user_id: None,
+                                    display_name: &display_name,
+                                    text: &text,
+                                },
                             )
                             .await
                             .expect("insert should succeed");
@@ -714,12 +738,15 @@ mod tests {
                             let text = format!("msg-{}", i);
                             insert_chat_message(
                                 &pool,
-                                mid,
-                                None, // legacy room for simplicity
-                                &room_id,
-                                &participant_id,
-                                &display_name,
-                                &text,
+                                InsertChatMessageParams {
+                                    message_id: mid,
+                                    channel_id: None,
+                                    room_id: &room_id,
+                                    participant_id: &participant_id,
+                                    user_id: None,
+                                    display_name: &display_name,
+                                    text: &text,
+                                },
                             )
                             .await
                             .expect("insert should succeed");

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -2751,6 +2751,7 @@ pub(crate) async fn dispatch_message(
             let signals = chat::handle_chat_send(
                 &payload.text,
                 &session_ref.participant_id,
+                session_ref.user_id.as_deref(),
                 &display_name,
                 &timestamp,
                 &message_id.to_string(),
@@ -2770,17 +2771,21 @@ pub(crate) async fn dispatch_message(
                 .and_then(|cid| cid.parse::<Uuid>().ok());
             let room_id_clone = session_ref.room_id.clone();
             let participant_id_clone = session_ref.participant_id.clone();
+            let user_id_clone = session_ref.user_id.clone();
             let display_name_clone = display_name.clone();
             let text_clone = payload.text.clone();
             tokio::spawn(async move {
                 if let Err(e) = chat_persistence::insert_chat_message(
                     &db_pool,
-                    message_id,
-                    channel_id_uuid,
-                    &room_id_clone,
-                    &participant_id_clone,
-                    &display_name_clone,
-                    &text_clone,
+                    chat_persistence::InsertChatMessageParams {
+                        message_id,
+                        channel_id: channel_id_uuid,
+                        room_id: &room_id_clone,
+                        participant_id: &participant_id_clone,
+                        user_id: user_id_clone.as_deref(),
+                        display_name: &display_name_clone,
+                        text: &text_clone,
+                    },
                 )
                 .await
                 {


### PR DESCRIPTION
## Summary
- Resolve chat sender colors from current participant/profile color at render time
- Add optional chat userId propagation through signaling, persistence, and history
- Preserve legacy participantId and stored-color fallbacks

## Verification
- npm.cmd run build
- npm.cmd test
- cargo test --workspace
- cargo clippy --workspace -- -D warnings

## Privacy gate
- Staged/committed files were limited to implementation and migration files
- Untracked local files README copy.md and user-id-investigation.md were not committed