### PR TITLE
fix(gui): delay media connection until a sub-room is joined

### DIFF
--- a/clients/wavis-gui/src/features/channels/ChannelDetail.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelDetail.tsx
@@ -920,17 +920,20 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
       </div>
 
       {/* Bottom command bar */}
-      <div className="border-t border-wavis-text-secondary px-3 sm:px-6 py-3 flex flex-wrap items-center gap-x-6 gap-y-2">
+      <div className="border-t border-wavis-text-secondary p-4 flex flex-wrap items-center gap-x-6 gap-y-2">
+        <div className="flex gap-4 border-b border-transparent w-full max-w-[1000px] mx-auto">
         {bottomCommands.map((cmd) => (
           <CmdButton
             key={cmd}
-            label={cmd === '/leave' ? '/abandon channel' : cmd}
+            label={cmd === '/leave' ? '/abandon' : cmd}
             onClick={() => handleCmdClick(cmd)}
             active={false}
             danger={cmd === '/leave'}
             disabled={submitting && cmd !== '/back'}
+            className="py-[7px] flex-1"
           />
         ))}
+        </div>
       </div>
     </div>
   );

--- a/clients/wavis-gui/src/features/channels/ChannelSwitcherPanel.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelSwitcherPanel.tsx
@@ -1,8 +1,15 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { type Channel, fetchChannels } from './channels';
+import {
+  type Channel,
+  fetchChannels,
+  createChannel,
+  joinChannelByInvite,
+  normalizeChannelName,
+} from './channels';
 import { fetchVoiceStatusWithFallback } from './channel-detail';
 import { ChannelRoleBadge } from './ChannelRoleBadge';
 import { usePolling } from '@shared/hooks/usePolling';
+import { ApiError } from '@shared/api';
 
 const POLL_MS = 15_000;
 
@@ -17,6 +24,22 @@ export function ChannelSwitcherPanel({ onChannelSelect, onClose, currentChannelI
   const [loading, setLoading] = useState(true);
   const [voiceStatus, setVoiceStatus] = useState<Map<string, { active: boolean; participantCount: number }>>(new Map());
   const requestInFlightRef = useRef(false);
+
+  const [activeForm, setActiveForm] = useState<'none' | 'create' | 'join'>('none');
+
+  // Create form
+  const [createName, setCreateName] = useState('');
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createBusy, setCreateBusy] = useState(false);
+
+  // Join form
+  const [joinCode, setJoinCode] = useState('');
+  const [joinError, setJoinError] = useState<string | null>(null);
+  const [joinBusy, setJoinBusy] = useState(false);
+  const [joinSuccess, setJoinSuccess] = useState(false);
+
+  const createInputRef = useRef<HTMLInputElement>(null);
+  const joinInputRef = useRef<HTMLInputElement>(null);
 
   const loadChannels = useCallback(async (showLoading: boolean) => {
     if (showLoading) setLoading(true);
@@ -45,6 +68,76 @@ export function ChannelSwitcherPanel({ onChannelSelect, onClose, currentChannelI
     loadChannels(false);
   }, POLL_MS);
 
+  useEffect(() => {
+    if (activeForm === 'create') createInputRef.current?.focus();
+    else if (activeForm === 'join') joinInputRef.current?.focus();
+  }, [activeForm]);
+
+  const closeForm = useCallback(() => {
+    setActiveForm('none');
+    setCreateName(''); setCreateError(null);
+    setJoinCode(''); setJoinError(null); setJoinSuccess(false);
+  }, []);
+
+  const toggleForm = useCallback((form: 'create' | 'join') => {
+    setActiveForm((prev) => (prev === form ? 'none' : form));
+    setCreateName(''); setCreateError(null);
+    setJoinCode(''); setJoinError(null); setJoinSuccess(false);
+  }, []);
+
+  const handleCreate = useCallback(async () => {
+    if (createBusy) return;
+    const normalized = normalizeChannelName(createName);
+    if (normalized.length < 1 || normalized.length > 100) {
+      setCreateError('name must be 1–100 characters');
+      return;
+    }
+    setCreateError(null);
+    setCreateBusy(true);
+    requestInFlightRef.current = true;
+    try {
+      const ch = await createChannel(createName);
+      setChannels((prev) => [...prev, ch]);
+      closeForm();
+      onChannelSelect(ch);
+    } catch (err) {
+      setCreateError(err instanceof ApiError ? err.message : 'something went wrong — try again');
+    } finally {
+      setCreateBusy(false);
+      requestInFlightRef.current = false;
+    }
+  }, [createName, createBusy, closeForm, onChannelSelect]);
+
+  const handleJoin = useCallback(async () => {
+    if (joinBusy) return;
+    const code = joinCode.trim();
+    if (!code) { setJoinError('enter an invite code'); return; }
+    setJoinError(null);
+    setJoinBusy(true);
+    requestInFlightRef.current = true;
+    try {
+      const ch = await joinChannelByInvite(code);
+      setChannels((prev) => prev.some((c) => c.id === ch.id) ? prev : [...prev, ch]);
+      setJoinSuccess(true);
+      setTimeout(() => { closeForm(); onChannelSelect(ch); }, 1200);
+    } catch (err) {
+      setJoinError(err instanceof ApiError ? err.message : 'something went wrong — try again');
+    } finally {
+      setJoinBusy(false);
+      requestInFlightRef.current = false;
+    }
+  }, [joinCode, joinBusy, closeForm, onChannelSelect]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && activeForm !== 'none') closeForm();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [activeForm, closeForm]);
+
+  const createValid = normalizeChannelName(createName).length >= 1;
+
   return (
     <div className="flex-1 flex flex-col min-h-0">
       <div className="px-3 py-3 border-b border-wavis-text-secondary h-[4.5rem] flex items-center justify-between">
@@ -55,6 +148,7 @@ export function ChannelSwitcherPanel({ onChannelSelect, onClose, currentChannelI
           aria-label="Close channel switcher"
         >[x]</button>
       </div>
+
       <div className="flex-1 overflow-y-auto p-3 space-y-1">
         {loading && (
           <div className="text-wavis-text-secondary text-xs">loading...</div>
@@ -90,6 +184,74 @@ export function ChannelSwitcherPanel({ onChannelSelect, onClose, currentChannelI
             </div>
           );
         })}
+      </div>
+
+      {/* Inline forms */}
+      {activeForm === 'create' && (
+        <div className="border-t border-wavis-text-secondary px-3 py-3">
+          <p className="text-xs text-wavis-text-secondary mb-2">create channel</p>
+          <div className="flex items-center gap-2">
+            <span className="text-wavis-accent shrink-0 text-xs">&gt;</span>
+            <input
+              ref={createInputRef}
+              type="text"
+              placeholder="channel name"
+              value={createName}
+              onChange={(e) => { setCreateName(e.target.value); setCreateError(null); }}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); }}
+              disabled={createBusy}
+              maxLength={100}
+              className="flex-1 min-w-0 bg-transparent border-b border-wavis-text-secondary outline-none px-1 py-0.5 font-mono text-xs text-wavis-text disabled:opacity-40"
+            />
+            <button
+              onClick={() => void handleCreate()}
+              disabled={createBusy || !createValid}
+              className="shrink-0 border border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg transition-colors px-1 py-0.5 text-[0.625rem] disabled:opacity-40 disabled:cursor-not-allowed"
+            >/create</button>
+          </div>
+          {createError && <p className="text-wavis-danger text-xs mt-1 ml-3">{createError}</p>}
+        </div>
+      )}
+
+      {activeForm === 'join' && (
+        <div className="border-t border-wavis-text-secondary px-3 py-3">
+          <p className="text-xs text-wavis-text-secondary mb-2">join by invite code</p>
+          <div className="flex items-center gap-2">
+            <span className="text-wavis-accent shrink-0 text-xs">&gt;</span>
+            <input
+              ref={joinInputRef}
+              type="text"
+              placeholder="INVITE CODE"
+              value={joinCode}
+              onChange={(e) => { setJoinCode(e.target.value); setJoinError(null); setJoinSuccess(false); }}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleJoin(); }}
+              disabled={joinBusy}
+              className="flex-1 min-w-0 bg-transparent border-b border-wavis-text-secondary outline-none px-1 py-0.5 font-mono text-xs text-wavis-text disabled:opacity-40"
+              style={{ letterSpacing: '0.15em' }}
+            />
+            <button
+              onClick={() => void handleJoin()}
+              disabled={joinBusy || !joinCode.trim()}
+              className="shrink-0 border border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg transition-colors px-1 py-0.5 text-[0.625rem] disabled:opacity-40 disabled:cursor-not-allowed"
+            >/join</button>
+          </div>
+          {joinSuccess && <p className="text-wavis-accent text-xs mt-1 ml-3">joined!</p>}
+          {joinError && <p className="text-wavis-danger text-xs mt-1 ml-3">{joinError}</p>}
+        </div>
+      )}
+
+      {/* Bottom command bar */}
+      <div className="border-t border-wavis-text-secondary p-4">
+        <div className="flex gap-4 border-b border-transparent w-full max-w-[1000px] mx-auto">
+        <button
+          onClick={() => toggleForm('create')}
+          className={`flex-1 py-[7px] px-1 text-xs text-center transition-colors border ${activeForm === 'create' ? 'border-wavis-accent text-wavis-accent bg-wavis-accent/8 hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
+        >/create</button>
+        <button
+          onClick={() => toggleForm('join')}
+          className={`flex-1 py-[7px] px-1 text-xs text-center transition-colors border ${activeForm === 'join' ? 'border-wavis-accent text-wavis-accent bg-wavis-accent/8 hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
+        >/join</button>
+        </div>
       </div>
     </div>
   );

--- a/clients/wavis-gui/src/features/diagnostics/BugReportFlow.tsx
+++ b/clients/wavis-gui/src/features/diagnostics/BugReportFlow.tsx
@@ -39,6 +39,7 @@ interface BugReportFlowProps {
 
 const LOG_PREFIX = '[wavis:bug-report]';
 const MIN_DESCRIPTION_LENGTH = 10;
+const MAX_TITLE_CHARS = 72;
 const OFFLINE_CATEGORIES = ['audio', 'ui', 'connectivity', 'crash', 'performance', 'other'];
 const MAX_ISSUE_BODY_CHARS = 900_000;
 const MAX_SUBMISSION_JSON_CHARS = 120_000;
@@ -50,6 +51,10 @@ const TRANSPORT_TRUNCATION_NOTICE = '\n\n_[diagnostics truncated for submission 
 
 export function validateDescription(text: string): boolean {
   return text.trim().length >= MIN_DESCRIPTION_LENGTH;
+}
+
+export function truncateTitle(title: string): string {
+  return title.length > MAX_TITLE_CHARS ? title.slice(0, MAX_TITLE_CHARS).trimEnd() : title;
 }
 
 export function truncateIssueBody(
@@ -317,7 +322,7 @@ export default function BugReportFlow({ onClose, preScreenshot }: BugReportFlowP
     if (!context) return;
     setReportMode('quick');
     const body = buildOfflineIssueBody(description, context, [], 'other');
-    setIssueTitle(`Bug Report: ${description.slice(0, 80)}`);
+    setIssueTitle(truncateTitle(`Bug Report: ${description}`));
     setIssueBody(body);
     setCategory('other');
     setStep('preview');
@@ -353,7 +358,7 @@ export default function BugReportFlow({ onClose, preScreenshot }: BugReportFlowP
       // Offline mode: go straight to preview
       if (!context) return;
       const body = buildOfflineFormBody(description, offlineForm, context);
-      const title = `Bug Report: ${description.slice(0, 80)}`;
+      const title = truncateTitle(`Bug Report: ${description}`);
       setIssueTitle(title);
       setIssueBody(body);
       setCategory(offlineForm.category || 'other');
@@ -405,14 +410,14 @@ export default function BugReportFlow({ onClose, preScreenshot }: BugReportFlowP
       } catch (err) {
         console.warn(LOG_PREFIX, 'Issue body generation failed, using offline format:', err);
         const body = buildOfflineIssueBody(description, context, rounds, category);
-        setIssueTitle(`Bug Report: ${description.slice(0, 80)}`);
+        setIssueTitle(truncateTitle(`Bug Report: ${description}`));
         setIssueBody(body);
       } finally {
         setLlmLoading(false);
       }
     } else {
       const body = buildOfflineIssueBody(description, context, rounds, category);
-      setIssueTitle(`Bug Report: ${description.slice(0, 80)}`);
+      setIssueTitle(truncateTitle(`Bug Report: ${description}`));
       setIssueBody(body);
     }
 

--- a/clients/wavis-gui/src/features/diagnostics/__tests__/bug-report-flow.test.ts
+++ b/clients/wavis-gui/src/features/diagnostics/__tests__/bug-report-flow.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import * as fc from 'fast-check';
-import { openExternalLink, truncateIssueBody, validateDescription } from '../BugReportFlow';
+import { openExternalLink, truncateIssueBody, truncateTitle, validateDescription } from '../BugReportFlow';
 import type { BugReportPayload } from '../bug-report';
 
 describe('Feature: in-app-bug-report, Property 9: Description minimum length enforcement', () => {
@@ -235,6 +235,51 @@ describe('Feature: in-app-bug-report, issue body truncation before submission', 
         fc.string({ minLength: 0, maxLength: LIMIT }),
         (body) => {
           expect(truncateIssueBody(body)).toBe(body);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+describe('Feature: in-app-bug-report, issue title truncation for branch naming', () => {
+  const LIMIT = 72;
+
+  it('returns the title unchanged when it is at or under the limit', () => {
+    const title = 'x'.repeat(LIMIT);
+    expect(truncateTitle(title)).toBe(title);
+  });
+
+  it('truncates to 72 characters when the title exceeds the limit', () => {
+    const title = 'x'.repeat(LIMIT + 10);
+    expect(truncateTitle(title).length).toBeLessThanOrEqual(LIMIT);
+  });
+
+  it('trims trailing whitespace after truncation', () => {
+    const title = 'a'.repeat(LIMIT - 2) + '   extra';
+    const result = truncateTitle(title);
+    expect(result.length).toBeLessThanOrEqual(LIMIT);
+    expect(result).not.toMatch(/ $/);
+  });
+
+  it('Property: result never exceeds 72 characters for any title', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 0, maxLength: 200 }),
+        (title) => {
+          expect(truncateTitle(title).length).toBeLessThanOrEqual(LIMIT);
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+
+  it('Property: title under the limit is always returned as-is', () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 0, maxLength: LIMIT }),
+        (title) => {
+          expect(truncateTitle(title)).toBe(title);
         },
       ),
       { numRuns: 200 },

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -2011,7 +2011,7 @@ export default function ActiveRoom() {
 
   const renderChannelSwitcherToggle = () => (
     <button
-      onClick={() => setChannelSwitcherOpen((v) => !v)}
+      onClick={() => { setChannelSwitcherOpen((v) => !v); setShowSettings(false); }}
       className={`shrink-0 border px-2 py-1 text-xs transition-colors ${
         channelSwitcherOpen
           ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
@@ -2514,7 +2514,7 @@ export default function ActiveRoom() {
               );
             })()}
             <div className="mt-4 flex flex-col gap-1">
-              <button onClick={() => setShowSettings(true)} className="w-full text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-xs text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast">/settings</button>
+              <button onClick={() => { setShowSettings(true); setChannelSwitcherOpen(false); }} className="w-full text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-xs text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast">/settings</button>
             </div>
           </div>
         </div>

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -282,8 +282,12 @@ const tick = () => new Promise<void>(r => setTimeout(r, 0));
 
 let latestState: VoiceRoomState | null = null;
 
-/** Initialize a session and drive it to the `active` state. */
-async function driveToActive(channelId = 'ch-1', channelName = 'test-room') {
+/** Initialize a session and drive it to the `active` state.
+ * By default also assigns self to room-1 via sub_room_state so that a
+ * subsequent media_token triggers connectMedia immediately. Pass
+ * joinSubRoom = false for tests that specifically need the pre-room state.
+ */
+async function driveToActive(channelId = 'ch-1', channelName = 'test-room', joinSubRoom = true) {
   latestState = null;
   initSession(channelId, channelName, 'owner', (s) => { latestState = s; });
   await tick(); // let connectWithAuth resolve
@@ -301,7 +305,11 @@ async function driveToActive(channelId = 'ch-1', channelName = 'test-room') {
       ],
     });
   }
-  await tick();
+  if (joinSubRoom) {
+    await assignSelfToSubRoom();
+  } else {
+    await tick();
+  }
 }
 
 async function assignSelfToSubRoom(subRoomId = 'room-1') {
@@ -539,6 +547,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
     await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
+    await tick();
 
     expect(getState().joinedSubRoomId).toBeNull();
     expect(getState().participants.find((p) => p.id === 'self-peer')).toMatchObject({
@@ -592,6 +602,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
     await tick();
     lastLkModule!.setMicEnabledCalls = [];
 
@@ -676,6 +688,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
     await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
+    await tick();
     lastLkModule!.setMicEnabledCalls = [];
     const sentBefore = sentMessages.length;
     const eventsBefore = getState().events.length;
@@ -710,6 +724,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
     await tick();
 
     toggleSelfMute();
@@ -749,6 +765,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
     await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
+    await tick();
     lastLkModule!.setMicEnabledCalls = [];
     const sentBefore = sentMessages.length;
     const eventsBefore = getState().events.length;
@@ -776,6 +794,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
     await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
+    await tick();
     lastLkModule!.setMicEnabledCalls = [];
     const eventsBefore = getState().events.length;
 
@@ -798,6 +818,8 @@ describe('VoiceRoom room-based effective volume isolation', () => {
     messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
     await tick();
     lastLkModule!.callbacks.onMediaConnected();
+    await tick();
+    messageHandler!({ type: 'sub_room_left', participantId: 'self-peer', subRoomId: 'room-1' });
     await tick();
     lastLkModule!.setMicEnabledCalls = [];
     const sentBefore = sentMessages.length;
@@ -935,7 +957,7 @@ describe('VoiceRoom room-based effective volume isolation', () => {
 
 describe('VoiceRoom room-scoped join/leave sounds', () => {
   it('does not play join sound for voice-session joined or participant_joined before room membership exists', async () => {
-    await driveToActive('ch-sounds', 'room-sounds');
+    await driveToActive('ch-sounds', 'room-sounds', false);
 
     expect(playNotificationSoundCalls).toEqual([]);
 
@@ -1111,7 +1133,7 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
   });
 
   it('plays one leave sound when the local participant is kicked', async () => {
-    await driveToActive('ch-sounds', 'room-sounds');
+    await driveToActive('ch-sounds', 'room-sounds', false);
 
     messageHandler!({
       type: 'participant_kicked',
@@ -1124,7 +1146,7 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
   });
 
   it('plays one leave sound when the local session is displaced', async () => {
-    await driveToActive('ch-sounds', 'room-sounds');
+    await driveToActive('ch-sounds', 'room-sounds', false);
 
     messageHandler!({ type: 'session_displaced' });
     await tick();
@@ -1134,7 +1156,7 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
   });
 
   it('plays one leave sound when signaling reconnect exhaustion ends an active session', async () => {
-    await driveToActive('ch-sounds', 'room-sounds');
+    await driveToActive('ch-sounds', 'room-sounds', false);
 
     statusChangeHandler!('disconnected');
     await tick();
@@ -1163,7 +1185,7 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
   });
 
   it('plays one leave sound when duplicate terminal paths arrive for the same session', async () => {
-    await driveToActive('ch-sounds', 'room-sounds');
+    await driveToActive('ch-sounds', 'room-sounds', false);
 
     messageHandler!({
       type: 'participant_kicked',
@@ -1328,7 +1350,7 @@ describe('Voice-room media wiring', () => {
 
   // P2: Media token buffering when not active
   describe('P2: Media token buffering when not active', () => {
-    it('media_token before active state is buffered and flushed on joined', async () => {
+    it('media_token before active state is buffered and flushed on sub_room_state', async () => {
       await fc.assert(
         fc.asyncProperty(
           fc.string({ minLength: 1, maxLength: 50 }).filter(s => s.trim().length > 0),
@@ -1349,7 +1371,7 @@ describe('Voice-room media wiring', () => {
             // No LiveKitModule created yet
             expect(lkConstructorCalls).toHaveLength(0);
 
-            // Now transition to active via joined
+            // Transition to active via joined — still buffered (no sub-room yet)
             messageHandler!({
               type: 'joined',
               peerId: 'self-peer',
@@ -1358,7 +1380,17 @@ describe('Voice-room media wiring', () => {
             });
             await tick();
 
-            // Buffered token should have been flushed — LiveKitModule created
+            // Still buffered: active but joinedSubRoomId is still null
+            expect(lkConstructorCalls).toHaveLength(0);
+
+            // sub_room_state snapshot arrives (as backend sends after join) — flushes token
+            messageHandler!({
+              type: 'sub_room_state',
+              rooms: [{ subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] }],
+            });
+            await tick();
+
+            // Buffered token flushed — LiveKitModule created
             expect(lkConstructorCalls).toHaveLength(1);
             expect(lastLkModule!.connectCalls).toHaveLength(1);
             expect(lastLkModule!.connectCalls[0].sfuUrl).toBe(sfuUrl);
@@ -1369,6 +1401,94 @@ describe('Voice-room media wiring', () => {
         ),
         { numRuns: 50 },
       );
+    });
+  });
+
+  // P2b: sub_room_joined ordering race — token arrives before sub_room_state seeds the room
+  describe('P2b: Media token flushed via sub_room_joined when room already in state', () => {
+    it('media_token buffered pre-join is flushed by sub_room_joined when room exists in state', async () => {
+      resetAll();
+      latestState = null;
+      initSession('ch-buf2', 'buf-room2', 'member', (s) => { latestState = s; });
+      await tick();
+
+      messageHandler!({ type: 'auth_success' });
+
+      // Buffer the token before active
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu-srj', token: 'tok-srj' });
+      await tick();
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // joined — active but no sub-room yet
+      messageHandler!({
+        type: 'joined',
+        peerId: 'self-peer',
+        roomId: 'room-srj',
+        participants: [{ participantId: 'self-peer', displayName: 'TestUser' }],
+      });
+      await tick();
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // sub_room_state seeds the room first (room now exists in state)
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [{ subRoomId: 'room-srj', roomNumber: 1, isDefault: true, participantIds: [] }],
+      });
+      await tick();
+      // Room exists but self not in it yet — still buffered
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // sub_room_joined for self — room already in state, joinedSubRoomId becomes non-null
+      messageHandler!({ type: 'sub_room_joined', participantId: 'self-peer', subRoomId: 'room-srj' });
+      await tick();
+
+      // Token flushed via sub_room_joined
+      expect(lkConstructorCalls).toHaveLength(1);
+      expect(lastLkModule!.connectCalls[0]).toEqual({ sfuUrl: 'wss://sfu-srj', token: 'tok-srj' });
+
+      leaveRoom();
+    });
+
+    it('media_token buffered pre-join is flushed by sub_room_state when sub_room_joined arrived before room was seeded', async () => {
+      resetAll();
+      latestState = null;
+      initSession('ch-buf3', 'buf-room3', 'member', (s) => { latestState = s; });
+      await tick();
+
+      messageHandler!({ type: 'auth_success' });
+
+      // Buffer the token before active
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu-srs', token: 'tok-srs' });
+      await tick();
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // joined — active but no sub-room yet
+      messageHandler!({
+        type: 'joined',
+        peerId: 'self-peer',
+        roomId: 'room-srs',
+        participants: [{ participantId: 'self-peer', displayName: 'TestUser' }],
+      });
+      await tick();
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // sub_room_joined arrives before sub_room_state — room not in state yet,
+      // so syncDerivedSubRoomState leaves joinedSubRoomId null → still buffered
+      messageHandler!({ type: 'sub_room_joined', participantId: 'self-peer', subRoomId: 'room-srs' });
+      await tick();
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // sub_room_state snapshot catches up — flushes the token
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [{ subRoomId: 'room-srs', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] }],
+      });
+      await tick();
+
+      expect(lkConstructorCalls).toHaveLength(1);
+      expect(lastLkModule!.connectCalls[0]).toEqual({ sfuUrl: 'wss://sfu-srs', token: 'tok-srs' });
+
+      leaveRoom();
     });
   });
 
@@ -1487,6 +1607,12 @@ describe('Voice-room media wiring', () => {
 
       expect(latestState!.participants.find((p) => p.id === 'self-peer')).toBeTruthy();
       expect(latestState!.events.some((e) => e.message === 'local participant state was restored')).toBe(true);
+
+      // Flush buffered token via sub_room_state snapshot, then leave to test no-room mute
+      messageHandler!({ type: 'sub_room_state', rooms: [{ subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] }] });
+      await tick();
+      messageHandler!({ type: 'sub_room_state', rooms: [{ subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: [] }] });
+      await tick();
 
       toggleSelfMute();
       await tick();
@@ -1839,6 +1965,16 @@ describe('Edge case unit tests', () => {
       });
       await tick();
 
+      // Still buffered: active but not yet in a sub-room
+      expect(lkConstructorCalls).toHaveLength(0);
+
+      // sub_room_state snapshot arrives (as backend sends after join) — flushes token
+      messageHandler!({
+        type: 'sub_room_state',
+        rooms: [{ subRoomId: 'room-1', roomNumber: 1, isDefault: true, participantIds: ['self-peer'] }],
+      });
+      await tick();
+
       expect(lkConstructorCalls).toHaveLength(1);
       expect(lastLkModule!.connectCalls[0]).toEqual({ sfuUrl: 'wss://sfu', token: 'deferred-tok' });
 
@@ -1901,14 +2037,14 @@ describe('Edge case unit tests', () => {
 
     it('startFallbackShare rejects when self is not in a synchronized room', async () => {
       resetAll();
-      await driveToActive();
+      await driveToActive('ch-1', 'test-room', false);
 
       messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
       await tick();
 
       const { startFallbackShare } = await import('../voice-room');
       await expect(startFallbackShare()).rejects.toThrow('Join a room before sharing.');
-      expect(lastLkModule!.startScreenShareCalls).toBe(0);
+      expect(lastLkModule?.startScreenShareCalls ?? 0).toBe(0);
       expect(sentMessages.filter(m => m.type === 'start_share')).toHaveLength(0);
 
       leaveRoom();

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1541,6 +1541,19 @@ function syncDerivedSubRoomState(): void {
   state.joinedSubRoomId = state.participantSubRoomById[state.selfParticipantId] ?? null;
 }
 
+/**
+ * If a media token is buffered and the local user is now in a sub-room,
+ * consume the token and connect media. Called from every handler that can
+ * advance joinedSubRoomId: joined, sub_room_joined, sub_room_state.
+ */
+function flushBufferedMediaTokenIfReady(): void {
+  if (bufferedMediaToken && state.joinedSubRoomId !== null) {
+    const { sfuUrl, token, iceConfig } = bufferedMediaToken;
+    bufferedMediaToken = null;
+    connectMedia(sfuUrl, token, iceConfig);
+  }
+}
+
 function ensureInSubRoomForShare(): void {
   if (state.joinedSubRoomId !== null) return;
   throw new Error('Join a room before sharing.');
@@ -2083,12 +2096,9 @@ function dispatchMessage(raw: unknown): void {
         appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'system', message: 'reconnected — back online' });
       }
 
-      // Flush buffered media token if present
-      if (bufferedMediaToken) {
-        const { sfuUrl, token, iceConfig } = bufferedMediaToken;
-        bufferedMediaToken = null;
-        connectMedia(sfuUrl, token, iceConfig);
-      }
+      // Belt-and-suspenders: flush if the backend ever sends joined with the
+      // user already in a sub-room. Normally fires on sub_room_joined/sub_room_state.
+      flushBufferedMediaTokenIfReady();
 
       // Request chat history after successful join
       if (client) {
@@ -2234,6 +2244,9 @@ function dispatchMessage(raw: unknown): void {
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
+      // Legacy-client fallback: sub_room_joined fires before sub_room_state (room doesn't exist
+      // yet in state when sub_room_joined arrives), so flush here once state catches up.
+      flushBufferedMediaTokenIfReady();
       notify();
       break;
     }
@@ -2292,6 +2305,9 @@ function dispatchMessage(raw: unknown): void {
           ? (srjWasInRoom ? `moved to ${srjRoomLabel}` : `joined ${srjRoomLabel}`)
           : (srjWasInRoom ? `${srjName} moved to ${srjRoomLabel}` : `${srjName} joined ${srjRoomLabel}`);
         appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'join', message: srjMessage, participantId });
+      }
+      if (participantId === state.selfParticipantId) {
+        flushBufferedMediaTokenIfReady();
       }
       notify();
       break;
@@ -2774,7 +2790,7 @@ function dispatchMessage(raw: unknown): void {
         break;
       }
 
-      if (state.machineState !== 'active') {
+      if (state.machineState !== 'active' || state.joinedSubRoomId === null) {
         bufferedMediaToken = { sfuUrl, token, iceConfig };
         break;
       }

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2173,13 +2173,6 @@ function dispatchMessage(raw: unknown): void {
       if (lkModule && state.mediaState === 'connected' && pjId !== state.selfParticipantId) {
         applyEffectiveParticipantVolume(newParticipant);
       }
-      appendEvent({
-        id: makeEventId(),
-        timestamp: timestamp(),
-        type: 'join',
-        message: `${msg.displayName} joined`,
-        participantId: msg.participantId as string,
-      });
       notify();
       break;
     }
@@ -2192,6 +2185,8 @@ function dispatchMessage(raw: unknown): void {
       state.participants = state.participants.filter((p) => p.id !== leftId);
       if (state.participantSubRoomById[leftId]) {
         const leftRoomId = state.participantSubRoomById[leftId];
+        const plRoom = state.subRooms.find((r) => r.id === leftRoomId);
+        const plRoomLabel = plRoom ? `Room ${plRoom.roomNumber}` : 'a room';
         state.subRooms = state.subRooms.map((room) => (
           room.id === leftRoomId
             ? { ...room, participantIds: room.participantIds.filter((id) => id !== leftId) }
@@ -2201,16 +2196,10 @@ function dispatchMessage(raw: unknown): void {
         reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
         playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
         applyEffectiveParticipantVolumes();
+        const plName = leftP?.displayName ?? displayNameCache.get(leftId) ?? leftId;
+        appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'leave', message: `${plName} left ${plRoomLabel}`, participantId: leftId });
       }
       speakingTracker.delete(leftId);
-      const leftName = leftP?.displayName ?? displayNameCache.get(leftId) ?? leftId;
-      appendEvent({
-        id: makeEventId(),
-        timestamp: timestamp(),
-        type: 'leave',
-        message: `${leftName} left`,
-        participantId: leftId,
-      });
       notify();
       break;
     }
@@ -2293,6 +2282,17 @@ function dispatchMessage(raw: unknown): void {
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
+      {
+        const srjName = displayNameCache.get(participantId) ?? state.participants.find((p) => p.id === participantId)?.displayName ?? participantId;
+        const srjRoom = state.subRooms.find((r) => r.id === subRoomId);
+        const srjRoomLabel = srjRoom ? `Room ${srjRoom.roomNumber}` : 'a room';
+        const srjWasInRoom = !!previousParticipantSubRoomById[participantId];
+        const srjIsSelf = participantId === state.selfParticipantId;
+        const srjMessage = srjIsSelf
+          ? (srjWasInRoom ? `moved to ${srjRoomLabel}` : `joined ${srjRoomLabel}`)
+          : (srjWasInRoom ? `${srjName} moved to ${srjRoomLabel}` : `${srjName} joined ${srjRoomLabel}`);
+        appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'join', message: srjMessage, participantId });
+      }
       notify();
       break;
     }
@@ -2302,6 +2302,8 @@ function dispatchMessage(raw: unknown): void {
       const previousJoinedSubRoomId = state.joinedSubRoomId;
       const participantId = msg.participantId as string;
       const subRoomId = msg.subRoomId as string;
+      const srlRoom = state.subRooms.find((r) => r.id === subRoomId);
+      const srlRoomLabel = srlRoom ? `Room ${srlRoom.roomNumber}` : 'a room';
       state.subRooms = state.subRooms.map((room) => (
         room.id === subRoomId
           ? { ...room, participantIds: room.participantIds.filter((id) => id !== participantId) }
@@ -2313,6 +2315,12 @@ function dispatchMessage(raw: unknown): void {
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
       reconcileDesiredSubRoomMembership();
+      {
+        const srlName = displayNameCache.get(participantId) ?? state.participants.find((p) => p.id === participantId)?.displayName ?? participantId;
+        const srlIsSelf = participantId === state.selfParticipantId;
+        const srlMessage = srlIsSelf ? `left ${srlRoomLabel}` : `${srlName} left ${srlRoomLabel}`;
+        appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'leave', message: srlMessage, participantId });
+      }
       notify();
       break;
     }

--- a/clients/wavis-gui/src/shared/CmdButton.tsx
+++ b/clients/wavis-gui/src/shared/CmdButton.tsx
@@ -4,6 +4,7 @@ interface CmdButtonProps {
   active?: boolean;
   danger?: boolean;
   disabled?: boolean;
+  className?: string;
 }
 
 export function CmdButton({
@@ -12,12 +13,13 @@ export function CmdButton({
   active,
   danger,
   disabled,
+  className,
 }: CmdButtonProps) {
   return (
     <button
       onClick={onClick}
       disabled={disabled}
-      className={`text-xs disabled:opacity-40 disabled:cursor-not-allowed border py-0.5 px-1 text-center transition-colors ${
+      className={`text-xs disabled:opacity-40 disabled:cursor-not-allowed border px-1 text-center transition-colors ${className ?? 'py-0.5'} ${
         danger
           ? 'border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-wavis-bg'
           : active

--- a/wavis-backend/src/diagnostics/llm_client.rs
+++ b/wavis-backend/src/diagnostics/llm_client.rs
@@ -430,7 +430,12 @@ fn build_issue_body_prompt(
     format!(
         "You are a bug report formatter for Wavis, a desktop voice chat application.\n\n\
          Generate a structured GitHub issue body. Respond with valid JSON only (no markdown fences):\n\
-         {{\n  \"title\": \"<concise bug title>\",\n  \"body\": \"<full markdown issue body>\"\n}}\n\n\
+         {{\n  \"title\": \"<bug title>\",\n  \"body\": \"<full markdown issue body>\"\n}}\n\n\
+         Title rules:\n\
+         - Maximum 72 characters\n\
+         - Write a direct, descriptive bug summary — do NOT start with \"Bug Report:\"\n\
+         - Use only letters, numbers, spaces, and hyphens (must be git branch-name-friendly)\n\
+         - Example: \"Audio drops when second participant joins room\"\n\n\
          The issue body must contain these sections:\n\
          1. ## Bug Report header\n\
          2. ### Category — \"{category}\"\n\


### PR DESCRIPTION
This PR ensures that media connectivity is delayed until the local participant has successfully joined a sub-room, preventing users from appearing connected while still in the channel lobby.

Key changes:
- Buffers media_token messages until joinedSubRoomId is non-null.
- Flushes the buffer upon joining a sub-room.
- Updated unit tests to verify buffering behavior.

Fixes #64.