### PR TITLE
Pre dev

### DIFF
--- a/clients/wavis-gui/src/features/channels/ChannelSwitcherPanel.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelSwitcherPanel.tsx
@@ -1,0 +1,96 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { type Channel, fetchChannels } from './channels';
+import { fetchVoiceStatusWithFallback } from './channel-detail';
+import { ChannelRoleBadge } from './ChannelRoleBadge';
+import { usePolling } from '@shared/hooks/usePolling';
+
+const POLL_MS = 15_000;
+
+interface ChannelSwitcherPanelProps {
+  onChannelSelect: (ch: Channel) => void;
+  onClose: () => void;
+  currentChannelId?: string;
+}
+
+export function ChannelSwitcherPanel({ onChannelSelect, onClose, currentChannelId }: ChannelSwitcherPanelProps) {
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [voiceStatus, setVoiceStatus] = useState<Map<string, { active: boolean; participantCount: number }>>(new Map());
+  const requestInFlightRef = useRef(false);
+
+  const loadChannels = useCallback(async (showLoading: boolean) => {
+    if (showLoading) setLoading(true);
+    requestInFlightRef.current = true;
+    try {
+      const result = await fetchChannels();
+      setChannels(result);
+      const ids = result.map((ch) => ch.id);
+      fetchVoiceStatusWithFallback(ids).then((status) => {
+        setVoiceStatus(status);
+      }).catch(() => { /* silent */ });
+    } catch {
+      // silent — switcher is non-critical
+    } finally {
+      requestInFlightRef.current = false;
+      if (showLoading) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadChannels(true);
+  }, [loadChannels]);
+
+  usePolling(() => {
+    if (requestInFlightRef.current) return;
+    loadChannels(false);
+  }, POLL_MS);
+
+  return (
+    <div className="flex-1 flex flex-col min-h-0">
+      <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex items-center justify-between">
+        <div className="font-bold text-sm">CHANNELS</div>
+        <button
+          onClick={onClose}
+          className="text-wavis-text-secondary hover:text-wavis-text transition-colors text-xs px-1"
+          aria-label="Close channel switcher"
+        >[x]</button>
+      </div>
+      <div className="flex-1 overflow-y-auto p-3 space-y-1">
+        {loading && (
+          <div className="text-wavis-text-secondary text-xs">loading...</div>
+        )}
+        {!loading && channels.length === 0 && (
+          <div className="text-wavis-text-secondary text-xs">no channels</div>
+        )}
+        {!loading && channels.map((ch) => {
+          const isCurrent = ch.id === currentChannelId;
+          return (
+            <div
+              key={ch.id}
+              onClick={() => { if (!isCurrent) onChannelSelect(ch); }}
+              className={`flex items-center justify-between gap-3 px-3 py-2 border transition-colors cursor-pointer ${
+                isCurrent
+                  ? 'border-wavis-accent bg-wavis-accent/8 cursor-default'
+                  : 'border-wavis-text-secondary hover:border-wavis-accent'
+              }`}
+            >
+              <span className="min-w-0 truncate text-sm">{ch.name}</span>
+              <div className="flex items-center gap-2 shrink-0">
+                {voiceStatus.get(ch.id)?.active && (
+                  <span className="text-wavis-accent text-xs flex items-center gap-1">
+                    <span>●</span>
+                    <span>{voiceStatus.get(ch.id)?.participantCount}</span>
+                  </span>
+                )}
+                <ChannelRoleBadge role={ch.role} variant="list" />
+                {isCurrent && (
+                  <span className="text-wavis-accent text-[0.625rem]">current</span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/clients/wavis-gui/src/features/channels/ChannelsList.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelsList.tsx
@@ -18,6 +18,7 @@ import { ErrorPanel } from '@shared/ErrorPanel';
 import { EmptyState } from '@shared/EmptyState';
 import { LoadingBlock } from '@shared/LoadingBlock';
 import { usePolling } from '@shared/hooks/usePolling';
+import { setLastChannel } from '@features/settings/settings-store';
 
 /* Constants */
 const POLL_MS = 15_000;
@@ -233,7 +234,10 @@ export default function ChannelsList() {
               {channels.map((ch) => (
                 <div
                   key={ch.id}
-                  onClick={() => navigate('/room', { state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role } })}
+                  onClick={() => {
+                    void setLastChannel(ch.id, ch.name, ch.role);
+                    navigate('/room', { state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role } });
+                  }}
                   className="flex items-center justify-between gap-4 px-3 sm:px-4 py-3 bg-wavis-panel border border-wavis-text-secondary hover:border-wavis-accent transition-colors text-left mb-1 cursor-pointer"
                 >
                   <span className="min-w-0 truncate">{ch.name}</span>

--- a/clients/wavis-gui/src/features/channels/InitialRedirect.tsx
+++ b/clients/wavis-gui/src/features/channels/InitialRedirect.tsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { getLastChannel } from '@features/settings/settings-store';
+import ChannelsList from './ChannelsList';
+
+/**
+ * Index route component that redirects returning users to their last channel's
+ * room view. New users (no stored channel) see the ChannelsList as before.
+ */
+export default function InitialRedirect() {
+  const navigate = useNavigate();
+  const [showChannelsList, setShowChannelsList] = useState(false);
+
+  useEffect(() => {
+    getLastChannel().then((ch) => {
+      if (ch) {
+        navigate('/room', {
+          state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role },
+          replace: true,
+        });
+      } else {
+        setShowChannelsList(true);
+      }
+    });
+  }, [navigate]);
+
+  if (!showChannelsList) return null;
+  return <ChannelsList />;
+}

--- a/clients/wavis-gui/src/features/settings/settings-store.ts
+++ b/clients/wavis-gui/src/features/settings/settings-store.ts
@@ -8,6 +8,7 @@
 
 import { load } from '@tauri-apps/plugin-store';
 import { PROFILE_COLORS } from '@shared/colors';
+import type { ChannelRole } from '@features/channels/channels';
 
 // ─── Types ─────────────────────────────────────────────────────────
 
@@ -57,6 +58,9 @@ export const STORE_KEYS = {
   notificationVolume: 'wavis_notification_volume',
   soundVolumes: 'wavis_notification_sound_volumes',
   inputVolume: 'wavis_input_volume',
+  lastChannelId: 'wavis_last_channel_id',
+  lastChannelName: 'wavis_last_channel_name',
+  lastChannelRole: 'wavis_last_channel_role',
 } as const;
 
 export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
@@ -288,4 +292,32 @@ export async function setChannelVolumes(channelId: string, prefs: ChannelVolumeP
   const all = await getStoreValue<Record<string, ChannelVolumePrefs>>(STORE_KEYS.channelVolumes, {});
   all[channelId] = prefs;
   return setStoreValue(STORE_KEYS.channelVolumes, all);
+}
+
+// ─── Last Channel (hub redirect) ───────────────────────────────────
+
+export async function getLastChannel(): Promise<{ id: string; name: string; role: ChannelRole } | null> {
+  const [id, name, role] = await Promise.all([
+    getStoreValue<string | null>(STORE_KEYS.lastChannelId, null),
+    getStoreValue<string | null>(STORE_KEYS.lastChannelName, null),
+    getStoreValue<string | null>(STORE_KEYS.lastChannelRole, null),
+  ]);
+  if (!id || !name || !role) return null;
+  return { id, name, role: role as ChannelRole };
+}
+
+export async function setLastChannel(id: string, name: string, role: ChannelRole): Promise<void> {
+  await Promise.all([
+    setStoreValue(STORE_KEYS.lastChannelId, id),
+    setStoreValue(STORE_KEYS.lastChannelName, name),
+    setStoreValue(STORE_KEYS.lastChannelRole, role),
+  ]);
+}
+
+export async function clearLastChannel(): Promise<void> {
+  await Promise.all([
+    setStoreValue(STORE_KEYS.lastChannelId, null),
+    setStoreValue(STORE_KEYS.lastChannelName, null),
+    setStoreValue(STORE_KEYS.lastChannelRole, null),
+  ]);
 }

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import { useBlocker, useLocation, useNavigate } from 'react-router';
 import type { ChannelRole } from '@features/channels/channels';
+import type { Channel } from '@features/channels/channels';
+import { ChannelSwitcherPanel } from '@features/channels/ChannelSwitcherPanel';
 import type {
   VoiceRoomState,
   VoiceRoomMachineState,
@@ -59,6 +61,7 @@ import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { startSending, stopSending, stopSendingForWindow, stopAllSending, resendStream } from '@features/screen-share/screen-share-viewer';
 import { getWatchAllHotkey } from '@features/settings/settings-store';
+import { setLastChannel, clearLastChannel } from '@features/settings/settings-store';
 
 const DEBUG_SHARE_VIEW = import.meta.env.VITE_DEBUG_SCREEN_SHARE_VIEW === 'true';
 const DEBUG_SHARE_AUDIO = import.meta.env.VITE_DEBUG_SHARE_AUDIO === 'true';
@@ -273,7 +276,7 @@ export default function ActiveRoom() {
   const [roomState, setRoomState] = useState<VoiceRoomState | null>(null);
   const [countdownNowMs, setCountdownNowMs] = useState(() => Date.now());
 
-  const [leaving, setLeaving] = useState(false);
+  const [, setLeaving] = useState(false);
   const [cliInput, setCliInput] = useState('');
   const [chatInput, setChatInput] = useState('');
   const logEndRef = useRef<HTMLDivElement>(null);
@@ -311,6 +314,7 @@ export default function ActiveRoom() {
   const cliDraftRef = useRef('');
 
   const [showSettings, setShowSettings] = useState(false);
+  const [channelSwitcherOpen, setChannelSwitcherOpen] = useState(false);
 
   // Transient chat error display (auto-dismiss after 5s)
   const [chatError, setChatError] = useState<string | null>(null);
@@ -457,6 +461,13 @@ export default function ActiveRoom() {
       if (chatErrorTimerRef.current) clearTimeout(chatErrorTimerRef.current);
     };
   }, []);
+
+  // Clear persisted last channel when kicked (so next launch falls back to ChannelsList)
+  useEffect(() => {
+    if (roomState?.error === 'You were kicked') {
+      void clearLastChannel();
+    }
+  }, [roomState?.error]);
 
   // Tray event wiring: dispatch tray menu actions to voice room
   useEffect(() => {
@@ -1717,7 +1728,7 @@ export default function ActiveRoom() {
             <div className="text-wavis-danger mb-4">{roomState.error}</div>
             <div className="flex gap-4 justify-center">
               <button className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast" onClick={() => { initRef.current = false; initSession(channelId, channelName, channelRole, setRoomState); initRef.current = true; }}>/retry</button>
-              <button className="text-xs text-wavis-danger border border-wavis-danger py-0.5 px-1 text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg" onClick={() => navigateAwayFromRoom('/', true)}>/leave</button>
+              <button className="text-xs text-wavis-danger border border-wavis-danger py-0.5 px-1 text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg" onClick={() => { void clearLastChannel(); navigateAwayFromRoom('/', true); }}>/leave</button>
             </div>
           </div>
         </div>
@@ -1728,8 +1739,12 @@ export default function ActiveRoom() {
   // Kicked state
   if (roomState.error === 'You were kicked') {
     return (
-      <div className="h-full flex items-center justify-center bg-wavis-bg font-mono text-wavis-danger">
-        you were kicked from the room
+      <div className="h-full flex flex-col items-center justify-center bg-wavis-bg font-mono text-wavis-danger gap-4">
+        <span>you were kicked from the room</span>
+        <button
+          className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast"
+          onClick={() => navigateAwayFromRoom('/', false)}
+        >/back</button>
       </div>
     );
   }
@@ -1738,6 +1753,14 @@ export default function ActiveRoom() {
   const handleLeave = () => {
     setLeaving(true);
     navigateAwayFromRoom('/', true);
+  };
+
+  const handleChannelSwitch = async (ch: Channel) => {
+    await setLastChannel(ch.id, ch.name, ch.role);
+    setChannelSwitcherOpen(false);
+    allowNavigationRef.current = true;
+    leaveRoom();
+    navigate('/room', { state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role } });
   };
 
   const handleSendChat = () => {
@@ -1900,25 +1923,36 @@ export default function ActiveRoom() {
   const statusBadge = combinedStatusBadge(roomState.machineState, roomState.mediaState);
 
   const roomHeader = (
-    <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex flex-col justify-center gap-0.5 overflow-hidden">
-      <div className="flex items-center gap-2">
-        <StatusDot color={sigDot.color} label={sigDot.label} />
-        <StatusDot color={mediaDot.color} label={mediaDot.label} />
-        {(() => {
-          const badge = connectionModeBadgeText(showSecrets, roomState.connectionMode);
-          return badge ? <span className="text-[0.625rem] text-wavis-purple">[{badge}]</span> : null;
-        })()}
-        <span className="text-sm" style={{ color: statusBadge.color }}>{statusBadge.text}</span>
-        <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.participants.length}/6</span>
-        <span className="text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
-        <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.networkStats.packetLossPercent.toFixed(1)}% loss</span>
+    <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex items-center gap-3 overflow-hidden">
+      <div className="flex-1 flex flex-col justify-center gap-0.5 min-w-0">
+        <div className="flex items-center gap-2">
+          <StatusDot color={sigDot.color} label={sigDot.label} />
+          <StatusDot color={mediaDot.color} label={mediaDot.label} />
+          {(() => {
+            const badge = connectionModeBadgeText(showSecrets, roomState.connectionMode);
+            return badge ? <span className="text-[0.625rem] text-wavis-purple">[{badge}]</span> : null;
+          })()}
+          <span className="text-sm" style={{ color: statusBadge.color }}>{statusBadge.text}</span>
+          <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.participants.length}/6</span>
+          <span className="text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
+          <span className="text-[0.625rem] text-wavis-text-secondary">{roomState.networkStats.packetLossPercent.toFixed(1)}% loss</span>
+        </div>
+        <div
+          className={`font-bold truncate min-w-0${roomState.channelName.length > 20 ? ' text-xs' : ' text-sm'}`}
+          title={roomState.channelName}
+        >
+          {roomState.channelName}
+        </div>
       </div>
-      <div
-        className={`font-bold truncate min-w-0${roomState.channelName.length > 20 ? ' text-xs' : ' text-sm'}`}
-        title={roomState.channelName}
-      >
-        {roomState.channelName}
-      </div>
+      <button
+        onClick={() => setChannelSwitcherOpen((v) => !v)}
+        className={`shrink-0 border px-2 py-1 text-xs transition-colors ${
+          channelSwitcherOpen
+            ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
+            : 'border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent'
+        }`}
+        title="Change channel"
+      >{channelSwitcherOpen ? '<' : '>'}</button>
     </div>
   );
 
@@ -2360,7 +2394,6 @@ export default function ActiveRoom() {
             })()}
             <div className="mt-4 flex flex-col gap-1">
               <button onClick={() => setShowSettings(true)} className="w-full text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-xs text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast">/settings</button>
-              <button onClick={handleLeave} disabled={leaving} className="w-full text-wavis-danger border border-wavis-danger py-0.5 px-1 text-xs text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg disabled:opacity-40 disabled:cursor-not-allowed">{leaving ? 'leaving...' : '/leave'}</button>
             </div>
           </div>
         </div>
@@ -2521,13 +2554,21 @@ export default function ActiveRoom() {
             <span className="shrink-0 text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
           </div>
           <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={() => setChannelSwitcherOpen((v) => !v)}
+              className={`px-2 py-1.5 border text-[0.625rem] transition-colors ${
+                channelSwitcherOpen
+                  ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
+                  : 'border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent'
+              }`}
+              title="Change channel"
+            >{channelSwitcherOpen ? '<' : '>'}</button>
             <button onClick={toggleSelfMute} disabled={selfP?.isHostMuted} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center disabled:opacity-40 disabled:cursor-not-allowed ${selfP?.isMuted ? 'border-wavis-danger text-wavis-danger bg-wavis-danger/8 hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
               {selfP?.isMuted ? '/unmute' : '/mute'}
             </button>
             <button onClick={toggleSelfDeafen} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center ${roomState.isDeafened ? 'border-wavis-purple text-wavis-purple hover:bg-wavis-purple hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
               {roomState.isDeafened ? '/undeafen' : '/deafen'}
             </button>
-            <button onClick={handleLeave} className="px-2 py-1.5 border border-wavis-danger text-wavis-danger text-[0.625rem] transition-colors text-center hover:bg-wavis-danger hover:text-wavis-bg">/leave</button>
           </div>
         </div>
 
@@ -2555,6 +2596,12 @@ export default function ActiveRoom() {
         <div className="flex-1 flex flex-col min-h-0 overflow-hidden">
           {showSettings ? (
             <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} />
+          ) : channelSwitcherOpen ? (
+            <ChannelSwitcherPanel
+              onChannelSelect={handleChannelSwitch}
+              onClose={() => setChannelSwitcherOpen(false)}
+              currentChannelId={channelId}
+            />
           ) : (
             <>
               {mobileTab === 'participants' && <div className="flex flex-col flex-1 min-h-0">{participantsSections}{youBar}</div>}
@@ -2575,7 +2622,13 @@ export default function ActiveRoom() {
           {youBar}
         </div>
         <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
-          {showSettings ? <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} /> : chatPanel}
+          {showSettings ? <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} /> : channelSwitcherOpen ? (
+            <ChannelSwitcherPanel
+              onChannelSelect={handleChannelSwitch}
+              onClose={() => setChannelSwitcherOpen(false)}
+              currentChannelId={channelId}
+            />
+          ) : chatPanel}
         </div>
         <div className="w-80 border-l border-wavis-text-secondary flex flex-col">
           {logPanel}

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { type ReactNode, useState, useEffect, useRef, useCallback } from 'react';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import { useBlocker, useLocation, useNavigate } from 'react-router';
 import type { ChannelRole } from '@features/channels/channels';
@@ -56,6 +56,7 @@ import type { OccupiedSlots } from '@features/screen-share/SharePicker';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { LogicalSize } from '@tauri-apps/api/dpi';
+import { open } from '@tauri-apps/plugin-shell';
 import { Tooltip, TooltipTrigger, TooltipContent } from '../../components/ui/tooltip';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
@@ -142,6 +143,54 @@ function formatTime(isoString: string): string {
   } catch {
     return '??:??:??';
   }
+}
+
+const CHAT_LINK_RE = /(https?:\/\/[^\s<]+|www\.[^\s<]+)/gi;
+const TRAILING_LINK_PUNCTUATION_RE = /[.,!?;:)\]]+$/;
+
+function normalizeChatLink(raw: string): string {
+  return raw.toLowerCase().startsWith('www.') ? `https://${raw}` : raw;
+}
+
+function splitChatLink(raw: string): { hrefText: string; trailingText: string } {
+  const trailingText = raw.match(TRAILING_LINK_PUNCTUATION_RE)?.[0] ?? '';
+  return trailingText
+    ? { hrefText: raw.slice(0, -trailingText.length), trailingText }
+    : { hrefText: raw, trailingText: '' };
+}
+
+function renderChatText(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(CHAT_LINK_RE)) {
+    const raw = match[0];
+    const index = match.index ?? 0;
+    if (index > lastIndex) nodes.push(text.slice(lastIndex, index));
+
+    const { hrefText, trailingText } = splitChatLink(raw);
+    const href = normalizeChatLink(hrefText);
+    nodes.push(
+      <a
+        key={`link-${index}-${hrefText}`}
+        href={href}
+        className="text-wavis-accent underline underline-offset-2 break-all hover:opacity-80"
+        onClick={(event) => {
+          event.preventDefault();
+          void open(href);
+        }}
+        rel="noreferrer"
+        title={href}
+      >
+        {hrefText}
+      </a>,
+    );
+    if (trailingText) nodes.push(trailingText);
+    lastIndex = index + raw.length;
+  }
+
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
+  return nodes;
 }
 
 function getUserColor(participants: RoomParticipant[], participantId?: string): string {
@@ -1993,7 +2042,6 @@ export default function ActiveRoom() {
           style={{ cursor: isSelf ? 'default' : 'pointer' }}
         >
           {isSelf ? <span className="text-xs text-wavis-accent inline-block w-6 text-center flex-none">&gt;</span> : <span className="text-[0.625rem] text-wavis-text-secondary inline-block w-6 text-center flex-none">{expandedUser === p.id ? '[-]' : '[+]'}</span>}
-          {p.role === 'host' && <span className="text-xs text-wavis-text-secondary">[HOST]</span>}
           <span style={{
             color: p.color,
             animation: p.isSpeaking && !p.isMuted ? 'pulse 3s ease-in-out infinite' : 'none',
@@ -2057,14 +2105,14 @@ export default function ActiveRoom() {
               </div>
             )}
             {isHost && (
-              <>
-                <button onClick={() => kickParticipant(p.id)} className="block w-full text-left border border-wavis-danger text-wavis-danger px-3 py-2 transition-colors hover:opacity-70">/kick {p.displayName}</button>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <button onClick={() => kickParticipant(p.id)} className="text-xs text-center border border-wavis-danger text-wavis-danger px-1 py-0.5 transition-colors hover:opacity-70">/kick</button>
                 {p.isHostMuted
-                  ? <button onClick={() => unmuteParticipant(p.id)} className="block w-full text-left border border-wavis-accent text-wavis-accent px-3 py-2 transition-colors hover:opacity-70">/unmute {p.displayName}</button>
-                  : !p.isMuted && <button onClick={() => muteParticipant(p.id)} className="block w-full text-left border px-3 py-2 transition-colors hover:opacity-70" style={{ color: 'var(--wavis-warn)', borderColor: 'var(--wavis-warn)' }}>/mute {p.displayName}</button>
+                  ? <button onClick={() => unmuteParticipant(p.id)} className="text-xs text-center border border-wavis-accent text-wavis-accent px-1 py-0.5 transition-colors hover:opacity-70">/unmute</button>
+                  : !p.isMuted && <button onClick={() => muteParticipant(p.id)} className="text-xs text-center border px-1 py-0.5 transition-colors hover:opacity-70" style={{ color: 'var(--wavis-warn)', borderColor: 'var(--wavis-warn)' }}>/mute</button>
                 }
-                {p.isSharing && <button onClick={() => stopParticipantShare(p.id)} className="block w-full text-left border border-wavis-danger text-wavis-danger px-3 py-2 transition-colors hover:opacity-70">/revoke {p.displayName}</button>}
-              </>
+                {p.isSharing && <button onClick={() => stopParticipantShare(p.id)} className="text-xs text-center border border-wavis-danger text-wavis-danger px-1 py-0.5 transition-colors hover:opacity-70">/revoke</button>}
+              </div>
             )}
           </div>
         )}
@@ -2270,7 +2318,6 @@ export default function ActiveRoom() {
         </button>
         <button onClick={() => toggleSection('you')} className="bg-transparent outline-none py-1 px-1 text-left flex items-center gap-2 hover:opacity-80">
           <span style={{ color: selfP?.color }}>{selfP?.displayName}</span>
-          {selfP?.role === 'host' && <span className="text-[0.625rem] text-wavis-text-secondary">[HOST]</span>}
         </button>
         {!expandedSections.you && (
           <div className="ml-auto flex items-center leading-none text-xs">
@@ -2455,7 +2502,7 @@ export default function ActiveRoom() {
             <div key={item.message.id} className="break-all">
               <span className="text-wavis-text-secondary">[{formatTime(item.message.timestamp)}]</span>{' '}
               <span style={{ color: item.message.color }}>{item.message.displayName}</span>
-              <span>: {item.message.text}</span>
+              <span>: {renderChatText(item.message.text)}</span>
             </div>
           )
         )}
@@ -2545,30 +2592,13 @@ export default function ActiveRoom() {
       {/* ═══ MOBILE LAYOUT (< md) ═══ */}
       <div className="flex flex-col flex-1 overflow-hidden md:hidden">
         {/* Compact header */}
-        <div className="flex items-center justify-between px-3 py-2 border-b border-wavis-text-secondary bg-wavis-panel">
+        <div className="flex items-center px-3 py-2 border-b border-wavis-text-secondary bg-wavis-panel">
           <div className="flex items-center gap-2 min-w-0">
             <StatusDot color={sigDot.color} label={sigDot.label} />
             <StatusDot color={mediaDot.color} label={mediaDot.label} />
             <span className="truncate text-sm">{roomState.channelName}</span>
             <span className="shrink-0 text-[0.625rem] text-wavis-text-secondary">{roomState.participants.length}/6</span>
             <span className="shrink-0 text-[0.625rem]" style={{ color: rttColor(roomState.networkStats.rttMs) }}>{roomState.networkStats.rttMs}ms</span>
-          </div>
-          <div className="flex items-center gap-2 shrink-0">
-            <button
-              onClick={() => setChannelSwitcherOpen((v) => !v)}
-              className={`px-2 py-1.5 border text-[0.625rem] transition-colors ${
-                channelSwitcherOpen
-                  ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
-                  : 'border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent'
-              }`}
-              title="Change channel"
-            >{channelSwitcherOpen ? '<' : '>'}</button>
-            <button onClick={toggleSelfMute} disabled={selfP?.isHostMuted} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center disabled:opacity-40 disabled:cursor-not-allowed ${selfP?.isMuted ? 'border-wavis-danger text-wavis-danger bg-wavis-danger/8 hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
-              {selfP?.isMuted ? '/unmute' : '/mute'}
-            </button>
-            <button onClick={toggleSelfDeafen} className={`px-2 py-1.5 border text-[0.625rem] transition-colors text-center ${roomState.isDeafened ? 'border-wavis-purple text-wavis-purple hover:bg-wavis-purple hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>
-              {roomState.isDeafened ? '/undeafen' : '/deafen'}
-            </button>
           </div>
         </div>
 

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -50,6 +50,7 @@ import {
   startPortalShare,
   setPendingSharePickerData,
   buildChatDisplayItems,
+  resolveChatMessageDisplayColor,
 } from './voice-room';
 import type { ShareSelection, EnumerationResult } from '@features/screen-share/share-types';
 import type { OccupiedSlots } from '@features/screen-share/SharePicker';
@@ -2501,7 +2502,7 @@ export default function ActiveRoom() {
           ) : (
             <div key={item.message.id} className="break-all">
               <span className="text-wavis-text-secondary">[{formatTime(item.message.timestamp)}]</span>{' '}
-              <span style={{ color: item.message.color }}>{item.message.displayName}</span>
+              <span style={{ color: resolveChatMessageDisplayColor(item.message, roomState.participants) }}>{item.message.displayName}</span>
               <span>: {renderChatText(item.message.text)}</span>
             </div>
           )

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -29,6 +29,9 @@ let messageHandler: ((msg: unknown) => void) | null;
 /** The status change handler registered via client.onStatusChange(). */
 let statusChangeHandler: ((status: string) => void) | null;
 
+/** The most recently created mock SignalingClient instance. */
+let lastSignalingClient: Record<string, unknown> | null;
+
 /** Whether connectWithAuth should reject. */
 let connectShouldFail: boolean;
 let playNotificationSoundCalls: string[];
@@ -110,6 +113,7 @@ vi.mock('../livekit-media', () => ({
 
 vi.mock('@shared/websocket', () => ({
   SignalingClient: vi.fn(function (this: Record<string, unknown>) {
+    lastSignalingClient = this;
     this.status = 'disconnected';
     this.send = vi.fn((msg: Record<string, unknown>) => { sentMessages.push(msg); });
     this.onMessage = vi.fn((handler: (msg: unknown) => void) => {
@@ -239,6 +243,7 @@ function resetAll() {
   sentMessages = [];
   messageHandler = null;
   statusChangeHandler = null;
+  lastSignalingClient = null;
   connectShouldFail = false;
   mockMaxRetries = 10;
   playNotificationSoundCalls = [];
@@ -876,7 +881,7 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
     expect(playNotificationSoundCalls).toEqual(['join']);
   });
 
-  it('does not play leave sound for explicit whole-session leave', async () => {
+  it('plays leave sound for explicit whole-session leave', async () => {
     await driveToActive('ch-sounds', 'room-sounds');
 
     messageHandler!({
@@ -890,8 +895,73 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
 
     leaveRoom();
 
-    expect(playNotificationSoundCalls).toEqual([]);
+    expect(playNotificationSoundCalls).toEqual(['leave']);
     expect(sentMessages).toContainEqual({ type: 'leave' });
+  });
+
+  it('plays one leave sound when the local participant is kicked', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    messageHandler!({
+      type: 'participant_kicked',
+      participantId: 'self-peer',
+    });
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('plays one leave sound when the local session is displaced', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    messageHandler!({ type: 'session_displaced' });
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('plays one leave sound when signaling reconnect exhaustion ends an active session', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    statusChangeHandler!('disconnected');
+    await tick();
+    expect(getState().machineState).toBe('reconnecting');
+
+    if (lastSignalingClient) {
+      lastSignalingClient.status = 'disconnected';
+      lastSignalingClient.reconnectTimer = null;
+      lastSignalingClient.periodicRetryTimer = null;
+    }
+    statusChangeHandler!('disconnected');
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('does not play leave sound for initial connection failure before room membership', async () => {
+    connectShouldFail = true;
+    initSession('ch-sounds', 'room-sounds', 'owner', (s) => { latestState = s; });
+    await tick();
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual([]);
+    expect(getState().machineState).toBe('idle');
+  });
+
+  it('plays one leave sound when duplicate terminal paths arrive for the same session', async () => {
+    await driveToActive('ch-sounds', 'room-sounds');
+
+    messageHandler!({
+      type: 'participant_kicked',
+      participantId: 'self-peer',
+    });
+    messageHandler!({ type: 'session_displaced' });
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual(['leave']);
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room.test.ts
@@ -438,6 +438,7 @@ import {
   computeSinceCursor,
   buildChatDisplayItems,
   shouldPlayChatNotification,
+  resolveChatMessageDisplayColor,
 } from '../voice-room';
 import type { ChatMessage } from '../voice-room';
 
@@ -559,6 +560,18 @@ describe('Property 6: Receive appends with 200-message cap', () => {
 // **Validates: Requirements 3.2**
 
 describe('Property 7: Color resolution from participant list', () => {
+  const message = (overrides: Partial<ChatMessage> = {}): ChatMessage => ({
+    id: 'msg-1',
+    messageId: 'message-1',
+    timestamp: '2026-05-05T00:00:00Z',
+    participantId: 'peer-1',
+    userId: undefined,
+    displayName: 'Alice',
+    color: '#123456',
+    text: 'hello',
+    ...overrides,
+  });
+
   it('when participantId matches a participant, color equals that participant color', () => {
     fc.assert(
       fc.property(
@@ -580,9 +593,10 @@ describe('Property 7: Color resolution from participant list', () => {
               volume: 70,
             },
           ];
-          // Simulate the color resolution logic from dispatchMessage
-          const participant = participants.find((p) => p.id === peerId);
-          const resolvedColor = participant?.color ?? '';
+          const resolvedColor = resolveChatMessageDisplayColor(
+            message({ participantId: peerId, color: TERMINAL_COLORS[0] }),
+            participants,
+          );
           expect(resolvedColor).toBe(TERMINAL_COLORS[colorIdx]);
         },
       ),
@@ -590,7 +604,7 @@ describe('Property 7: Color resolution from participant list', () => {
     );
   });
 
-  it('when participantId not found, color is empty string', () => {
+  it('uses stored message color when no current participant matches', () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 1, maxLength: 20 }),
@@ -612,12 +626,102 @@ describe('Property 7: Color resolution from participant list', () => {
           ];
           // Only test when unknownId differs from the known peer
           if (unknownId === 'known-peer') return;
-          const participant = participants.find((p) => p.id === unknownId);
-          const resolvedColor = participant?.color ?? '';
-          expect(resolvedColor).toBe('');
+          const resolvedColor = resolveChatMessageDisplayColor(
+            message({ participantId: unknownId, color: '#ABCDEF' }),
+            participants,
+          );
+          expect(resolvedColor).toBe('#ABCDEF');
         },
       ),
       { numRuns: 100 },
+    );
+  });
+
+  it('messages recolor when a matching participant color changes', () => {
+    const chatMessage = message({ participantId: 'peer-1', color: '#111111' });
+    const before: RoomParticipant[] = [{
+      id: 'peer-1',
+      displayName: 'Alice',
+      color: '#222222',
+      role: 'guest',
+      isSpeaking: false,
+      isMuted: false,
+      isHostMuted: false,
+      isDeafened: false,
+      isSharing: false,
+      rmsLevel: 0,
+      volume: 70,
+    }];
+    const after = before.map((p) => ({ ...p, color: '#333333' }));
+
+    expect(resolveChatMessageDisplayColor(chatMessage, before)).toBe('#222222');
+    expect(resolveChatMessageDisplayColor(chatMessage, after)).toBe('#333333');
+  });
+
+  it('userId match takes precedence over stale participantId', () => {
+    const participants: RoomParticipant[] = [
+      {
+        id: 'old-peer',
+        userId: 'someone-else',
+        displayName: 'Stale',
+        color: '#111111',
+        role: 'guest',
+        isSpeaking: false,
+        isMuted: false,
+        isHostMuted: false,
+        isDeafened: false,
+        isSharing: false,
+        rmsLevel: 0,
+        volume: 70,
+      },
+      {
+        id: 'new-peer',
+        userId: 'user-1',
+        displayName: 'Alice',
+        color: '#44AA88',
+        role: 'guest',
+        isSpeaking: false,
+        isMuted: false,
+        isHostMuted: false,
+        isDeafened: false,
+        isSharing: false,
+        rmsLevel: 0,
+        volume: 70,
+      },
+    ];
+
+    expect(resolveChatMessageDisplayColor(
+      message({ participantId: 'old-peer', userId: 'user-1', color: '#999999' }),
+      participants,
+    )).toBe('#44AA88');
+  });
+
+  it('legacy messages without userId still recolor by participantId', () => {
+    const participants: RoomParticipant[] = [{
+      id: 'legacy-peer',
+      displayName: 'Legacy',
+      color: '#AA7744',
+      role: 'guest',
+      isSpeaking: false,
+      isMuted: false,
+      isHostMuted: false,
+      isDeafened: false,
+      isSharing: false,
+      rmsLevel: 0,
+      volume: 70,
+    }];
+
+    expect(resolveChatMessageDisplayColor(
+      message({ participantId: 'legacy-peer', userId: undefined, color: '#999999' }),
+      participants,
+    )).toBe('#AA7744');
+  });
+
+  it('hash fallback is stable when no participant and no stored color match', () => {
+    const chatMessage = message({ participantId: 'peer-fallback', userId: 'user-fallback', color: '' });
+
+    expect(resolveChatMessageDisplayColor(chatMessage, [])).toBe(
+      colorFor({ userId: 'user-fallback', id: 'peer-fallback' }),
     );
   });
 });
@@ -1018,6 +1122,23 @@ describe('Property 6: Client merge, dedup, and cap', () => {
       }),
       { numRuns: 100 },
     );
+  });
+
+  it('history merge preserves optional userId', () => {
+    const merged = mergeHistoryMessages(
+      [{
+        messageId: 'history-1',
+        participantId: 'old-peer',
+        userId: 'user-1',
+        displayName: 'Alice',
+        text: 'from history',
+        timestamp: '2026-05-05T00:00:00Z',
+      }],
+      [],
+    );
+
+    expect(merged[0].userId).toBe('user-1');
+    expect(merged[0].color).toBe(colorFor({ userId: 'user-1', id: 'old-peer' }));
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -949,6 +949,8 @@ const MAX_AUTH_REFRESH_RETRIES = 2;
 let authRefreshRetries = 0;
 let wasReconnecting = false;
 let unsubTokenRefresh: (() => void) | null = null;
+let localSessionJoined = false;
+let localDisconnectSoundPlayed = false;
 // TODO: proactiveReconnecting flag — wire into onStatusChange to suppress
 // the "already reconnecting → connection lost" path during token-refresh reconnects.
 
@@ -957,6 +959,19 @@ let unsubTokenRefresh: (() => void) | null = null;
  * late-arriving events (share_stopped, etc.) can still resolve display names.
  */
 const displayNameCache = new Map<string, string>();
+
+function playLocalDisconnectSoundOnce(): void {
+  const wasInLocalSession =
+    localSessionJoined ||
+    !!state.selfParticipantId ||
+    !!state.roomId ||
+    state.machineState === 'active' ||
+    state.machineState === 'reconnecting';
+
+  if (!wasInLocalSession || localDisconnectSoundPlayed) return;
+  localDisconnectSoundPlayed = true;
+  void playNotificationSound('leave');
+}
 
 /* ─── Share Picker Data (Tauri event handshake) ─────────────────── */
 
@@ -1565,6 +1580,7 @@ function dispatchMessage(raw: unknown): void {
           if (result.status !== 'success' || !client) {
             console.warn(LOG, 'token refresh failed after auth_failed:', result.status);
             state.error = (msg.reason as string) || 'Authentication failed';
+            playLocalDisconnectSoundOnce();
             state.machineState = 'idle';
             notify();
             return;
@@ -1574,6 +1590,7 @@ function dispatchMessage(raw: unknown): void {
             client.reconnectWithNewToken(toWsUrl(serverUrl)).catch((err) => {
               console.error(LOG, 'reconnect after refresh failed:', err);
               state.error = 'Authentication failed';
+              playLocalDisconnectSoundOnce();
               state.machineState = 'idle';
               notify();
             });
@@ -1586,17 +1603,23 @@ function dispatchMessage(raw: unknown): void {
       if (client) {
         client.disconnect();
       }
+      playLocalDisconnectSoundOnce();
       state.machineState = 'idle';
       notify();
       break;
     }
 
     case 'joined': {
+      const joinedActiveSession = state.machineState !== 'idle';
       stopColdStartRetry();
       state.serverStartingEstimatedWaitSecs = null;
       state.lastRateLimitError = null;
       state.selfParticipantId = msg.peerId as string;
       state.roomId = msg.roomId as string;
+      if (joinedActiveSession) {
+        localSessionJoined = true;
+        localDisconnectSoundPlayed = false;
+      }
       syncDerivedSubRoomState();
       syncDesiredSubRoomPreference();
       state.sharePermission = (msg.sharePermission as string) === 'host_only' ? 'host_only' : 'anyone';
@@ -1677,6 +1700,7 @@ function dispatchMessage(raw: unknown): void {
       console.warn(LOG, `join_rejected reason=${rawReason} channelId=${state.channelId}`);
       if (state.machineState === 'server_starting') {
         stopColdStartRetry();
+        playLocalDisconnectSoundOnce();
         state.machineState = 'idle';
         state.serverStartingEstimatedWaitSecs = null;
         state.rejectionReason = (msg.reason as string) || 'Server failed to start';
@@ -1697,6 +1721,7 @@ function dispatchMessage(raw: unknown): void {
         client.disconnect();
       }
       client = null;
+      playLocalDisconnectSoundOnce();
       state.machineState = 'idle';
       notify();
       break;
@@ -1963,6 +1988,7 @@ function dispatchMessage(raw: unknown): void {
           client.disconnect();
         }
         client = null;
+        playLocalDisconnectSoundOnce();
         state.machineState = 'idle';
       }
       notify();
@@ -1990,6 +2016,7 @@ function dispatchMessage(raw: unknown): void {
         client.disconnect();
       }
       client = null;
+      playLocalDisconnectSoundOnce();
       state.machineState = 'idle';
       stopColdStartRetry();
       stopPeriodicMediaRetry();
@@ -2423,6 +2450,8 @@ export function initSession(
     machineState: 'connecting',
     screenShareStreams: new Map(),
   };
+  localSessionJoined = false;
+  localDisconnectSoundPlayed = false;
   desiredSubRoomIntent = undefined;
 
   // Push initial state to the component
@@ -2479,6 +2508,7 @@ export function initSession(
           appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'system', message: 'signaling reconnect failed — session lost' });
           state.error = 'Connection lost';
           state.lastRateLimitError = null;
+          playLocalDisconnectSoundOnce();
           state.machineState = 'idle';
           notify();
         }
@@ -2513,6 +2543,7 @@ export function initSession(
         console.error(LOG, 'connect failed:', err);
         if (client !== thisClient) return;
         state.error = 'Connection failed';
+        playLocalDisconnectSoundOnce();
         state.machineState = 'idle';
         notify();
       });
@@ -2521,6 +2552,8 @@ export function initSession(
 }
 
 export function leaveRoom(): void {
+  playLocalDisconnectSoundOnce();
+
   // Clean up custom share captures (best-effort, fire-and-forget)
   if (state.activeVideoShare || state.activeAudioShare) {
     if (lkModule && lkModule instanceof LiveKitModule) {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -94,6 +94,7 @@ export interface ChatMessage {
   messageId?: string;
   timestamp: string;
   participantId: string;
+  userId?: string;
   displayName: string;
   color: string;
   text: string;
@@ -314,6 +315,21 @@ export function colorFor(participant: { userId?: string; id: string }): string {
     h = Math.imul(h, 16777619);
   }
   return TERMINAL_COLORS[Math.abs(h) % TERMINAL_COLORS.length];
+}
+
+export function resolveChatMessageDisplayColor(
+  message: Pick<ChatMessage, 'participantId' | 'userId' | 'color'>,
+  participants: Array<Pick<RoomParticipant, 'id' | 'userId' | 'color'>>,
+): string {
+  if (message.userId) {
+    const userMatch = participants.find((p) => p.userId === message.userId);
+    if (userMatch?.color) return userMatch.color;
+  }
+
+  const participantMatch = participants.find((p) => p.id === message.participantId);
+  if (participantMatch?.color) return participantMatch.color;
+
+  return message.color || colorFor({ userId: message.userId, id: message.participantId });
 }
 
 /**
@@ -561,7 +577,7 @@ export function shouldPlayChatNotification(
  * Exported for property testing.
  */
 export function mergeHistoryMessages(
-  historyPayload: Array<{ messageId: string; participantId: string; displayName: string; text: string; timestamp: string }>,
+  historyPayload: Array<{ messageId: string; participantId: string; userId?: string; displayName: string; text: string; timestamp: string }>,
   existingMessages: ChatMessage[],
 ): ChatMessage[] {
   // Build set of existing messageIds for dedup (skip entries without messageId)
@@ -578,8 +594,9 @@ export function mergeHistoryMessages(
       messageId: h.messageId,
       timestamp: h.timestamp,
       participantId: h.participantId,
+      userId: h.userId,
       displayName: h.displayName,
-      color: colorFor({ id: h.participantId }),
+      color: colorFor({ userId: h.userId, id: h.participantId }),
       text: h.text,
       isHistory: true,
     }));
@@ -2375,6 +2392,7 @@ function dispatchMessage(raw: unknown): void {
         messageId: (msg.messageId as string) || undefined,
         timestamp: msg.timestamp as string,
         participantId: msg.participantId as string,
+        userId: (msg.userId as string) || undefined,
         displayName: msg.displayName as string,
         color: participant?.color ?? '',
         text: msg.text as string,
@@ -2395,6 +2413,7 @@ function dispatchMessage(raw: unknown): void {
       const historyPayload = messages.map((m) => ({
         messageId: m.messageId as string,
         participantId: m.participantId as string,
+        userId: (m.userId as string) || undefined,
         displayName: m.displayName as string,
         text: m.text as string,
         timestamp: m.timestamp as string,

--- a/clients/wavis-gui/src/routes.ts
+++ b/clients/wavis-gui/src/routes.ts
@@ -1,7 +1,7 @@
 import { createBrowserRouter } from 'react-router';
 import DeviceSetup from '@features/auth/DeviceSetup';
 import AuthGate from '@features/auth/AuthGate';
-import ChannelsList from '@features/channels/ChannelsList';
+import InitialRedirect from '@features/channels/InitialRedirect';
 
 /** Helper to add HydrateFallback to lazy-loaded routes. In React Router v7 with CSR,
  * lazy routes briefly enter a "hydrating" state while the dynamic import resolves.
@@ -80,7 +80,7 @@ export const router = createBrowserRouter([
     path: '/',
     Component: AuthGate,
     children: [
-      { index: true, Component: ChannelsList },
+      { index: true, Component: InitialRedirect },
       {
         path: 'channel/:channelId',
         lazy: async () => {

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -9,3 +9,6 @@ crash.log
 # Don't commit actual secrets in tfvars
 # (terraform.tfvars is committed with placeholders — override locally)
 *.auto.tfvars
+
+# Backend config contains real S3 bucket name — keep local only
+**/backend.tf

--- a/infrastructure/environments/dev-ecs/cloudfront.tf
+++ b/infrastructure/environments/dev-ecs/cloudfront.tf
@@ -7,8 +7,12 @@ resource "aws_cloudfront_distribution" "backend" {
   enabled         = true
   is_ipv6_enabled = true
   comment         = "Wavis ${local.env} ECS backend + LiveKit signaling"
-  price_class     = "PriceClass_100"
   tags            = local.tags
+
+  # WAF is managed by CloudFront's bundled security plan — can't be removed via API
+  lifecycle {
+    ignore_changes = [web_acl_id, price_class]
+  }
 
   origin {
     domain_name = aws_lb.backend.dns_name

--- a/infrastructure/environments/dev-ecs/ecs_backend.tf
+++ b/infrastructure/environments/dev-ecs/ecs_backend.tf
@@ -18,6 +18,7 @@ resource "aws_ecr_repository" "backend" {
 resource "aws_cloudwatch_log_group" "backend" {
   name              = "/aws/ecs/${local.project}-${local.env}-backend"
   retention_in_days = var.backend_log_retention_days
+  log_group_class   = "INFREQUENT_ACCESS"
   tags              = local.tags
 }
 
@@ -30,6 +31,18 @@ resource "aws_ecs_cluster" "backend" {
   }
 
   tags = local.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "backend" {
+  cluster_name = aws_ecs_cluster.backend.name
+
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+    base              = 0
+  }
 }
 
 resource "aws_lb" "backend" {
@@ -190,10 +203,15 @@ resource "aws_ecs_service" "backend" {
   cluster                           = aws_ecs_cluster.backend.id
   task_definition                   = aws_ecs_task_definition.backend.arn
   desired_count                     = var.backend_desired_count
-  launch_type                       = "FARGATE"
   health_check_grace_period_seconds = var.backend_health_check_grace_period_seconds
   enable_execute_command            = true
   wait_for_steady_state             = false
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE_SPOT"
+    weight            = 1
+    base              = 0
+  }
 
   deployment_circuit_breaker {
     enable   = true

--- a/infrastructure/environments/dev-ecs/variables.tf
+++ b/infrastructure/environments/dev-ecs/variables.tf
@@ -271,3 +271,9 @@ variable "rds_connections_alarm_threshold" {
   type        = number
   default     = 40
 }
+
+variable "cloudfront_web_acl_id" {
+  description = "WAF WebACL ARN attached to the CloudFront distribution (required by CF Security Bundle pricing plan)"
+  type        = string
+  default     = ""
+}

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -757,7 +757,11 @@ pub struct SubRoomInfoPayload {
     pub participant_ids: Vec<String>,
     /// When the room is scheduled for auto-deletion, expressed as epoch milliseconds.
     /// Absent for ROOM 1 and any non-empty room.
-    #[serde(rename = "deleteAtMs", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "deleteAtMs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub delete_at_ms: Option<u64>,
 }
 
@@ -867,6 +871,9 @@ pub struct ChatMessagePayload {
     /// Participant identifier for the sender.
     #[serde(rename = "participantId")]
     pub participant_id: String,
+    /// Stable authenticated user identifier for the sender, when available.
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
     /// Display name for the sender at the time the message was emitted.
     #[serde(rename = "displayName")]
     pub display_name: String,
@@ -898,6 +905,9 @@ pub struct ChatHistoryMessagePayload {
     /// Participant identifier for the original sender.
     #[serde(rename = "participantId")]
     pub participant_id: String,
+    /// Stable authenticated user identifier for the original sender, when available.
+    #[serde(rename = "userId", skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
     /// Display name captured with the historical message.
     #[serde(rename = "displayName")]
     pub display_name: String,

--- a/shared/src/signaling/proptest_support.rs
+++ b/shared/src/signaling/proptest_support.rs
@@ -709,11 +709,13 @@ impl Arbitrary for PassthroughStatePayload {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (any::<String>(), any::<String>(), any::<String>())
-            .prop_map(|(source_sub_room_id, target_sub_room_id, label)| PassthroughStatePayload {
-                source_sub_room_id,
-                target_sub_room_id,
-                label,
-            })
+            .prop_map(
+                |(source_sub_room_id, target_sub_room_id, label)| PassthroughStatePayload {
+                    source_sub_room_id,
+                    target_sub_room_id,
+                    label,
+                },
+            )
             .boxed()
     }
 }
@@ -748,12 +750,18 @@ impl Arbitrary for SubRoomJoinedPayload {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<String>(), any::<String>(), any::<WireSubRoomMembershipSource>())
-            .prop_map(|(participant_id, sub_room_id, source)| SubRoomJoinedPayload {
-                participant_id,
-                sub_room_id,
-                source,
-            })
+        (
+            any::<String>(),
+            any::<String>(),
+            any::<WireSubRoomMembershipSource>(),
+        )
+            .prop_map(
+                |(participant_id, sub_room_id, source)| SubRoomJoinedPayload {
+                    participant_id,
+                    sub_room_id,
+                    source,
+                },
+            )
             .boxed()
     }
 }
@@ -812,18 +820,22 @@ impl Arbitrary for ChatMessagePayload {
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         (
             any::<String>(),
+            prop::option::of(any::<String>()),
             any::<String>(),
             any::<String>(),
             any::<String>(),
             prop::option::of(any::<String>()),
         )
             .prop_map(
-                |(participant_id, display_name, text, timestamp, message_id)| ChatMessagePayload {
-                    participant_id,
-                    display_name,
-                    text,
-                    timestamp,
-                    message_id,
+                |(participant_id, user_id, display_name, text, timestamp, message_id)| {
+                    ChatMessagePayload {
+                        participant_id,
+                        user_id,
+                        display_name,
+                        text,
+                        timestamp,
+                        message_id,
+                    }
                 },
             )
             .boxed()
@@ -848,15 +860,17 @@ impl Arbitrary for ChatHistoryMessagePayload {
         (
             any::<String>(),
             any::<String>(),
+            prop::option::of(any::<String>()),
             any::<String>(),
             any::<String>(),
             any::<String>(),
         )
             .prop_map(
-                |(message_id, participant_id, display_name, text, timestamp)| {
+                |(message_id, participant_id, user_id, display_name, text, timestamp)| {
                     ChatHistoryMessagePayload {
                         message_id,
                         participant_id,
+                        user_id,
                         display_name,
                         text,
                         timestamp,

--- a/shared/src/signaling/tests.rs
+++ b/shared/src/signaling/tests.rs
@@ -1,6 +1,49 @@
 use super::*;
 use proptest::prelude::*;
 
+#[test]
+fn chat_payloads_serialize_optional_user_id_as_user_id() {
+    let chat = SignalingMessage::ChatMessage(ChatMessagePayload {
+        participant_id: "peer-1".to_string(),
+        user_id: Some("user-1".to_string()),
+        display_name: "Alice".to_string(),
+        text: "hello".to_string(),
+        timestamp: "2026-05-05T00:00:00Z".to_string(),
+        message_id: Some("message-1".to_string()),
+    });
+    let json = to_json(&chat).unwrap();
+    assert!(json.contains(r#""userId":"user-1""#));
+    assert!(!json.contains("user_id"));
+
+    let history = SignalingMessage::ChatHistoryResponse(ChatHistoryResponsePayload {
+        messages: vec![ChatHistoryMessagePayload {
+            message_id: "message-1".to_string(),
+            participant_id: "peer-1".to_string(),
+            user_id: Some("user-1".to_string()),
+            display_name: "Alice".to_string(),
+            text: "hello".to_string(),
+            timestamp: "2026-05-05T00:00:00Z".to_string(),
+        }],
+    });
+    let history_json = to_json(&history).unwrap();
+    assert!(history_json.contains(r#""userId":"user-1""#));
+    assert!(!history_json.contains("user_id"));
+}
+
+#[test]
+fn chat_payloads_omit_absent_user_id() {
+    let chat = SignalingMessage::ChatMessage(ChatMessagePayload {
+        participant_id: "peer-1".to_string(),
+        user_id: None,
+        display_name: "Alice".to_string(),
+        text: "hello".to_string(),
+        timestamp: "2026-05-05T00:00:00Z".to_string(),
+        message_id: Some("message-1".to_string()),
+    });
+    let json = to_json(&chat).unwrap();
+    assert!(!json.contains("userId"));
+}
+
 // --- Unit tests for invite lifecycle messages ---
 
 #[test]
@@ -248,6 +291,7 @@ proptest! {
         );
         let original = SignalingMessage::ChatMessage(ChatMessagePayload {
             participant_id,
+            user_id: Some("user-123".to_string()),
             display_name,
             text,
             timestamp,

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -259,7 +259,11 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
         }
         SignalingMessage::LeaveSubRoom(_) => {}
         SignalingMessage::SetPassthrough(p) => {
-            check("targetSubRoomId", &p.target_sub_room_id, MAX_SUB_ROOM_ID_LEN)?;
+            check(
+                "targetSubRoomId",
+                &p.target_sub_room_id,
+                MAX_SUB_ROOM_ID_LEN,
+            )?;
         }
         SignalingMessage::ClearPassthrough(_) => {}
         SignalingMessage::SubRoomState(p) => {
@@ -270,8 +274,16 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
                 }
             }
             if let Some(passthrough) = &p.passthrough {
-                check("sourceSubRoomId", &passthrough.source_sub_room_id, MAX_SUB_ROOM_ID_LEN)?;
-                check("targetSubRoomId", &passthrough.target_sub_room_id, MAX_SUB_ROOM_ID_LEN)?;
+                check(
+                    "sourceSubRoomId",
+                    &passthrough.source_sub_room_id,
+                    MAX_SUB_ROOM_ID_LEN,
+                )?;
+                check(
+                    "targetSubRoomId",
+                    &passthrough.target_sub_room_id,
+                    MAX_SUB_ROOM_ID_LEN,
+                )?;
             }
         }
         SignalingMessage::SubRoomCreated(p) => {
@@ -828,6 +840,7 @@ mod tests {
                 .map(|i| ChatHistoryMessagePayload {
                     message_id: format!("msg-{}", i),
                     participant_id: format!("peer-{}", i),
+                    user_id: None,
                     display_name: format!("user-{}", i),
                     text: long_str(text_len),
                     timestamp: "2025-01-15T10:00:00Z".to_string(),

--- a/wavis-backend/migrations/015_add_chat_message_user_id.sql
+++ b/wavis-backend/migrations/015_add_chat_message_user_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_messages
+    ADD COLUMN IF NOT EXISTS user_id TEXT;

--- a/wavis-backend/src/chat/chat.rs
+++ b/wavis-backend/src/chat/chat.rs
@@ -7,12 +7,14 @@ use shared::signaling::{
 pub fn handle_chat_send(
     text: &str,
     participant_id: &str,
+    user_id: Option<&str>,
     display_name: &str,
     timestamp: &str,
     message_id: &str,
 ) -> Vec<OutboundSignal> {
     let msg = SignalingMessage::ChatMessage(ChatMessagePayload {
         participant_id: participant_id.to_string(),
+        user_id: user_id.map(ToString::to_string),
         display_name: display_name.to_string(),
         text: text.to_string(),
         timestamp: timestamp.to_string(),
@@ -28,6 +30,7 @@ pub fn build_history_response(rows: Vec<ChatMessageRow>) -> SignalingMessage {
         .map(|row| ChatHistoryMessagePayload {
             message_id: row.message_id.to_string(),
             participant_id: row.participant_id,
+            user_id: row.user_id,
             display_name: row.display_name,
             text: row.text,
             timestamp: row.created_at.to_rfc3339(),
@@ -69,7 +72,14 @@ mod tests {
     /// perform fallback — that responsibility belongs to the handler (ws.rs).
     #[test]
     fn empty_display_name_passed_through() {
-        let signals = handle_chat_send("hello", "peer-abc", "", "2025-01-15T10:30:00Z", "msg-001");
+        let signals = handle_chat_send(
+            "hello",
+            "peer-abc",
+            None,
+            "",
+            "2025-01-15T10:30:00Z",
+            "msg-001",
+        );
         assert_eq!(signals.len(), 1);
         match &signals[0].msg {
             SignalingMessage::ChatMessage(p) => {
@@ -80,6 +90,42 @@ mod tests {
                 assert_eq!(p.participant_id, "peer-abc");
             }
             other => panic!("expected ChatMessage, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn history_response_preserves_nullable_user_id() {
+        let created_at = chrono::DateTime::parse_from_rfc3339("2026-05-05T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let with_user = uuid::Uuid::new_v4();
+        let without_user = uuid::Uuid::new_v4();
+
+        let response = build_history_response(vec![
+            ChatMessageRow {
+                message_id: with_user,
+                participant_id: "peer-1".to_string(),
+                user_id: Some("user-1".to_string()),
+                display_name: "Alice".to_string(),
+                text: "hello".to_string(),
+                created_at,
+            },
+            ChatMessageRow {
+                message_id: without_user,
+                participant_id: "peer-2".to_string(),
+                user_id: None,
+                display_name: "Bob".to_string(),
+                text: "hi".to_string(),
+                created_at,
+            },
+        ]);
+
+        match response {
+            SignalingMessage::ChatHistoryResponse(payload) => {
+                assert_eq!(payload.messages[0].user_id.as_deref(), Some("user-1"));
+                assert_eq!(payload.messages[1].user_id, None);
+            }
+            other => panic!("expected ChatHistoryResponse, got {:?}", other),
         }
     }
 
@@ -95,7 +141,8 @@ mod tests {
             timestamp in arb_timestamp(),
             message_id in arb_nonempty_string(64),
         ) {
-            let signals = handle_chat_send(&text, &participant_id, &display_name, &timestamp, &message_id);
+            let user_id = Some("user-abc");
+            let signals = handle_chat_send(&text, &participant_id, user_id, &display_name, &timestamp, &message_id);
 
             // Exactly one signal returned.
             prop_assert_eq!(signals.len(), 1, "expected exactly 1 signal, got {}", signals.len());
@@ -112,6 +159,7 @@ mod tests {
             match &signal.msg {
                 SignalingMessage::ChatMessage(payload) => {
                     prop_assert_eq!(&payload.participant_id, &participant_id);
+                    prop_assert_eq!(payload.user_id.as_deref(), user_id);
                     prop_assert_eq!(&payload.display_name, &display_name);
                     prop_assert_eq!(&payload.text, &text);
                     prop_assert_eq!(&payload.timestamp, &timestamp);

--- a/wavis-backend/src/chat/chat_persistence.rs
+++ b/wavis-backend/src/chat/chat_persistence.rs
@@ -28,32 +28,39 @@ use uuid::Uuid;
 pub struct ChatMessageRow {
     pub message_id: Uuid,
     pub participant_id: String,
+    pub user_id: Option<String>,
     pub display_name: String,
     pub text: String,
     pub created_at: DateTime<Utc>,
 }
 
+pub struct InsertChatMessageParams<'a> {
+    pub message_id: Uuid,
+    pub channel_id: Option<Uuid>,
+    pub room_id: &'a str,
+    pub participant_id: &'a str,
+    pub user_id: Option<&'a str>,
+    pub display_name: &'a str,
+    pub text: &'a str,
+}
+
 /// Insert a chat message into Postgres. Best-effort — caller handles errors.
 pub async fn insert_chat_message(
     pool: &PgPool,
-    message_id: Uuid,
-    channel_id: Option<Uuid>,
-    room_id: &str,
-    participant_id: &str,
-    display_name: &str,
-    text: &str,
+    params: InsertChatMessageParams<'_>,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         "INSERT INTO chat_messages (message_id, channel_id, room_id, \
-         participant_id, display_name, text) \
-         VALUES ($1, $2, $3, $4, $5, $6)",
+         participant_id, user_id, display_name, text) \
+         VALUES ($1, $2, $3, $4, $5, $6, $7)",
     )
-    .bind(message_id)
-    .bind(channel_id)
-    .bind(room_id)
-    .bind(participant_id)
-    .bind(display_name)
-    .bind(text)
+    .bind(params.message_id)
+    .bind(params.channel_id)
+    .bind(params.room_id)
+    .bind(params.participant_id)
+    .bind(params.user_id)
+    .bind(params.display_name)
+    .bind(params.text)
     .execute(pool)
     .await?;
     Ok(())
@@ -69,7 +76,7 @@ pub async fn fetch_history_by_channel(
     limit: i64,
 ) -> Result<Vec<ChatMessageRow>, sqlx::Error> {
     sqlx::query_as::<_, ChatMessageRow>(
-        "SELECT message_id, participant_id, display_name, text, created_at \
+        "SELECT message_id, participant_id, user_id, display_name, text, created_at \
          FROM chat_messages \
          WHERE channel_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2) \
          ORDER BY created_at ASC \
@@ -92,7 +99,7 @@ pub async fn fetch_history_by_room(
     limit: i64,
 ) -> Result<Vec<ChatMessageRow>, sqlx::Error> {
     sqlx::query_as::<_, ChatMessageRow>(
-        "SELECT message_id, participant_id, display_name, text, created_at \
+        "SELECT message_id, participant_id, user_id, display_name, text, created_at \
          FROM chat_messages \
          WHERE room_id = $1 AND ($2::timestamptz IS NULL OR created_at > $2) \
          ORDER BY created_at ASC \
@@ -178,6 +185,7 @@ mod tests {
             arb_optional_channel_id(),                                      // channel_id
             arb_nonempty_string(100),                                       // room_id
             arb_nonempty_string(50),                                        // participant_id
+            prop::option::of(arb_nonempty_string(50)),                      // user_id
             arb_nonempty_string(50),                                        // display_name
             arb_chat_text(),                                                // text
         );
@@ -186,7 +194,7 @@ mod tests {
         runner
             .run(
                 &strategy,
-                |(message_id, channel_id, room_id, participant_id, display_name, text)| {
+                |(message_id, channel_id, room_id, participant_id, user_id, display_name, text)| {
                     let rt = tokio::runtime::Handle::current();
                     let pool = pool.clone();
                     rt.block_on(async {
@@ -194,12 +202,15 @@ mod tests {
 
                         insert_chat_message(
                             &pool,
-                            message_id,
-                            channel_id,
-                            &room_id,
-                            &participant_id,
-                            &display_name,
-                            &text,
+                            InsertChatMessageParams {
+                                message_id,
+                                channel_id,
+                                room_id: &room_id,
+                                participant_id: &participant_id,
+                                user_id: user_id.as_deref(),
+                                display_name: &display_name,
+                                text: &text,
+                            },
                         )
                         .await
                         .expect("insert should succeed");
@@ -225,6 +236,7 @@ mod tests {
 
                         // Verify all fields match
                         prop_assert_eq!(&row.participant_id, &participant_id);
+                        prop_assert_eq!(&row.user_id, &user_id);
                         prop_assert_eq!(&row.display_name, &display_name);
                         prop_assert_eq!(&row.text, &text);
 
@@ -315,12 +327,15 @@ mod tests {
                                 all_message_ids.push(mid);
                                 insert_chat_message(
                                     &pool,
-                                    mid,
-                                    Some(channel_id),
-                                    room_id,
-                                    participant_id,
-                                    display_name,
-                                    text,
+                                    InsertChatMessageParams {
+                                        message_id: mid,
+                                        channel_id: Some(channel_id),
+                                        room_id,
+                                        participant_id,
+                                        user_id: None,
+                                        display_name,
+                                        text,
+                                    },
                                 )
                                 .await
                                 .expect("insert should succeed");
@@ -366,12 +381,15 @@ mod tests {
                                     .push(mid);
                                 insert_chat_message(
                                     &pool,
-                                    mid,
-                                    None, // null channel_id
-                                    room_id,
-                                    participant_id,
-                                    display_name,
-                                    text,
+                                    InsertChatMessageParams {
+                                        message_id: mid,
+                                        channel_id: None,
+                                        room_id,
+                                        participant_id,
+                                        user_id: None,
+                                        display_name,
+                                        text,
+                                    },
                                 )
                                 .await
                                 .expect("insert should succeed");
@@ -472,12 +490,15 @@ mod tests {
                             let text = format!("msg-{}", i);
                             insert_chat_message(
                                 &pool,
-                                mid,
-                                channel_id,
-                                &room_id,
-                                &participant_id,
-                                &display_name,
-                                &text,
+                                InsertChatMessageParams {
+                                    message_id: mid,
+                                    channel_id,
+                                    room_id: &room_id,
+                                    participant_id: &participant_id,
+                                    user_id: None,
+                                    display_name: &display_name,
+                                    text: &text,
+                                },
                             )
                             .await
                             .expect("insert should succeed");
@@ -589,12 +610,15 @@ mod tests {
                             let text = format!("msg-{}", i);
                             insert_chat_message(
                                 &pool,
-                                mid,
-                                channel_id,
-                                &room_id,
-                                &participant_id,
-                                &display_name,
-                                &text,
+                                InsertChatMessageParams {
+                                    message_id: mid,
+                                    channel_id,
+                                    room_id: &room_id,
+                                    participant_id: &participant_id,
+                                    user_id: None,
+                                    display_name: &display_name,
+                                    text: &text,
+                                },
                             )
                             .await
                             .expect("insert should succeed");
@@ -714,12 +738,15 @@ mod tests {
                             let text = format!("msg-{}", i);
                             insert_chat_message(
                                 &pool,
-                                mid,
-                                None, // legacy room for simplicity
-                                &room_id,
-                                &participant_id,
-                                &display_name,
-                                &text,
+                                InsertChatMessageParams {
+                                    message_id: mid,
+                                    channel_id: None,
+                                    room_id: &room_id,
+                                    participant_id: &participant_id,
+                                    user_id: None,
+                                    display_name: &display_name,
+                                    text: &text,
+                                },
                             )
                             .await
                             .expect("insert should succeed");

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -2751,6 +2751,7 @@ pub(crate) async fn dispatch_message(
             let signals = chat::handle_chat_send(
                 &payload.text,
                 &session_ref.participant_id,
+                session_ref.user_id.as_deref(),
                 &display_name,
                 &timestamp,
                 &message_id.to_string(),
@@ -2770,17 +2771,21 @@ pub(crate) async fn dispatch_message(
                 .and_then(|cid| cid.parse::<Uuid>().ok());
             let room_id_clone = session_ref.room_id.clone();
             let participant_id_clone = session_ref.participant_id.clone();
+            let user_id_clone = session_ref.user_id.clone();
             let display_name_clone = display_name.clone();
             let text_clone = payload.text.clone();
             tokio::spawn(async move {
                 if let Err(e) = chat_persistence::insert_chat_message(
                     &db_pool,
-                    message_id,
-                    channel_id_uuid,
-                    &room_id_clone,
-                    &participant_id_clone,
-                    &display_name_clone,
-                    &text_clone,
+                    chat_persistence::InsertChatMessageParams {
+                        message_id,
+                        channel_id: channel_id_uuid,
+                        room_id: &room_id_clone,
+                        participant_id: &participant_id_clone,
+                        user_id: user_id_clone.as_deref(),
+                        display_name: &display_name_clone,
+                        text: &text_clone,
+                    },
                 )
                 .await
                 {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
