### PR TITLE
feat(gui): add focus-main button and hotkey for screen share windows

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { startReceiving, stopReceiving } from './screen-share-viewer';
 import type { ShareQuality } from '@features/voice/voice-room';
@@ -632,6 +633,7 @@ export default function ScreenSharePage() {
           onVoiceVolumeChange={handleVoiceVolumeChange}
           onVoiceMuteToggle={handleVoiceMuteToggle}
           ownerControls={ownerControls}
+          onFocusMain={() => { void WebviewWindow.getByLabel('main').then((win) => win?.setFocus()); }}
         />
 
         {import.meta.env.VITE_DEBUG_SHOW_STREAM_OVERLAY === 'true' && (

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback, memo } from 'react';
 import { Volume2 } from 'lucide-react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
+import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { StreamReceiver } from './screen-share-viewer';
 import { computeGridLayout } from './watch-all-grid';
@@ -10,6 +11,7 @@ import { useAutoHide } from '@shared/hooks/useAutoHide';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import ParticipantMixer, { type MixerParticipant } from '@shared/ParticipantMixer';
 import QuickActionButtons from '@shared/QuickActionButtons';
+import FocusMainButton from '@shared/FocusMainButton';
 import ShareSwitchingOverlay from './ShareSwitchingOverlay';
 
 /* ─── Constants ─────────────────────────────────────────────────── */
@@ -797,6 +799,10 @@ export default function WatchAllPage() {
           isDeafened={userState.isDeafened}
           onToggleMute={() => { void emit('share:toggle-mute'); }}
           onToggleDeafen={() => { void emit('share:toggle-deafen'); }}
+        />
+        <span className="text-wavis-text-secondary opacity-30 select-none leading-none px-0.5">│</span>
+        <FocusMainButton
+          onClick={() => { void WebviewWindow.getByLabel('main').then((win) => win?.setFocus()); }}
         />
         <div className="flex-1" />
         <div className="relative flex items-center gap-1 shrink-0">

--- a/clients/wavis-gui/src/features/settings/Settings.tsx
+++ b/clients/wavis-gui/src/features/settings/Settings.tsx
@@ -4,10 +4,11 @@ const ChannelDetail = lazy(() => import('@features/channels/ChannelDetail'));
 import { useNavigate } from 'react-router';
 import { invoke } from '@tauri-apps/api/core';
 import { emit } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getVersion, getTauriVersion } from '@tauri-apps/api/app';
 import { resetAuth, logout, getServerUrl, getDeviceId, getDisplayName, getAccessToken, INSECURE_TLS_ALLOWED } from '@features/auth/auth';
 import { PROFILE_COLORS } from '@shared/colors';
-import { getProfileColor, setProfileColor, getStoreValue, setStoreValue, STORE_KEYS, getDefaultVolume, DEFAULT_VOLUME, getMinimizeToTray, setMinimizeToTray, getNotificationToggles, setNotificationToggle, getMuteHotkey, setMuteHotkey, DEFAULT_MUTE_HOTKEY, getWatchAllHotkey, setWatchAllHotkey, DEFAULT_WATCH_ALL_HOTKEY, getDenoiseEnabled, setDenoiseEnabled, getNotificationVolume, setNotificationVolume, getSoundVolumes, setSoundVolumes, getInputVolume, setInputVolume, getScreenShareCodec, setScreenShareCodec, type ScreenShareCodecOverride, DEFAULT_SCREEN_SHARE_CODEC } from './settings-store';
+import { getProfileColor, setProfileColor, getStoreValue, setStoreValue, STORE_KEYS, getDefaultVolume, DEFAULT_VOLUME, getMinimizeToTray, setMinimizeToTray, getNotificationToggles, setNotificationToggle, getMuteHotkey, setMuteHotkey, DEFAULT_MUTE_HOTKEY, getWatchAllHotkey, setWatchAllHotkey, DEFAULT_WATCH_ALL_HOTKEY, getFocusMainHotkey, setFocusMainHotkey, DEFAULT_FOCUS_MAIN_HOTKEY, getDenoiseEnabled, setDenoiseEnabled, getNotificationVolume, setNotificationVolume, getSoundVolumes, setSoundVolumes, getInputVolume, setInputVolume, getScreenShareCodec, setScreenShareCodec, type ScreenShareCodecOverride, DEFAULT_SCREEN_SHARE_CODEC } from './settings-store';
 import { updateCachedNotificationVolume, updateCachedSoundVolumes } from '@features/voice/notification-sounds';
 import { updateSessionProfileColor, getState as getVoiceRoomState } from '@features/voice/voice-room';
 import { VolumeSlider } from '@shared/VolumeSlider';
@@ -15,7 +16,7 @@ import { setAudioDevice, setAudioInputVolume, setMediaDenoiseEnabled } from '@fe
 import type { NotificationToggles } from './settings-store';
 import { redactToken } from '@shared/helpers';
 import { useDebug } from '@shared/debug-context';
-import { formatHotkeyCombination, unregisterMuteHotkey, unregisterWatchAllHotkey, isHotkeyRegistered } from '@shared/hotkey-bridge';
+import { formatHotkeyCombination, unregisterMuteHotkey, unregisterWatchAllHotkey, unregisterFocusMainHotkey, registerFocusMainHotkey, isHotkeyRegistered } from '@shared/hotkey-bridge';
 import { Switch } from '../../components/ui/switch';
 import { open } from '@tauri-apps/plugin-shell';
 import { ConfirmTextGate } from '@shared/ConfirmTextGate';
@@ -160,6 +161,11 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
   const [recordedWatchAllModifiers, setRecordedWatchAllModifiers] = useState<string[]>([]);
   const [_recordedWatchAllKey, setRecordedWatchAllKey] = useState<string | null>(null);
   const [watchAllHotkeyError, setWatchAllHotkeyError] = useState<string | null>(null);
+  const [focusMainHotkey, setFocusMainHotkeyState] = useState<string>(DEFAULT_FOCUS_MAIN_HOTKEY);
+  const [recordingFocusMainHotkey, setRecordingFocusMainHotkey] = useState(false);
+  const [recordedFocusMainModifiers, setRecordedFocusMainModifiers] = useState<string[]>([]);
+  const [_recordedFocusMainKey, setRecordedFocusMainKey] = useState<string | null>(null);
+  const [focusMainHotkeyError, setFocusMainHotkeyError] = useState<string | null>(null);
   const denoiseStatus = describeDenoiseStatus({
     denoiseEnabled,
     connectionMode: getVoiceRoomState().connectionMode,
@@ -181,6 +187,7 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
     getNotificationToggles().then(setNotifyToggles);
     getMuteHotkey().then(setMuteHotkeyState);
     getWatchAllHotkey().then(setWatchAllHotkeyState);
+    getFocusMainHotkey().then(setFocusMainHotkeyState);
     getDenoiseEnabled().then(setDenoiseEnabledState);
     getScreenShareCodec().then(setScreenShareCodecState);
     getInputVolume().then(setInputVolumeState);
@@ -346,6 +353,65 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
     document.addEventListener('keydown', handleKeyDown, true);
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, [recordingWatchAllHotkey, watchAllHotkey]);
+
+  // Focus Main hotkey recording: capture keydown events when in recording mode
+  useEffect(() => {
+    if (!recordingFocusMainHotkey) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      if (e.key === 'Escape') {
+        setRecordingFocusMainHotkey(false);
+        setRecordedFocusMainModifiers([]);
+        setRecordedFocusMainKey(null);
+        setFocusMainHotkeyError(null);
+        return;
+      }
+
+      const mods: string[] = [];
+      if (e.ctrlKey) mods.push('Ctrl');
+      if (e.shiftKey) mods.push('Shift');
+      if (e.altKey) mods.push('Alt');
+      if (e.metaKey) mods.push('Meta');
+
+      if (['Control', 'Shift', 'Alt', 'Meta'].includes(e.key)) {
+        setRecordedFocusMainModifiers(mods);
+        return;
+      }
+
+      const mainKey = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+      setRecordedFocusMainModifiers(mods);
+      setRecordedFocusMainKey(mainKey);
+
+      const combo = formatHotkeyCombination(mods, mainKey);
+      setRecordingFocusMainHotkey(false);
+      setRecordedFocusMainModifiers([]);
+      setRecordedFocusMainKey(null);
+      setFocusMainHotkeyError(null);
+
+      const oldHotkey = focusMainHotkey;
+      setFocusMainHotkeyState(combo);
+      setFocusMainHotkey(combo);
+
+      isHotkeyRegistered(oldHotkey).then(async (wasRegistered) => {
+        if (wasRegistered) {
+          try {
+            await unregisterFocusMainHotkey(oldHotkey);
+          } catch {
+            // best effort
+          }
+          // Re-register new hotkey immediately so it works without reconnecting
+          registerFocusMainHotkey(combo, () => {
+            void getCurrentWindow().setFocus();
+          });
+        }
+      }).catch(() => {});
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [recordingFocusMainHotkey, focusMainHotkey]);
 
   return (
     <div className="h-full flex flex-col min-w-0 bg-wavis-bg font-mono text-wavis-text">
@@ -749,6 +815,31 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
               )}
               {watchAllHotkeyError && (
                 <p className="text-wavis-danger text-xs">{watchAllHotkeyError}</p>
+              )}
+              <div>
+                <label className="text-wavis-text-secondary block mb-1">Focus main window hotkey</label>
+                <button
+                  onClick={() => {
+                    setRecordingFocusMainHotkey(true);
+                    setRecordedFocusMainModifiers([]);
+                    setRecordedFocusMainKey(null);
+                    setFocusMainHotkeyError(null);
+                  }}
+                  className="w-full text-left bg-wavis-bg border border-wavis-text-secondary text-wavis-text font-mono text-sm px-2 py-1 outline-none focus:border-wavis-accent"
+                  aria-label="Record focus main hotkey"
+                >
+                  {recordingFocusMainHotkey
+                    ? (recordedFocusMainModifiers.length > 0
+                        ? `${recordedFocusMainModifiers.join('+')}+...`
+                        : 'Press keys...')
+                    : focusMainHotkey}
+                </button>
+              </div>
+              {recordingFocusMainHotkey && (
+                <p className="text-xs text-wavis-text-secondary">Press Escape to cancel</p>
+              )}
+              {focusMainHotkeyError && (
+                <p className="text-wavis-danger text-xs">{focusMainHotkeyError}</p>
               )}
             </div>
           </div>

--- a/clients/wavis-gui/src/features/settings/settings-store.ts
+++ b/clients/wavis-gui/src/features/settings/settings-store.ts
@@ -56,6 +56,7 @@ export const STORE_KEYS = {
   reconnectConfig: 'wavis_reconnect_config',
   muteHotkey: 'wavis_mute_hotkey',
   watchAllHotkey: 'wavis_watch_all_hotkey',
+  focusMainHotkey: 'wavis_focus_main_hotkey',
   logLevel: 'wavis_log_level',
   denoiseEnabled: 'wavis_denoise_enabled',
   channelVolumes: 'wavis_channel_volumes',
@@ -80,6 +81,7 @@ export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
 export const DEFAULT_VOLUME = 70;
 export const DEFAULT_MUTE_HOTKEY = 'Ctrl+Shift+M';
 export const DEFAULT_WATCH_ALL_HOTKEY = 'CmdOrCtrl+Shift+W';
+export const DEFAULT_FOCUS_MAIN_HOTKEY = 'CmdOrCtrl+Shift+Home';
 export const DEFAULT_WINDOWS_SHARE_PATH: WindowsSharePathPreference = 'browser';
 export const DEFAULT_SCREEN_SHARE_CODEC: ScreenShareCodecOverride = 'auto';
 
@@ -223,6 +225,16 @@ export async function getWatchAllHotkey(): Promise<string> {
 
 export async function setWatchAllHotkey(hotkey: string): Promise<void> {
   return setStoreValue(STORE_KEYS.watchAllHotkey, hotkey);
+}
+
+// ─── Focus Main Hotkey ─────────────────────────────────────────────
+
+export async function getFocusMainHotkey(): Promise<string> {
+  return getStoreValue(STORE_KEYS.focusMainHotkey, DEFAULT_FOCUS_MAIN_HOTKEY);
+}
+
+export async function setFocusMainHotkey(hotkey: string): Promise<void> {
+  return setStoreValue(STORE_KEYS.focusMainHotkey, hotkey);
 }
 
 // ─── Denoise ───────────────────────────────────────────────────────

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -62,13 +62,13 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '../../components/ui/too
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { startSending, stopSending, stopSendingForWindow, stopAllSending, resendStream } from '@features/screen-share/screen-share-viewer';
-import { getWatchAllHotkey, setLastChannel, clearLastChannel } from '@features/settings/settings-store';
+import { getWatchAllHotkey, getFocusMainHotkey, setLastChannel, clearLastChannel } from '@features/settings/settings-store';
 
 const DEBUG_SHARE_VIEW = import.meta.env.VITE_DEBUG_SCREEN_SHARE_VIEW === 'true';
 const DEBUG_SHARE_AUDIO = import.meta.env.VITE_DEBUG_SHARE_AUDIO === 'true';
 const LOG_SS = '[wavis:active-room:screen-share]';
 const ROOM_REMOVAL_COUNTDOWN_INTERVAL_MS = 10_000;
-import { registerWatchAllHotkey, unregisterWatchAllHotkey } from '@shared/hotkey-bridge';
+import { registerWatchAllHotkey, unregisterWatchAllHotkey, registerFocusMainHotkey, unregisterFocusMainHotkey } from '@shared/hotkey-bridge';
 import { listenTrayEvents, updateTrayState } from './tray-bridge';
 import type { TrayAction } from './tray-bridge';
 import { useDebug } from '@shared/debug-context';
@@ -646,6 +646,7 @@ export default function ActiveRoom() {
   const [watchAllOpen, setWatchAllOpen] = useState(false);
   const watchAllReadyRef = useRef(false);
   const watchAllHotkeyRef = useRef<string | null>(null);
+  const focusMainHotkeyRef = useRef<string | null>(null);
   const toggleWatchAllRef = useRef<() => void>(() => { });
 
   // Screen share window state (multi-window: one per sharer)
@@ -1488,6 +1489,26 @@ export default function ActiveRoom() {
       if (watchAllHotkeyRef.current) {
         unregisterWatchAllHotkey(watchAllHotkeyRef.current);
         watchAllHotkeyRef.current = null;
+      }
+    };
+  }, [roomState?.mediaState]);
+
+  // Register Focus Main hotkey when media connects
+  useEffect(() => {
+    if (roomState?.mediaState !== 'connected') return;
+
+    let cancelled = false;
+    getFocusMainHotkey().then((hotkey) => {
+      if (cancelled) return;
+      focusMainHotkeyRef.current = hotkey;
+      registerFocusMainHotkey(hotkey, () => { void getCurrentWindow().setFocus(); });
+    });
+
+    return () => {
+      cancelled = true;
+      if (focusMainHotkeyRef.current) {
+        unregisterFocusMainHotkey(focusMainHotkeyRef.current);
+        focusMainHotkeyRef.current = null;
       }
     };
   }, [roomState?.mediaState]);

--- a/clients/wavis-gui/src/shared/FocusMainButton.tsx
+++ b/clients/wavis-gui/src/shared/FocusMainButton.tsx
@@ -1,0 +1,28 @@
+interface FocusMainButtonProps {
+  /** Called when the user clicks the button. The handler is responsible
+   *  for calling setFocus() on the appropriate window — `getCurrentWindow()`
+   *  from a main-window context, `WebviewWindow.getByLabel('main')` from
+   *  a popup window. */
+  onClick: () => void;
+}
+
+/**
+ * Small icon button that requests focus on the main Wavis window.
+ * Used by the screen-share/watch-all popup hover bars and bottom bars.
+ *
+ * Stops mousedown/click propagation to avoid interfering with the
+ * draggable region / hover-bar parent that hosts it.
+ */
+export default function FocusMainButton({ onClick }: FocusMainButtonProps) {
+  return (
+    <button
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => { e.stopPropagation(); onClick(); }}
+      className="px-1.5 flex items-center justify-center text-wavis-text-secondary hover:opacity-70 transition-opacity"
+      aria-label="Focus main window"
+      title="focus main window"
+    >
+      ⌂
+    </button>
+  );
+}

--- a/clients/wavis-gui/src/shared/StreamHoverBar.tsx
+++ b/clients/wavis-gui/src/shared/StreamHoverBar.tsx
@@ -3,6 +3,7 @@ import { Volume2 } from 'lucide-react';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import QuickActionButtons, { SEPARATOR } from '@shared/QuickActionButtons';
 import ParticipantMixer, { type MixerParticipant } from '@shared/ParticipantMixer';
+import FocusMainButton from '@shared/FocusMainButton';
 
 interface StreamHoverBarProps {
   visible: boolean;
@@ -19,6 +20,7 @@ interface StreamHoverBarProps {
   onVoiceVolumeChange: (id: string, vol: number) => void;
   onVoiceMuteToggle: (id: string) => void;
   ownerControls?: ReactNode;
+  onFocusMain?: () => void;
 }
 
 const STREAM_MUTED_ICON = '\u25cb';
@@ -39,6 +41,7 @@ export default function StreamHoverBar({
   onVoiceVolumeChange,
   onVoiceMuteToggle,
   ownerControls,
+  onFocusMain,
 }: StreamHoverBarProps) {
   const [voiceMixerOpen, setVoiceMixerOpen] = useState(false);
 
@@ -57,6 +60,13 @@ export default function StreamHoverBar({
         onToggleMute={onToggleMute}
         onToggleDeafen={onToggleDeafen}
       />
+
+      {onFocusMain && (
+        <>
+          <span className="text-wavis-text-secondary opacity-30 select-none leading-none">{SEPARATOR}</span>
+          <FocusMainButton onClick={onFocusMain} />
+        </>
+      )}
 
       <span className="text-wavis-text-secondary opacity-30 select-none leading-none">{SEPARATOR}</span>
 

--- a/clients/wavis-gui/src/shared/hotkey-bridge.ts
+++ b/clients/wavis-gui/src/shared/hotkey-bridge.ts
@@ -104,6 +104,42 @@ export async function unregisterWatchAllHotkey(hotkey: string): Promise<void> {
   }
 }
 
+/* ─── Focus Main Hotkey ─────────────────────────────────────────── */
+
+/**
+ * Register the Focus Main hotkey — called from connectMedia() success path.
+ * Non-fatal on failure (same policy as Watch All hotkey).
+ */
+export async function registerFocusMainHotkey(
+  hotkey: string,
+  onFocus: () => void,
+): Promise<void> {
+  try {
+    await register(hotkey, (event) => {
+      if (event.state === 'Pressed') {
+        onFocus();
+      }
+    });
+    console.log(LOG, `registered focus-main hotkey: ${hotkey}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(LOG, `failed to register focus-main hotkey "${hotkey}":`, message);
+  }
+}
+
+/**
+ * Unregister the Focus Main hotkey — called from leaveRoom() and
+ * disconnect paths.
+ */
+export async function unregisterFocusMainHotkey(hotkey: string): Promise<void> {
+  try {
+    await unregister(hotkey);
+    console.log(LOG, `unregistered focus-main hotkey: ${hotkey}`);
+  } catch (err) {
+    console.warn(LOG, `failed to unregister focus-main hotkey "${hotkey}":`, err);
+  }
+}
+
 /**
  * Check if a hotkey is currently registered (for settings UI re-registration).
  */


### PR DESCRIPTION
## Summary

- Adds a **Focus Main** button to the WatchAll and WatchOne (ScreenShare) hover bars, letting users return to the main window without Alt-Tabbing
- Backs the button with a configurable global hotkey (default: `CmdOrCtrl+Shift+Home`) registered on media connect and unregistered on disconnect — same lifecycle as the Watch All hotkey
- Adds a **Focus Main hotkey** row to Settings so users can rebind it

## Test plan

- [ ] Open a screen share / WatchAll window and confirm the Focus Main button appears in the hover bar
- [ ] Click the button — main window should come to the foreground
- [ ] Press the default hotkey (`Ctrl+Shift+Home` / `Cmd+Shift+Home`) while focused on a share window — main window gains focus
- [ ] Rebind the hotkey in Settings; confirm the new combo works and the old one no longer fires
- [ ] Leave the room / disconnect — confirm the hotkey is unregistered (no ghost triggers)
- [ ] Confirm WatchOne (ScreenSharePage) hover bar also shows the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)