### PR TITLE
screen shot bug fixes

### DIFF
--- a/clients/wavis-gui/src-tauri/src/bug_report.rs
+++ b/clients/wavis-gui/src-tauri/src/bug_report.rs
@@ -120,7 +120,8 @@ pub fn get_rust_log_buffer(state: tauri::State<'_, RustLogBufferState>) -> Vec<S
 ///
 /// - Windows: Uses Win32 GDI APIs (GetWindowRect, BitBlt) to capture the window content.
 /// - macOS: Uses CGWindowListCreateImage to capture the window.
-/// - Linux: Returns an error — descoped to follow-up.
+/// - Linux: Uses xdg-desktop-portal Screenshot (works on Wayland, X11, XWayland);
+///   returns the full screen — bug-report redactor handles cropping/masking.
 #[tauri::command]
 pub fn capture_window_screenshot(window: tauri::Window) -> Result<Vec<u8>, String> {
     capture_window_screenshot_impl(window)
@@ -359,5 +360,36 @@ extern "C" {
 
 #[cfg(target_os = "linux")]
 fn capture_window_screenshot_impl(_window: tauri::Window) -> Result<Vec<u8>, String> {
-    Err("Screenshot capture not available on Linux".to_string())
+    // xdg-desktop-portal Screenshot API — works on Wayland, X11, and XWayland.
+    // Returns the full screen; the bug-report redactor handles any cropping
+    // or sensitive-area masking client-side.
+    if let Ok(h) = tokio::runtime::Handle::try_current() {
+        tokio::task::block_in_place(move || h.block_on(capture_via_portal_async()))
+    } else {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("tokio runtime build failed: {e}"))?;
+        rt.block_on(capture_via_portal_async())
+    }
+}
+
+#[cfg(target_os = "linux")]
+async fn capture_via_portal_async() -> Result<Vec<u8>, String> {
+    use ashpd::desktop::screenshot::Screenshot;
+
+    let response = Screenshot::request()
+        .interactive(false)
+        .modal(false)
+        .send()
+        .await
+        .map_err(|e| format!("portal Screenshot request failed: {e}"))?
+        .response()
+        .map_err(|e| format!("portal Screenshot response failed: {e}"))?;
+
+    let uri = response.uri();
+    let path = uri
+        .to_file_path()
+        .map_err(|_| format!("portal returned non-file URI: {uri}"))?;
+    std::fs::read(&path).map_err(|e| format!("read portal screenshot {path:?}: {e}"))
 }

--- a/clients/wavis-gui/src/features/diagnostics/BugReportButton.tsx
+++ b/clients/wavis-gui/src/features/diagnostics/BugReportButton.tsx
@@ -217,8 +217,8 @@ export default function BugReportButton() {
     try {
       const bytes = await invoke<number[]>('capture_window_screenshot');
       screenshot = new Uint8Array(bytes);
-    } catch {
-      // Non-fatal — flow continues without a screenshot.
+    } catch (err) {
+      console.warn('[bug-report] capture_window_screenshot failed:', err);
     }
     setPreScreenshot(screenshot);
     setIsCapturing(false);

--- a/clients/wavis-gui/src/features/diagnostics/BugReportFlow.tsx
+++ b/clients/wavis-gui/src/features/diagnostics/BugReportFlow.tsx
@@ -75,10 +75,6 @@ export async function openExternalLink(
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
-function isLinux(): boolean {
-  return navigator.platform?.toLowerCase().includes('linux') ?? false;
-}
-
 function measureBugReportPayloadChars(payload: BugReportPayload): number {
   return JSON.stringify(payload).length;
 }
@@ -245,8 +241,7 @@ export default function BugReportFlow({ onClose, preScreenshot }: BugReportFlowP
         if (cancelled) return;
         setContext(captured);
 
-        // Skip redaction step on Linux or if no screenshot
-        if (isLinux() || !captured.screenshot) {
+        if (!captured.screenshot) {
           setStep('describe');
         } else {
           setStep('redact');


### PR DESCRIPTION
Description

  Fixes the bug-report screenshot capture on Linux. The IPC command was stubbed to return an error on Linux, and the JS flow had a hard-coded isLinux() bypass that skipped the
  screenshot/redactor step entirely. Replaces the stub with an xdg-desktop-portal Screenshot implementation (works on Wayland, X11, and XWayland) and removes the bypass so the
  redactor runs on Linux like it does on Windows/macOS. Also adds a console.warn on capture failure so silent breakage is easier to diagnose next time.

  Type of Change

  - Bug fix
  - New feature
  - Refactor
  - Dependency update
  - Documentation / config only

  ---
  Security Checklist

  ▎ Complete this section for any PR that touches signaling or token paths:
  ▎ domain/jwt.rs, domain/livekit_bridge.rs, domain/relay.rs,
  ▎ domain/sfu_relay.rs, handlers/ws.rs

  If this PR does not touch any of those files, check this box and skip the rest:
  - This PR does not touch signaling or token paths — checklist not applicable

  Otherwise, confirm each item below:

  Sensitive Data Logging (Req 5.1–5.4)

  - No JWT strings, raw tokens, or MediaToken values are passed to log macros
  - No invite code values are passed to log macros (lengths/counts are OK)
  - No SDP content is passed to log macros (lengths/types are OK)
  - No ICE candidate strings are passed to log macros (counts/types are OK)
  - cargo test --test no_sensitive_logs passes locally (also enforced by CI: backend-ci.yml)

  Message Size Limits (Req 3.5, 3.8)

  - SDP payloads are validated against MAX_SDP_BYTES (64 KB) before forwarding
  - ICE candidate payloads are validated against MAX_ICE_CANDIDATE_BYTES (2 KB) before forwarding
  - Oversized payloads return a descriptive error and are not forwarded

  Server-Enforced Identity (Req 2.3, 2.4)

  - All post-join message dispatch uses session.participant_id as sender identity
  - No client-supplied identity fields are trusted for routing or authorization

  Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)

  - Action messages (kick, mute) are rejected in P2P rooms
  - Host-only actions check session.role == Host in the handler (Tier 1)
  - Domain functions (handle_kick, etc.) independently validate role (Tier 2 / defense in depth)
  - Action messages are never forwarded through the relay path

  Token Scope and Lifetime (Req 1.1–1.7)

  - MediaTokens include iss and aud claims
  - Token TTL is ≤ 600s (default) — no unbounded lifetimes
  - validate_media_token checks both iss and aud
  - Revoked participants are blocked from token re-issuance within the TTL window

  ---
  Tests

  - cargo test -p wavis-backend passes
  - New property tests added for any new correctness properties
  - No tests were deleted or disabled to make the build pass