### PR TITLE
fix

### DIFF
--- a/clients/shared/src/livekit_video.rs
+++ b/clients/shared/src/livekit_video.rs
@@ -102,10 +102,30 @@ pub(super) async fn run_video_receiver_task(
     });
 
     let mut frames_received: u64 = 0;
+    let mut frames_dropped: u64 = 0;
+
+    #[cfg(target_os = "linux")]
+    let mut last_frame_emit: Option<std::time::Instant> = None;
+    #[cfg(target_os = "linux")]
+    const MIN_REMOTE_FRAME_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 
     while let Some(frame) = stream.next().await {
         if closing.load(std::sync::atomic::Ordering::SeqCst) {
             break;
+        }
+
+        frames_received += 1;
+
+        #[cfg(target_os = "linux")]
+        {
+            let now = std::time::Instant::now();
+            if let Some(last) = last_frame_emit {
+                if now.duration_since(last) < MIN_REMOTE_FRAME_INTERVAL {
+                    frames_dropped += 1;
+                    continue;
+                }
+            }
+            last_frame_emit = Some(now);
         }
 
         let buffer = frame.buffer.as_ref();
@@ -132,17 +152,16 @@ pub(super) async fn run_video_receiver_task(
         // Send to the keep-latest channel (drops old frame).
         let _ = frame_tx.send(Some((rgba, width, height)));
 
-        frames_received += 1;
         if frames_received.is_multiple_of(150) {
             log::info!(
-                "livekit_video: participant={participant_id} frames_received={frames_received}"
+                "livekit_video: participant={participant_id} frames_received={frames_received} frames_dropped={frames_dropped}"
             );
         }
     }
 
     emit_task.abort();
     log::info!(
-        "livekit_video: video stream ended for {participant_id}, total frames={frames_received}"
+        "livekit_video: video stream ended for {participant_id}, total frames={frames_received} dropped={frames_dropped}"
     );
 
     // Fire track-ended callback when the stream ends.

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -606,10 +606,10 @@ pub fn media_connect(
         // JSON Tauri event. Under load (multiple shares, large resolutions)
         // this saturates CPU and lets libwebrtc's native frame queue grow
         // unbounded — eventually segfaulting. Capping the visible refresh at
-        // 15 fps keeps the screen share visually fluid while preventing the
+        // 10 fps keeps the screen share usable while preventing the
         // overload regime that triggered the crashes we observed.
         const VIEWER_MIN_FRAME_INTERVAL: std::time::Duration =
-            std::time::Duration::from_millis(66); // ≈ 15 fps
+            std::time::Duration::from_millis(100); // 10 fps
         let last_emit_per_identity: Arc<Mutex<std::collections::HashMap<String, std::time::Instant>>> =
             Arc::new(Mutex::new(std::collections::HashMap::new()));
 
@@ -693,11 +693,15 @@ pub fn media_connect(
 
     match state.runtime.block_on(async { conn.connect(&url, &token) }) {
         Ok(()) => {
-            conn.set_mic_enabled(false)
-                .map_err(|err| format!("failed to disable mic before publish: {err}"))?;
-            if let Err(err) = conn.publish_audio(&AudioTrack {
-                id: "native-mic".to_string(),
-            }) {
+            let publish_result = state.runtime.block_on(async {
+                conn.set_mic_enabled(false)
+                    .map_err(|err| format!("failed to disable mic before publish: {err}"))?;
+                conn.publish_audio(&AudioTrack {
+                    id: "native-mic".to_string(),
+                })
+                .map_err(|err| format!("{err}"))
+            });
+            if let Err(err) = publish_result {
                 let reason = format!("{err}");
                 log::error!("{LOG} publish failed: {reason}");
                 let _ = state.runtime.block_on(async { conn.disconnect() });


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
