### PR TITLE
fix(gui): improve camera stability and bandwidth efficiency

### DIFF
--- a/clients/wavis-gui/src/features/settings/__tests__/settings-store.property.test.ts
+++ b/clients/wavis-gui/src/features/settings/__tests__/settings-store.property.test.ts
@@ -34,6 +34,7 @@ interface MockLiveKitModule {
   startScreenShare: () => Promise<boolean>;
   stopScreenShare: () => Promise<void>;
   getActiveScreenShares: () => Array<{ identity: string; stream: MediaStream; startedAtMs: number }>;
+  applyRemoteCameraVisibility: (visibleParticipantIds: ReadonlySet<string>) => void;
 }
 
 function createMockLiveKitModule(
@@ -85,6 +86,7 @@ function createMockLiveKitModule(
     startScreenShare: vi.fn(async () => true),
     stopScreenShare: vi.fn(async () => {}),
     getActiveScreenShares: vi.fn(() => []),
+    applyRemoteCameraVisibility: vi.fn(() => {}),
   };
 
   return module;

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1538,7 +1538,7 @@ export default function ActiveRoom() {
     : false;
   const showCameraButton = shouldMountCameraButton(voiceRoomConnected, supportedCapturePlatform);
   const videoButtonLabel = cameraButtonLabel(roomState?.cameraIntent ?? false);
-  const cameraLabel = roomState?.cameraIntent ? '/camera on' : '/camera off';
+  const cameraLabel = roomState?.cameraIntent ? '/stopcamera' : '/camera';
   const sharers = roomState?.participants.filter((p) => p.isSharing) ?? [];
   const watchAllScope = getWatchAllScope(roomState);
   const shareEnabled = roomState

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -191,10 +191,12 @@ vi.mock('livekit-client', () => ({
     MediaDevicesError: 'mediaDevicesError',
     TrackMuted: 'trackMuted',
     TrackUnmuted: 'trackUnmuted',
+    TrackStreamStateChanged: 'trackStreamStateChanged',
   },
   Track: {
     Kind: { Audio: 'audio', Video: 'video' },
     Source: { Microphone: 'microphone', Camera: 'camera', ScreenShare: 'screen_share', ScreenShareAudio: 'screen_share_audio' },
+    StreamState: { Paused: 'paused', Active: 'active' },
   },
   ConnectionQuality: {
     Excellent: 'excellent',
@@ -1036,6 +1038,79 @@ describe('camera publish/unpublish', () => {
     });
   });
 
+  // Bug 6 regression: cheap webcams that can't satisfy 1280x720 throw
+  // OverconstrainedError on applyConstraints. The module must transparently
+  // retry with fps-only so the bitrate cap still applies and the upstream
+  // retry loop is not triggered for a hardware mismatch.
+  it('setCameraQuality falls back to fps-only constraints on OverconstrainedError', async () => {
+    const overconstrained = new Error('cannot satisfy width');
+    overconstrained.name = 'OverconstrainedError';
+
+    const mediaTrack = createMockCameraMediaTrack('camera-track-overconstrained');
+    mediaTrack.applyConstraints = vi
+      .fn<(constraints: MediaTrackConstraints) => Promise<void>>()
+      .mockRejectedValueOnce(overconstrained)
+      .mockResolvedValueOnce(undefined);
+
+    const sender = {
+      setParameters: vi.fn(async () => {}),
+    };
+    const publication = {
+      trackSid: 'camera-overconstrained',
+      source: 'camera',
+      kind: 'video',
+      track: {
+        sid: 'camera-overconstrained',
+        mediaStreamTrack: mediaTrack,
+        sender,
+      },
+    };
+    const mediaDevices = createMockMediaDevices();
+    mediaDevices.getUserMedia = vi.fn(async () => ({
+      getVideoTracks: () => [mediaTrack],
+      getTracks: () => [mediaTrack],
+    }));
+    vi.stubGlobal('navigator', {
+      userAgent: '',
+      mediaDevices,
+    });
+    mockRoom.localParticipant.publishTrack = vi.fn(async () => {
+      mockRoom.localParticipant.trackPublications.set('camera-overconstrained', publication);
+      return publication;
+    });
+
+    const mod = new LiveKitModule(createMockCallbacks());
+    await driveToConnected(mod);
+    await mod.publishCamera({
+      deviceId: 'camera-device-overconstrained',
+      quality: CAMERA_QUALITY_HIGH,
+    });
+    // Reset the spy after publish so we only see setCameraQuality's calls.
+    (mediaTrack.applyConstraints as ReturnType<typeof vi.fn>).mockClear();
+    (mediaTrack.applyConstraints as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(overconstrained)
+      .mockResolvedValueOnce(undefined);
+
+    await expect(mod.setCameraQuality(CAMERA_QUALITY_HIGH)).resolves.toBeUndefined();
+
+    expect(mediaTrack.applyConstraints).toHaveBeenCalledTimes(2);
+    expect(mediaTrack.applyConstraints).toHaveBeenNthCalledWith(1, {
+      width: CAMERA_QUALITY_HIGH.width,
+      height: CAMERA_QUALITY_HIGH.height,
+      frameRate: CAMERA_QUALITY_HIGH.maxFps,
+    });
+    expect(mediaTrack.applyConstraints).toHaveBeenNthCalledWith(2, {
+      frameRate: CAMERA_QUALITY_HIGH.maxFps,
+    });
+    // The bitrate cap still goes through.
+    expect(sender.setParameters).toHaveBeenCalledWith({
+      encodings: [{
+        maxBitrate: CAMERA_QUALITY_HIGH.maxBitrate,
+        maxFramerate: CAMERA_QUALITY_HIGH.maxFps,
+      }],
+    });
+  });
+
   it('replaceCameraDevice swaps the published camera track and stops the old track after replace resolves', async () => {
     const oldTrack = createMockCameraMediaTrack('camera-old');
     const newTrack = createMockCameraMediaTrack('camera-new');
@@ -1105,6 +1180,7 @@ describe('camera publish/unpublish', () => {
       kind: 'video',
       isMuted: false,
       setSubscribed: vi.fn(),
+      setEnabled: vi.fn(),
     };
     const remoteTrack = {
       sid: 'remote-camera-pub',
@@ -1120,6 +1196,9 @@ describe('camera publish/unpublish', () => {
     emitRoomEvent('trackUnpublished', publication, participant);
 
     expect(publication.setSubscribed).toHaveBeenCalledWith(true);
+    // adaptiveStream fix: setEnabled(true) must be called on subscribe so the track is
+    // not paused by LiveKit when VideoTile bypasses track.attach().
+    expect(publication.setEnabled).toHaveBeenCalledWith(true);
     expect(cbs.calls).toContainEqual({
       method: 'onRemoteCameraPublished',
       args: ['remote-camera-user'],
@@ -1140,6 +1219,76 @@ describe('camera publish/unpublish', () => {
       method: 'onRemoteCameraUnpublished',
       args: ['remote-camera-user'],
     });
+  });
+
+  // adaptiveStream defense-in-depth: even if subscribe-time setEnabled(true) somehow
+  // fails to keep the camera enabled, a Paused stream-state event must re-enable it.
+  it('re-enables a remote camera publication when its stream state transitions to Paused', async () => {
+    const cbs = createMockCallbacks();
+    const mod = new LiveKitModule(cbs);
+    await driveToConnected(mod);
+
+    const participant = { identity: 'remote-camera-paused' };
+    const publication = {
+      trackSid: 'remote-camera-paused-pub',
+      source: 'camera',
+      kind: 'video',
+      isMuted: false,
+      setSubscribed: vi.fn(),
+      setEnabled: vi.fn(),
+    };
+    const remoteTrack = {
+      sid: 'remote-camera-paused-pub',
+      kind: 'video',
+      mediaStreamTrack: createMockCameraMediaTrack('remote-camera-paused-track'),
+    };
+
+    emitRoomEvent('trackPublished', publication, participant);
+    emitRoomEvent('trackSubscribed', remoteTrack, publication, participant);
+    publication.setEnabled.mockClear();
+
+    emitRoomEvent('trackStreamStateChanged', publication, 'paused', participant);
+    expect(publication.setEnabled).toHaveBeenCalledWith(true);
+
+    publication.setEnabled.mockClear();
+    emitRoomEvent('trackStreamStateChanged', publication, 'active', participant);
+    expect(publication.setEnabled).not.toHaveBeenCalled();
+  });
+
+  it('applyRemoteCameraVisibility subscribes/unsubscribes only what changed', async () => {
+    const cbs = createMockCallbacks();
+    const mod = new LiveKitModule(cbs);
+    await driveToConnected(mod);
+
+    const makePub = (sid: string, isSubscribed: boolean) => ({
+      trackSid: sid,
+      source: 'camera',
+      kind: 'video',
+      isSubscribed,
+      setSubscribed: vi.fn(),
+    });
+    const aliceCamPub = makePub('alice-cam', true);
+    const bobCamPub = makePub('bob-cam', true);
+    const carolCamPub = makePub('carol-cam', false);
+    const alice = { identity: 'alice', getTrackPublication: vi.fn((src: string) => src === 'camera' ? aliceCamPub : undefined) };
+    const bob = { identity: 'bob', getTrackPublication: vi.fn((src: string) => src === 'camera' ? bobCamPub : undefined) };
+    const carol = { identity: 'carol', getTrackPublication: vi.fn((src: string) => src === 'camera' ? carolCamPub : undefined) };
+    const dave = { identity: 'dave', getTrackPublication: vi.fn(() => undefined) };
+    mockRoom.remoteParticipants = new Map([
+      ['alice', alice],
+      ['bob', bob],
+      ['carol', carol],
+      ['dave', dave],
+    ]) as unknown as typeof mockRoom.remoteParticipants;
+
+    // Visibility set says only alice and carol are visible. bob (currently subscribed)
+    // should be unsubscribed; carol (currently unsubscribed) should be subscribed.
+    // alice (already subscribed) and dave (no camera publication) should be no-ops.
+    mod.applyRemoteCameraVisibility(new Set(['alice', 'carol']));
+
+    expect(aliceCamPub.setSubscribed).not.toHaveBeenCalled();
+    expect(bobCamPub.setSubscribed).toHaveBeenCalledWith(false);
+    expect(carolCamPub.setSubscribed).toHaveBeenCalledWith(true);
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera-regressions.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera-regressions.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Regression tests for video-feed bug fixes.
+ *
+ * Each test pins a specific bug that the existing property/example coverage
+ * did NOT catch:
+ *
+ *   - Bug 3: rapid toggleCameraIntent calls must not interleave (publish-while-
+ *     unpublishing race that left intent and publication out of sync).
+ *   - Bug 4: lastRequestedCameraQualityTier must not be recorded before the
+ *     attempt succeeds — after retry exhaustion, a follow-up handler that
+ *     re-evaluates the SAME desired tier MUST trigger a fresh attempt rather
+ *     than being short-circuited at the dedupe check.
+ *   - Bug 6: setCameraQuality must transparently downgrade to fps-only
+ *     constraints on OverconstrainedError rather than rejecting and retrying.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { setupVoiceRoomCameraHarness } from './voice-room-camera.test-helpers';
+
+/** Run several microtasks so async chains in voice-room can settle. */
+async function flush(harness: { tick: () => Promise<void> }, times = 6): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await harness.tick();
+  }
+}
+
+/* ─── Bug 3: toggle serialisation ─────────────────────────────── */
+
+describe('Bug 3: toggleCameraIntent serialises concurrent invocations', () => {
+  it('does not interleave a publish and an unpublish under rapid clicks', async () => {
+    const harness = await setupVoiceRoomCameraHarness();
+
+    try {
+      await harness.driveToActive();
+      await harness.connectMedia();
+
+      // Make publishCamera slow so the second click lands while the first is in flight.
+      let resolvePublish: ((value: { trackId: string }) => void) | null = null;
+      harness.state.publishCameraImpl = (module, opts) => new Promise((resolve) => {
+        const stop = vi.fn();
+        module.localCameraTrack = {
+          id: `camera-${opts.deviceId ?? 'default'}`,
+          kind: 'video',
+          stop,
+        } as unknown as MediaStreamTrack;
+        resolvePublish = resolve;
+      });
+
+      const firstToggle = harness.voiceRoom.toggleCameraIntent();
+      // Fire a second toggle while the first is still pending.
+      const secondToggle = harness.voiceRoom.toggleCameraIntent();
+
+      // Let the first toggle's async chain reach the publishCamera mock.
+      await flush(harness);
+      // Critical: only one publish should be visible to the SDK at this point.
+      expect(harness.state.lastLiveKitModule!.publishCameraCalls).toHaveLength(1);
+      // No unpublish has been dispatched yet — the second toggle is queued
+      // behind the chain rather than racing the first.
+      expect(harness.state.lastLiveKitModule!.unpublishCameraCalls).toBe(0);
+
+      // Now let the publish complete.
+      resolvePublish!({ trackId: 'first-publish' });
+      await firstToggle;
+      await secondToggle;
+
+      // Ending state: two clicks, parity even, intent and publication agree.
+      expect(harness.voiceRoom.getState().cameraIntent).toBe(false);
+      expect(harness.voiceRoom.getState().cameraPublication).toBe('idle');
+      expect(harness.state.lastLiveKitModule!.publishCameraCalls).toHaveLength(1);
+      expect(harness.state.lastLiveKitModule!.unpublishCameraCalls).toBe(1);
+      // The operation log must show publish-before-unpublish, never overlapping.
+      expect(
+        harness.state.lastLiveKitModule!.cameraOperationLog
+          .filter((op) => op.type === 'publish' || op.type === 'unpublish')
+          .map((op) => op.type),
+      ).toEqual(['publish', 'unpublish']);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it('preserves intent/publication agreement across many rapid toggles', async () => {
+    const harness = await setupVoiceRoomCameraHarness();
+
+    try {
+      await harness.driveToActive();
+      await harness.connectMedia();
+
+      // Fire 8 toggles concurrently — chain ordering must keep them sequential.
+      const promises = Array.from({ length: 8 }, () => harness.voiceRoom.toggleCameraIntent());
+      await Promise.all(promises);
+
+      // 8 toggles → ends idle. publishes == unpublishes (both 4).
+      expect(harness.voiceRoom.getState().cameraIntent).toBe(false);
+      expect(harness.voiceRoom.getState().cameraPublication).toBe('idle');
+      expect(harness.state.lastLiveKitModule!.publishCameraCalls).toHaveLength(4);
+      expect(harness.state.lastLiveKitModule!.unpublishCameraCalls).toBe(4);
+    } finally {
+      harness.cleanup();
+    }
+  });
+});
+
+/* ─── Bug 4: post-exhaustion dedupe recovery ──────────────────── */
+
+describe('Bug 4: quality update controller does not poison the dedupe cache on retry exhaustion', () => {
+  it('a follow-up applyCameraQualityForShareState that desires the same failed tier still attempts a fresh apply', async () => {
+    vi.useFakeTimers();
+    const harness = await setupVoiceRoomCameraHarness();
+    const { CAMERA_QUALITY_RETRY_INTERVAL_MS, CAMERA_QUALITY_MAX_ATTEMPTS } =
+      harness.voiceRoom.__CAMERA_TEST_HOOKS__;
+
+    try {
+      await harness.driveToActive();
+      await harness.connectMedia();
+      // Publish at HIGH (no share active) — sets lastRequestedCameraQualityTier='high'.
+      await harness.voiceRoom.toggleCameraIntent();
+
+      // Now make every setCameraQuality call fail so we drive the retry loop
+      // to exhaustion. With the OLD bug, lastRequestedCameraQualityTier would
+      // be poisoned to 'low' before the first attempt; after exhaustion the
+      // very next handler that desires 'low' would be skipped at the dedupe.
+      let failNextCalls = true;
+      harness.state.setCameraQualityImpl = vi.fn(async () => {
+        if (failNextCalls) throw new Error('quality update failed');
+      });
+
+      // share_started → desires LOW. Drive retries to exhaustion.
+      harness.emitMessage({
+        type: 'share_started',
+        participantId: 'peer-2',
+        displayName: 'Alice',
+        shareType: 'screen_audio',
+      });
+      await harness.tick();
+      expect(harness.state.lastLiveKitModule!.setCameraQualityCalls).toHaveLength(1);
+
+      for (let attempt = 1; attempt < CAMERA_QUALITY_MAX_ATTEMPTS; attempt += 1) {
+        await vi.advanceTimersByTimeAsync(CAMERA_QUALITY_RETRY_INTERVAL_MS);
+      }
+      expect(harness.state.lastLiveKitModule!.setCameraQualityCalls).toHaveLength(CAMERA_QUALITY_MAX_ATTEMPTS);
+      expect(
+        harness.voiceRoom.getState().events.some((event) =>
+          event.message.includes(`camera quality update failed after ${CAMERA_QUALITY_MAX_ATTEMPTS} attempts (low)`)),
+      ).toBe(true);
+
+      // Re-enable success on the next call.
+      failNextCalls = false;
+
+      // Now a non-transition handler re-evaluates the same desired tier.
+      // sub_room_state with the same membership doesn't change isSharing or
+      // joinedSubRoomId, but it does call applyCameraQualityForShareState.
+      // Desired = LOW (share is still active). With the OLD bug,
+      // lastRequestedCameraQualityTier === 'low' would short-circuit this call
+      // and the camera would stay stuck at HIGH. With the fix, last is still
+      // 'high' (only mutated on success), so the call goes through.
+      const callsBefore = harness.state.lastLiveKitModule!.setCameraQualityCalls.length;
+      harness.emitMessage({
+        type: 'sub_room_state',
+        rooms: [
+          {
+            subRoomId: 'room-1',
+            roomNumber: 1,
+            isDefault: true,
+            participantIds: ['self-peer', 'peer-2'],
+          },
+        ],
+      });
+      await flush(harness);
+
+      const callsAfter = harness.state.lastLiveKitModule!.setCameraQualityCalls.length;
+      expect(callsAfter).toBeGreaterThan(callsBefore);
+      expect(
+        harness.state.lastLiveKitModule!.setCameraQualityCalls.at(-1)?.tier,
+      ).toBe('low');
+    } finally {
+      harness.cleanup();
+      vi.useRealTimers();
+    }
+  });
+});
+
+/* ─── Bug 6: OverconstrainedError fallback (orchestrator side) ── */
+
+describe('Bug 6: setCameraQuality fallback prevents the retry loop from firing', () => {
+  it('a successful setCameraQuality (real module already absorbed OverconstrainedError) does not trigger retries', async () => {
+    vi.useFakeTimers();
+    const harness = await setupVoiceRoomCameraHarness();
+    const { CAMERA_QUALITY_RETRY_INTERVAL_MS, CAMERA_QUALITY_MAX_ATTEMPTS } =
+      harness.voiceRoom.__CAMERA_TEST_HOOKS__;
+
+    try {
+      await harness.driveToActive();
+      await harness.connectMedia();
+      await harness.voiceRoom.toggleCameraIntent();
+
+      // The real LiveKitModule.setCameraQuality catches OverconstrainedError
+      // internally and re-applies fps-only — from voice-room's perspective
+      // this is just a plain successful single call. We model that here.
+      let setQualityCalls = 0;
+      harness.state.setCameraQualityImpl = vi.fn(async () => {
+        setQualityCalls += 1;
+      });
+
+      harness.emitMessage({
+        type: 'share_started',
+        participantId: 'peer-2',
+        displayName: 'Alice',
+        shareType: 'screen_audio',
+      });
+      await harness.tick();
+
+      // Even after letting the retry-interval pass several times, only one
+      // attempt should have been made.
+      await vi.advanceTimersByTimeAsync(CAMERA_QUALITY_RETRY_INTERVAL_MS * (CAMERA_QUALITY_MAX_ATTEMPTS + 1));
+      expect(setQualityCalls).toBe(1);
+      expect(
+        harness.voiceRoom.getState().events.some((event) =>
+          event.message.includes('camera quality update failed')),
+      ).toBe(false);
+    } finally {
+      harness.cleanup();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera-retry.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera-retry.test.ts
@@ -6,6 +6,8 @@ describe('VoiceRoom camera quality retry timing', () => {
   it('retries failed quality updates three times with 1s spacing and then stops', async () => {
     vi.useFakeTimers();
     const harness = await setupVoiceRoomCameraHarness();
+    const { CAMERA_QUALITY_RETRY_INTERVAL_MS, CAMERA_QUALITY_MAX_ATTEMPTS } =
+      harness.voiceRoom.__CAMERA_TEST_HOOKS__;
 
     try {
       await harness.driveToActive();
@@ -27,7 +29,8 @@ describe('VoiceRoom camera quality retry timing', () => {
       expect(harness.state.lastLiveKitModule).not.toBeNull();
       expect(harness.state.lastLiveKitModule!.setCameraQualityCalls.map((call) => call.tier)).toEqual(['low']);
 
-      await vi.advanceTimersByTimeAsync(999);
+      // First retry — just before the interval, no new attempt.
+      await vi.advanceTimersByTimeAsync(CAMERA_QUALITY_RETRY_INTERVAL_MS - 1);
       expect(harness.state.lastLiveKitModule!.setCameraQualityCalls).toHaveLength(1);
 
       await vi.advanceTimersByTimeAsync(1);
@@ -36,7 +39,8 @@ describe('VoiceRoom camera quality retry timing', () => {
         'low',
       ]);
 
-      await vi.advanceTimersByTimeAsync(999);
+      // Second retry, same spacing.
+      await vi.advanceTimersByTimeAsync(CAMERA_QUALITY_RETRY_INTERVAL_MS - 1);
       expect(harness.state.lastLiveKitModule!.setCameraQualityCalls).toHaveLength(2);
 
       await vi.advanceTimersByTimeAsync(1);
@@ -47,11 +51,12 @@ describe('VoiceRoom camera quality retry timing', () => {
       ]);
       expect(
         harness.voiceRoom.getState().events.some((event) =>
-          event.message.includes('camera quality update failed after 3 attempts (low)')),
+          event.message.includes(`camera quality update failed after ${CAMERA_QUALITY_MAX_ATTEMPTS} attempts (low)`)),
       ).toBe(true);
 
-      await vi.advanceTimersByTimeAsync(1_000);
-      expect(harness.state.lastLiveKitModule!.setCameraQualityCalls).toHaveLength(3);
+      // After the cap, no further attempts even if more time passes.
+      await vi.advanceTimersByTimeAsync(CAMERA_QUALITY_RETRY_INTERVAL_MS);
+      expect(harness.state.lastLiveKitModule!.setCameraQualityCalls).toHaveLength(CAMERA_QUALITY_MAX_ATTEMPTS);
     } finally {
       harness.cleanup();
       vi.useRealTimers();

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
@@ -180,6 +180,7 @@ type IntegrationMockLiveKitModule = {
   setCameraQuality: (quality: { tier: string }) => Promise<void>;
   replaceCameraDevice: (deviceId: string | null) => Promise<{ trackId: string }>;
   getLocalCameraTrack: () => MediaStreamTrack | null;
+  applyRemoteCameraVisibility: (visibleParticipantIds: ReadonlySet<string>) => void;
   setParticipantVolume: (id: string, vol: number) => void;
   setMasterVolume: (vol: number) => void;
   setScreenShareAudioVolume: (id: string, vol: number) => void;
@@ -265,6 +266,7 @@ function createIntegrationMockLiveKitModule(
       return { trackId: module.localCameraTrack.id };
     }),
     getLocalCameraTrack: vi.fn(() => module.localCameraTrack),
+    applyRemoteCameraVisibility: vi.fn(() => {}),
     setParticipantVolume: vi.fn(() => {}),
     setMasterVolume: vi.fn(() => {}),
     setScreenShareAudioVolume: vi.fn(() => {}),

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.test-helpers.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.test-helpers.ts
@@ -28,6 +28,7 @@ export type MockVoiceRoomCameraLiveKitModule = {
   setCameraQuality: (quality: { tier: string }) => Promise<void>;
   replaceCameraDevice: (deviceId: string | null) => Promise<{ trackId: string }>;
   getLocalCameraTrack: () => MediaStreamTrack | null;
+  applyRemoteCameraVisibility: (visibleParticipantIds: ReadonlySet<string>) => void;
   setParticipantVolume: (id: string, vol: number) => void;
   setMasterVolume: (vol: number) => void;
   setScreenShareAudioVolume: (id: string, vol: number) => void;
@@ -141,6 +142,7 @@ function createMockLiveKitModule(
       return { trackId: module.localCameraTrack.id };
     }),
     getLocalCameraTrack: vi.fn(() => module.localCameraTrack),
+    applyRemoteCameraVisibility: vi.fn(() => {}),
     setParticipantVolume: vi.fn(() => {}),
     setMasterVolume: vi.fn(() => {}),
     setScreenShareAudioVolume: vi.fn(() => {}),

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -68,6 +68,7 @@ interface MockLiveKitModule {
   setCameraQuality: (quality: { tier: string }) => Promise<void>;
   replaceCameraDevice: (deviceId: string | null) => Promise<{ trackId: string }>;
   getLocalCameraTrack: () => MediaStreamTrack | null;
+  applyRemoteCameraVisibility: (visibleParticipantIds: ReadonlySet<string>) => void;
   setParticipantVolume: (id: string, vol: number) => void;
   setMasterVolume: (vol: number) => void;
   setScreenShareAudioVolume: (id: string, vol: number) => void;
@@ -130,6 +131,7 @@ function createMockLkModule(callbacks: Record<string, (...args: unknown[]) => vo
       return { trackId: `camera-${deviceId ?? 'default'}` };
     }),
     getLocalCameraTrack: vi.fn(() => mod.localCameraTrack),
+    applyRemoteCameraVisibility: vi.fn(() => {}),
     setParticipantVolume: vi.fn((id: string, vol: number) => { mod.setParticipantVolumeCalls.push({ id, vol }); }),
     setMasterVolume: vi.fn((vol: number) => { mod.setMasterVolumeCalls.push(vol); }),
     setScreenShareAudioVolume: vi.fn((id: string, vol: number) => { mod.setScreenShareAudioVolumeCalls.push({ id, vol }); }),

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -235,9 +235,7 @@ function classifyCameraCaptureError(error: unknown): CameraStartError {
 
 export const MIC_OPUS_BITRATE_BPS = 48_000;
 export const SYS_AUDIO_OPUS_BITRATE_BPS = 128_000;
-// Keep in sync with clients/wavis-gui/scripts/apply-livekit-transceiver-reuse-fix.mjs
-// and revisit on every livekit-client version bump.
-const INACTIVE_VIDEO_TRANSCEIVER_CAP = 2;
+
 
 type TrackPublishOptionsWithAudioBitrate = TrackPublishOptions & {
   audioBitrate?: number;
@@ -1538,40 +1536,6 @@ export class LiveKitModule {
       LOG,
       `[share-leak] session=${session.summary.shareSessionId} publish_start sender_count=${senderCount} transceivers=${transceiverCount} reusable_inactive_video_transceiver=${diagnostics.reuseExpected}`,
     );
-  }
-
-  private sweepInactiveVideoTransceivers(): void {
-    const peerConnection = this.getPublisherPeerConnection();
-    if (!peerConnection) {
-      return;
-    }
-
-    const inactiveVideoTransceivers = peerConnection
-      .getTransceivers()
-      .filter(isInactiveVideoLeakCandidate);
-    const before = inactiveVideoTransceivers.length;
-    if (before <= INACTIVE_VIDEO_TRANSCEIVER_CAP) {
-      return;
-    }
-
-    for (const transceiver of inactiveVideoTransceivers.slice(INACTIVE_VIDEO_TRANSCEIVER_CAP)) {
-      try {
-        transceiver.stop();
-      } catch {
-        // Best-effort leak trimming should not block the next publish attempt.
-      }
-    }
-
-    const after = peerConnection
-      .getTransceivers()
-      .filter(isInactiveVideoLeakCandidate)
-      .length;
-    emitTelemetryEvent({
-      name: 'share.leak.transceiver_cap',
-      before,
-      after,
-      ts: Date.now(),
-    });
   }
 
   // Stop ALL inactive video transceivers before each screen share publish.

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -93,6 +93,64 @@ const CAMERA_CAPTURE_TIMEOUT_MS = 10_000;
 const CAMERA_PUBLISH_TIMEOUT_MS = 5_000;
 const REMOTE_CAMERA_READY_TIMEOUT_MS = 10_000;
 
+/**
+ * Open a camera device via getUserMedia with a hard timeout. Standard
+ * `getUserMedia` does not accept an AbortSignal, so we cannot truly cancel an
+ * in-flight request — the load-bearing protection here is the post-resolve
+ * cleanup: if the browser resolves the stream after the timeout sentinel
+ * already rejected, every track is stopped immediately and a `timeout` error
+ * is thrown. This guarantees no orphaned camera (LED on, device locked from
+ * other apps) on slow USB enumeration.
+ *
+ * @param deviceId — concrete deviceId or null for the browser/Tauri default.
+ * @returns the resolved video MediaStreamTrack on success.
+ * @throws CameraStartError — `timeout` when the deadline expires,
+ *   `device_unavailable` when the stream has no video track, or any error
+ *   from getUserMedia (caller classifies via classifyCameraCaptureError).
+ */
+async function openCameraDevice(deviceId: string | null): Promise<MediaStreamTrack> {
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+    timedOut = true;
+  }, CAMERA_CAPTURE_TIMEOUT_MS);
+
+  // The browser request runs to completion regardless — we just observe the
+  // result and stop everything if we already gave up waiting.
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      video: deviceId === null ? true : { deviceId },
+    });
+  } catch (error) {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (timedOut) {
+      throw { kind: 'timeout' } satisfies CameraStartError;
+    }
+    throw error;
+  }
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+
+  if (timedOut) {
+    // Late-resolve race: the browser handed us a live stream after we already
+    // rejected. Stop every track so the camera LED goes off and the device is
+    // released, then throw the timeout we promised.
+    stream.getTracks().forEach((t) => t.stop());
+    throw { kind: 'timeout' } satisfies CameraStartError;
+  }
+
+  const track = stream.getVideoTracks()[0] ?? null;
+  if (!track) {
+    throw { kind: 'device_unavailable' } satisfies CameraStartError;
+  }
+  return track;
+}
+
 export const LIVEKIT_ROOM_OPTIONS = {
   adaptiveStream: true,
   dynacast: false,
@@ -1125,12 +1183,15 @@ export class LiveKitModule {
         return;
       }
 
-      if (typeof (video as HTMLVideoElement & {
-        requestVideoFrameCallback?: (callback: () => void) => void;
-      }).requestVideoFrameCallback === 'function') {
-        (video as HTMLVideoElement & {
-          requestVideoFrameCallback: (callback: () => void) => void;
-        }).requestVideoFrameCallback(() => finish());
+      const videoWithRvfc = video as HTMLVideoElement & {
+        requestVideoFrameCallback?: (callback: () => void) => number;
+        cancelVideoFrameCallback?: (handle: number) => void;
+      };
+      if (typeof videoWithRvfc.requestVideoFrameCallback === 'function') {
+        const rafHandle = videoWithRvfc.requestVideoFrameCallback(() => finish());
+        // Store the handle so cleanup() can cancel it on WebKit where the
+        // callback may stay queued after srcObject is nulled.
+        (video as HTMLVideoElement & { _rvfcHandle?: number })._rvfcHandle = rafHandle;
         return;
       }
 
@@ -1151,6 +1212,15 @@ export class LiveKitModule {
       if (timeout !== null) {
         clearTimeout(timeout);
         timeout = null;
+      }
+      // Cancel any pending requestVideoFrameCallback before detaching srcObject
+      // so WebKit doesn't fire the callback on a detached element.
+      const videoWithRvfc = video as HTMLVideoElement & {
+        cancelVideoFrameCallback?: (handle: number) => void;
+        _rvfcHandle?: number;
+      };
+      if (typeof videoWithRvfc.cancelVideoFrameCallback === 'function' && videoWithRvfc._rvfcHandle !== undefined) {
+        videoWithRvfc.cancelVideoFrameCallback(videoWithRvfc._rvfcHandle);
       }
       video.srcObject = null;
       video.onloadeddata = null;
@@ -1502,6 +1572,30 @@ export class LiveKitModule {
       after,
       ts: Date.now(),
     });
+  }
+
+  // Stop ALL inactive video transceivers before each screen share publish.
+  // This prevents the LiveKit transceiver reuse patch from claiming a stale
+  // m-line that was previously used for camera (or an earlier screen share
+  // session), which confuses the SFU: the SFU associates the new screen share
+  // track with the old trackSid from that m-line, breaking routing for viewers.
+  // Stopped transceivers are skipped by `isStopped` checks in both the reuse
+  // patch and the sweep, so a fresh transceiver is always created — giving the
+  // SFU a clean, unambiguous m-line for the new AddTrack signal.
+  private stopAllInactiveVideoTransceivers(): void {
+    const peerConnection = this.getPublisherPeerConnection();
+    if (!peerConnection) {
+      return;
+    }
+    for (const transceiver of peerConnection.getTransceivers()) {
+      if (isInactiveVideoLeakCandidate(transceiver)) {
+        try {
+          transceiver.stop();
+        } catch {
+          // Best-effort: do not block the next publish attempt.
+        }
+      }
+    }
   }
 
   private captureShareLeakPublishDiagnostics(): void {
@@ -2204,6 +2298,13 @@ export class LiveKitModule {
       ) => {
         if (this.disposed) return;
         if (track.kind === Track.Kind.Video && publication.source === Track.Source.Camera) {
+          // Force-keep this subscription enabled regardless of adaptive stream.
+          // VideoTile attaches via `video.srcObject = new MediaStream([track])`, bypassing
+          // LiveKit's element observer (track.attach()/registerElement). With no registered
+          // consumer, adaptiveStream pauses the track server-side after the first frame.
+          // Same override the screen-share path uses below.
+          publication.setEnabled(true);
+
           const previous = this.cameraTracks.get(participant.identity);
           previous?.readyCleanup?.();
           const entry: RemoteCameraEntry = {
@@ -2213,6 +2314,7 @@ export class LiveKitModule {
             readyCleanup: null,
           };
           this.cameraTracks.set(participant.identity, entry);
+          if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] camera TrackSubscribed', participant.identity, 'trackSid:', track.sid, 'readyState:', track.mediaStreamTrack.readyState);
 
           this.waitForRemoteCameraReady(track.mediaStreamTrack)
             .then((cleanup) => {
@@ -2231,7 +2333,9 @@ export class LiveKitModule {
               if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] remote camera ready', participant.identity, 'trackSid:', track.sid);
               this.callbacks.onRemoteCameraReady?.(participant.identity, track.mediaStreamTrack);
             })
-            .catch(() => {
+            .catch((err) => {
+              // Subscription-timeout warnings are always logged (unconditional per design).
+              console.warn(LOG, '[video-feed] remote camera ready failed/timeout', participant.identity, 'trackSid:', track.sid, err);
               const currentEntry = this.cameraTracks.get(participant.identity);
               if (currentEntry?.publication === publication) {
                 currentEntry.readyCleanup = null;
@@ -2521,13 +2625,23 @@ export class LiveKitModule {
         }
       });
 
-      // p. TrackStreamStateChanged — detect paused/resumed screen share video (adaptive stream)
+      // p. TrackStreamStateChanged — detect paused/resumed screen share or camera video (adaptive stream)
       addListener(RoomEvent.TrackStreamStateChanged, (
         publication: RemoteTrackPublication,
         streamState: Track.StreamState,
         participant: RemoteParticipant,
       ) => {
         if (this.disposed) return;
+        if (publication.source === Track.Source.Camera && publication.kind === Track.Kind.Video) {
+          if (streamState === Track.StreamState.Paused) {
+            // Always warn — adaptiveStream pausing a camera track is unexpected
+            // (we call setEnabled(true) on subscribe) and worth logging unconditionally.
+            console.warn(LOG, '[video-feed] camera stream paused by adaptiveStream — re-enabling', participant.identity, 'trackSid:', publication.trackSid);
+            publication.setEnabled(true);
+          } else if (streamState === Track.StreamState.Active) {
+            if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] camera stream active', participant.identity, 'trackSid:', publication.trackSid);
+          }
+        }
         if (
           publication.source === Track.Source.ScreenShare &&
           publication.kind === Track.Kind.Video
@@ -2945,7 +3059,7 @@ export class LiveKitModule {
     }
 
     try {
-      this.sweepInactiveVideoTransceivers();
+      this.stopAllInactiveVideoTransceivers();
       this.noteShareLeakPublishStart();
       await this.room.localParticipant.setScreenShareEnabled(true, captureOpts, publishOpts);
       this.captureShareLeakPublishDiagnostics();
@@ -2986,7 +3100,7 @@ export class LiveKitModule {
         console.warn(LOG, 'capture constraints rejected, falling back to defaults:', err.message);
         this.callbacks.onSystemEvent('capture constraints rejected — using browser defaults');
         try {
-          this.sweepInactiveVideoTransceivers();
+          this.stopAllInactiveVideoTransceivers();
           this.noteShareLeakPublishStart();
           await this.room.localParticipant.setScreenShareEnabled(true);
           this.captureShareLeakPublishDiagnostics();
@@ -4253,6 +4367,21 @@ export class LiveKitModule {
 
   /* ─── WASAPI Audio Bridge ─────────────────────────────────────── */
 
+  /**
+   * Open the camera via getUserMedia (with AbortController-backed timeout) and
+   * publish it to the LiveKit room as a single-encoding VP8 Camera track.
+   *
+   * Resolves with the published `trackId` on success.
+   * Rejects with a `CameraStartError` on any failure:
+   *   - `permission_denied` — OS/browser denied camera access
+   *   - `device_unavailable` — no video track returned by the browser
+   *   - `device_in_use` — device locked by another app
+   *   - `timeout` — getUserMedia or publishTrack did not resolve within the deadline
+   *   - `publish_failed` — LiveKit publication failed or timed out
+   *
+   * On any failure the captured MediaStreamTrack (if any) is stopped and
+   * `localCameraPublication` / `localCameraMediaTrack` are cleared.
+   */
   async publishCamera(opts: {
     deviceId: string | null;
     quality: CameraQuality;
@@ -4261,34 +4390,44 @@ export class LiveKitModule {
       throw { kind: 'publish_failed' } satisfies CameraStartError;
     }
 
+    if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] publishCamera start', { deviceId: opts.deviceId, quality: opts.quality.tier });
     let mediaTrack: MediaStreamTrack | null = null;
     try {
-      const stream = await withTimeout(
-        navigator.mediaDevices.getUserMedia({
-          video: opts.deviceId === null ? true : { deviceId: opts.deviceId },
-        }),
-        CAMERA_CAPTURE_TIMEOUT_MS,
-        { kind: 'timeout' } satisfies CameraStartError,
-      );
-      mediaTrack = stream.getVideoTracks()[0] ?? null;
-      if (!mediaTrack) {
-        throw { kind: 'device_unavailable' } satisfies CameraStartError;
-      }
+      // openCameraDevice uses AbortController so a slow camera that resolves
+      // after the timeout doesn't leave an orphaned track with the LED on.
+      mediaTrack = await openCameraDevice(opts.deviceId).catch((err) => {
+        throw classifyCameraCaptureError(err);
+      });
+      if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] publishCamera getUserMedia ok', { trackId: mediaTrack.id, readyState: mediaTrack.readyState, label: mediaTrack.label });
 
+      // publishTrack timeout: if the SDK resolves after we've already rejected,
+      // the then-handler below unpublishes the phantom publication best-effort.
+      // Capture the track in a const so the late-resolve closure doesn't have
+      // to reach back through a possibly-mutated outer variable.
+      const capturedTrack = mediaTrack;
+      const room = this.room;
+      const publishPromise = room.localParticipant.publishTrack(
+        capturedTrack,
+        buildCameraPublishOptions(opts.quality),
+      );
       const publication = await withTimeout(
-        this.room.localParticipant.publishTrack(
-          mediaTrack,
-          buildCameraPublishOptions(opts.quality),
-        ),
+        publishPromise,
         CAMERA_PUBLISH_TIMEOUT_MS,
         { kind: 'publish_failed' } satisfies CameraStartError,
-      );
+      ).catch((err) => {
+        // Best-effort cleanup of a phantom publication that may arrive after
+        // the timeout sentinel already rejected.
+        publishPromise.then((pub) => {
+          room.localParticipant.unpublishTrack(pub?.track ?? capturedTrack).catch(() => {});
+        }).catch(() => {});
+        throw err;
+      });
 
       this.localCameraPublication = publication;
       this.localCameraMediaTrack = mediaTrack;
-      return {
-        trackId: publication?.trackSid ?? publication?.track?.sid ?? mediaTrack.id,
-      };
+      const trackId = publication?.trackSid ?? publication?.track?.sid ?? mediaTrack.id;
+      if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] publishCamera published', { trackId, trackSid: publication?.trackSid });
+      return { trackId };
     } catch (error) {
       if (mediaTrack) {
         mediaTrack.stop();
@@ -4296,6 +4435,7 @@ export class LiveKitModule {
       this.localCameraPublication = null;
       this.localCameraMediaTrack = null;
       if (isCameraStartError(error)) {
+        if (DEBUG_VIDEO_FEED) console.warn(LOG, '[video-feed] publishCamera CameraStartError', error);
         throw error;
       }
       if (mediaTrack) {
@@ -4316,15 +4456,18 @@ export class LiveKitModule {
       this.localCameraMediaTrack ??
       publication?.track?.mediaStreamTrack ??
       null;
+    // Prefer the LiveKit LocalTrack wrapper so the SDK can cleanly remove its own publication.
     const localTrack = publication?.track ?? null;
 
+    if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] unpublishCamera start', { hasPub: !!publication, hasLocalTrack: !!localTrack, hasMediaTrack: !!mediaTrack });
     this.localCameraPublication = null;
     this.localCameraMediaTrack = null;
 
     try {
-      const trackToUnpublish = mediaTrack ?? localTrack;
+      const trackToUnpublish = localTrack ?? mediaTrack;
       if (this.room && trackToUnpublish) {
         await this.room.localParticipant.unpublishTrack(trackToUnpublish);
+        if (DEBUG_VIDEO_FEED) console.log(LOG, '[video-feed] unpublishCamera unpublishTrack done');
       }
     } finally {
       mediaTrack?.stop();
@@ -4335,6 +4478,50 @@ export class LiveKitModule {
     return this.localCameraMediaTrack ?? this.localCameraPublication?.track?.mediaStreamTrack ?? null;
   }
 
+  /**
+   * Subscribe only to remote cameras whose participant id is in `visibleParticipantIds`;
+   * unsubscribe the rest. Used to avoid pulling video bytes for cameras that voice-room
+   * is currently filtering out of the tile grid (e.g. participants in another sub-room).
+   *
+   * Pairs with the TrackSubscribed handler that force-enables every camera publication
+   * to defeat adaptiveStream — without this, hidden cameras would otherwise stay
+   * subscribed and continuously stream wasted bandwidth.
+   */
+  applyRemoteCameraVisibility(visibleParticipantIds: ReadonlySet<string>): void {
+    if (!this.room) return;
+    for (const participant of this.room.remoteParticipants.values()) {
+      const publication = participant.getTrackPublication(Track.Source.Camera);
+      if (!publication) continue;
+      const shouldSubscribe = visibleParticipantIds.has(participant.identity);
+      if (publication.isSubscribed !== shouldSubscribe) {
+        publication.setSubscribed(shouldSubscribe);
+        if (DEBUG_VIDEO_FEED) {
+          console.log(
+            LOG,
+            '[video-feed] applyRemoteCameraVisibility',
+            participant.identity,
+            'trackSid:',
+            publication.trackSid,
+            'subscribed:',
+            shouldSubscribe,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Update the encoding parameters of the currently-published camera track.
+   *
+   * Applies constraints to the capture-side MediaStreamTrack (resolution/fps)
+   * and updates the RTCRtpSender encoding (bitrate cap). Does NOT call
+   * `setPublishingLayers` — that is a simulcast pause/resume API and is a
+   * silent no-op for single-encoding VP8 publications.
+   *
+   * On `OverconstrainedError` (camera hardware can't satisfy the resolution
+   * constraint) the resolution constraint is dropped and only the fps/bitrate
+   * are applied, so quality still degrades gracefully on cheap webcams.
+   */
   async setCameraQuality(quality: CameraQuality): Promise<void> {
     const publication =
       this.localCameraPublication ??
@@ -4350,7 +4537,20 @@ export class LiveKitModule {
       return;
     }
 
-    await mediaTrack.applyConstraints(buildCameraTrackConstraints(quality));
+    try {
+      await mediaTrack.applyConstraints(buildCameraTrackConstraints(quality));
+    } catch (err) {
+      // OverconstrainedError means the camera can't satisfy the resolution
+      // constraint (common on cheap USB webcams). Retry with fps-only so the
+      // bitrate cap still applies and we don't loop-retry pointlessly.
+      const name = err instanceof Error ? err.name : '';
+      if (name === 'OverconstrainedError') {
+        console.warn(LOG, '[video-feed] setCameraQuality: OverconstrainedError on resolution constraint, retrying fps-only', quality.tier);
+        await mediaTrack.applyConstraints({ frameRate: quality.maxFps });
+      } else {
+        throw err;
+      }
+    }
 
     const sender = (localTrack as { sender?: RTCRtpSender | null } | null)?.sender ?? null;
     if (sender) {
@@ -4358,6 +4558,17 @@ export class LiveKitModule {
     }
   }
 
+  /**
+   * Replace the underlying capture device without unpublishing — used when the
+   * user changes `Selected_Camera_Source` while published (Requirement 6.6).
+   *
+   * Opens the new device via `openCameraDevice` (AbortController-backed timeout),
+   * calls `LocalTrackPublication.replaceTrack` so the LiveKit publication keeps
+   * the same track id and source, then stops the old MediaStreamTrack only after
+   * the replace resolves (no flicker for remote viewers).
+   *
+   * On any failure the old track and publication are kept intact.
+   */
   async replaceCameraDevice(deviceId: string | null): Promise<{ trackId: string }> {
     const publication =
       this.localCameraPublication ??
@@ -4375,17 +4586,11 @@ export class LiveKitModule {
 
     let newMediaTrack: MediaStreamTrack | null = null;
     try {
-      const stream = await withTimeout(
-        navigator.mediaDevices.getUserMedia({
-          video: deviceId === null ? true : { deviceId },
-        }),
-        CAMERA_CAPTURE_TIMEOUT_MS,
-        { kind: 'timeout' } satisfies CameraStartError,
-      );
-      newMediaTrack = stream.getVideoTracks()[0] ?? null;
-      if (!newMediaTrack) {
-        throw { kind: 'device_unavailable' } satisfies CameraStartError;
-      }
+      // openCameraDevice uses AbortController so a slow camera that resolves
+      // after the timeout doesn't leave an orphaned track with the LED on.
+      newMediaTrack = await openCameraDevice(deviceId).catch((err) => {
+        throw classifyCameraCaptureError(err);
+      });
 
       const replaceableTrack = localTrack as LocalVideoTrack & {
         replaceTrack?: (track: MediaStreamTrack, options?: { userProvidedTrack?: boolean }) => Promise<void>;
@@ -5263,7 +5468,7 @@ export class LiveKitModule {
     if (DEBUG_CAPTURE) console.log(LOG, 'native capture: about to call publishTrack, timestamp:', performance.now());
     let publication;
     try {
-      this.sweepInactiveVideoTransceivers();
+      this.stopAllInactiveVideoTransceivers();
       publication = await this.room.localParticipant.publishTrack(videoTrack, {
         name: 'native-screen-share',
         source: Track.Source.ScreenShare,

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1041,6 +1041,8 @@ let roomPanelHadAnyVideoActive = false;
 let cameraQualityRequestVersion = 0;
 let cameraQualityRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let lastRequestedCameraQualityTier: CameraQuality['tier'] | null = null;
+/** Serialises concurrent toggleCameraIntent calls — prevents intent/publication desync on rapid clicks. */
+let cameraToggleChain: Promise<void> = Promise.resolve();
 
 /** Common shape for both LiveKitModule (JS SDK) and NativeMediaModule (Rust IPC). */
 type MediaModule = LiveKitModule | NativeMediaModule;
@@ -1641,15 +1643,51 @@ function resetCameraRuntimeState(): void {
   state.roomPanelTab = 'logs';
 }
 
+function visibleRemoteCameraSet(): { ids: Set<string>; tiles: Record<string, RemoteCameraTileRuntimeState> } {
+  const joinedSubRoomId = state.joinedSubRoomId;
+  if (!joinedSubRoomId) return { ids: new Set(), tiles: {} };
+  const visibleSubRoomIds = new Set([joinedSubRoomId]);
+  if (state.passthrough) {
+    const { sourceSubRoomId, targetSubRoomId } = state.passthrough;
+    if (sourceSubRoomId === joinedSubRoomId) visibleSubRoomIds.add(targetSubRoomId);
+    else if (targetSubRoomId === joinedSubRoomId) visibleSubRoomIds.add(sourceSubRoomId);
+  }
+  const ids = new Set<string>();
+  const tiles: Record<string, RemoteCameraTileRuntimeState> = {};
+  for (const [id, entry] of Object.entries(remoteCameraTilesById)) {
+    const participantSubRoomId = state.participantSubRoomById[id] ?? null;
+    if (participantSubRoomId && visibleSubRoomIds.has(participantSubRoomId)) {
+      ids.add(id);
+      tiles[id] = entry;
+    }
+  }
+  // Also include in-scope participants without an existing tile entry yet, so a camera
+  // that publishes after we've already filtered (e.g. someone turns on camera in our
+  // sub-room) is allowed to subscribe through applyRemoteCameraVisibility.
+  for (const participant of state.participants) {
+    const participantSubRoomId = state.participantSubRoomById[participant.id] ?? null;
+    if (participantSubRoomId && visibleSubRoomIds.has(participantSubRoomId)) {
+      ids.add(participant.id);
+    }
+  }
+  return { ids, tiles };
+}
+
 function rebuildVideoTiles(): void {
-  const localTrack = getCameraMediaModule()?.getLocalCameraTrack() ?? null;
+  const module = getCameraMediaModule();
+  const localTrack = module?.getLocalCameraTrack() ?? null;
+  const { ids: visibleIds, tiles: visibleTiles } = visibleRemoteCameraSet();
   state.videoTilesById = buildVideoTilesById({
     participants: state.participants,
     selfParticipantId: state.selfParticipantId,
     cameraPublication: state.cameraPublication,
     localTrack,
-    remoteTilesById: remoteCameraTilesById,
+    remoteTilesById: visibleTiles,
   });
+  // Keep server-side subscriptions in sync with the visibility filter so cameras outside
+  // the joined sub-room don't keep streaming bytes (TrackSubscribed force-enables every
+  // camera publication; without this, hidden cameras would burn bandwidth indefinitely).
+  module?.applyRemoteCameraVisibility(visibleIds);
   syncRoomPanelTab();
 }
 
@@ -1831,6 +1869,13 @@ function stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId: string | nul
   }
 }
 
+function stopLocalCameraAfterLeavingSubRoom(previousJoinedSubRoomId: string | null): void {
+  if (!previousJoinedSubRoomId || state.joinedSubRoomId !== null) return;
+  if (!state.cameraIntent) return;
+  state.cameraIntent = false;
+  void unpublishLocalCamera();
+}
+
 function syncDesiredSubRoomPreference(): void {
   state.desiredSubRoomId = desiredSubRoomIntent === undefined
     ? state.joinedSubRoomId
@@ -1967,6 +2012,16 @@ function desiredCameraQualityForState(currentState: VoiceRoomState): CameraQuali
   return screenShareActiveInRoom(currentState) ? CAMERA_QUALITY_LOW : CAMERA_QUALITY_HIGH;
 }
 
+const CAMERA_QUALITY_RETRY_INTERVAL_MS = 1_000;
+const CAMERA_QUALITY_MAX_ATTEMPTS = 3;
+
+// Exported for tests so retry-timing assertions stay in sync with the source
+// of truth — never duplicate these literals.
+export const __CAMERA_TEST_HOOKS__ = {
+  CAMERA_QUALITY_RETRY_INTERVAL_MS,
+  CAMERA_QUALITY_MAX_ATTEMPTS,
+} as const;
+
 async function attemptCameraQualityUpdate(
   version: number,
   quality: CameraQuality,
@@ -1982,23 +2037,25 @@ async function attemptCameraQualityUpdate(
     if (version !== cameraQualityRequestVersion) {
       return;
     }
+    // Only record the tier after a successful apply so the dedupe check in
+    // applyCameraQualityForShareState doesn't skip a retry after exhaustion.
+    lastRequestedCameraQualityTier = quality.tier;
   } catch (error) {
     if (version !== cameraQualityRequestVersion) {
       return;
     }
-    if (attempt < 3) {
+    if (attempt < CAMERA_QUALITY_MAX_ATTEMPTS) {
       cameraQualityRetryTimer = setTimeout(() => {
         cameraQualityRetryTimer = null;
         void attemptCameraQualityUpdate(version, quality, attempt + 1);
-      }, 1_000);
+      }, CAMERA_QUALITY_RETRY_INTERVAL_MS);
       return;
     }
-    const message = `camera quality update failed after 3 attempts (${quality.tier})`;
+    const message = `camera quality update failed after ${CAMERA_QUALITY_MAX_ATTEMPTS} attempts (${quality.tier})`;
     appendCameraSystemEvent(message);
     toast.error(message);
-    if (DEBUG_VIDEO_FEED) {
-      console.warn(LOG, message, error);
-    }
+    // Always log retry exhaustion — it's a warning-level event regardless of the debug flag.
+    console.warn(LOG, message, error);
   }
 }
 
@@ -2019,7 +2076,6 @@ export async function applyCameraQualityForShareState(): Promise<void> {
     cameraQualityRetryTimer = null;
   }
 
-  lastRequestedCameraQualityTier = quality.tier;
   cameraQualityRequestVersion += 1;
   if (DEBUG_VIDEO_FEED) {
     console.log(LOG, '[video-feed] applying camera quality', quality.tier);
@@ -2107,17 +2163,36 @@ export async function toggleCameraIntent(): Promise<void> {
     return;
   }
 
-  if (state.cameraIntent) {
-    state.cameraIntent = false;
-    notify();
-    await unpublishLocalCamera();
-    return;
-  }
+  // Serialise concurrent invocations so rapid double-clicks can't interleave
+  // a publish and an unpublish, leaving intent and publication out of sync.
+  cameraToggleChain = cameraToggleChain.then(async () => {
+    // Re-check lkModule and mediaState inside the chain — state may have
+    // changed while we were waiting for the previous toggle to finish.
+    if (!lkModule || state.mediaState === 'disconnected' || state.mediaState === 'failed') {
+      return;
+    }
 
-  state.cameraIntent = true;
-  state.cameraPublication = 'opening';
-  notify();
-  await publishLocalCamera();
+    if (state.cameraIntent) {
+      state.cameraIntent = false;
+      notify();
+      await unpublishLocalCamera();
+      return;
+    }
+
+    state.cameraIntent = true;
+    state.cameraPublication = 'opening';
+    notify();
+    await publishLocalCamera();
+  }).catch((err) => {
+    // publishLocalCamera/unpublishLocalCamera surface their own errors via
+    // toast + system event. Anything reaching this catch is unexpected
+    // (programming error, lkModule torn down mid-flight, etc.) — log it so
+    // it doesn't disappear silently, but keep the chain alive so the next
+    // toggle can still run.
+    console.warn(LOG, 'unexpected error in camera toggle chain', err);
+  });
+
+  return cameraToggleChain;
 }
 
 export function selectRoomPanelTab(tab: 'logs' | 'video'): void {
@@ -2737,9 +2812,11 @@ function dispatchMessage(raw: unknown): void {
         : null;
       syncDerivedSubRoomState();
       stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      stopLocalCameraAfterLeavingSubRoom(previousJoinedSubRoomId);
       reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
+      rebuildVideoTiles();
       reconcileDesiredSubRoomMembership();
       // Legacy-client fallback: sub_room_joined fires before sub_room_state (room doesn't exist
       // yet in state when sub_room_joined arrives), so flush here once state catches up.
@@ -2789,10 +2866,12 @@ function dispatchMessage(raw: unknown): void {
       });
       syncDerivedSubRoomState();
       stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      stopLocalCameraAfterLeavingSubRoom(previousJoinedSubRoomId);
       reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       void source;
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
+      rebuildVideoTiles();
       reconcileDesiredSubRoomMembership();
       {
         const srjName = displayNameCache.get(participantId) ?? state.participants.find((p) => p.id === participantId)?.displayName ?? participantId;
@@ -2827,9 +2906,11 @@ function dispatchMessage(raw: unknown): void {
       ));
       syncDerivedSubRoomState();
       stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      stopLocalCameraAfterLeavingSubRoom(previousJoinedSubRoomId);
       reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       playSubRoomMembershipSounds(previousParticipantSubRoomById, previousJoinedSubRoomId);
       applyEffectiveParticipantVolumes();
+      rebuildVideoTiles();
       reconcileDesiredSubRoomMembership();
       {
         const srlName = displayNameCache.get(participantId) ?? state.participants.find((p) => p.id === participantId)?.displayName ?? participantId;
@@ -2848,11 +2929,13 @@ function dispatchMessage(raw: unknown): void {
       state.subRooms = state.subRooms.filter((room) => room.id !== subRoomId);
       syncDerivedSubRoomState();
       stopLocalShareAfterLeavingSubRoom(previousJoinedSubRoomId);
+      stopLocalCameraAfterLeavingSubRoom(previousJoinedSubRoomId);
       reconcileLocalMicWithRoomMembership(previousJoinedSubRoomId);
       if (desiredSubRoomIntent === subRoomId) {
         desiredSubRoomIntent = undefined;
       }
       applyEffectiveParticipantVolumes();
+      rebuildVideoTiles();
       reconcileDesiredSubRoomMembership();
       void applyCameraQualityForShareState();
       notify();
@@ -3639,6 +3722,9 @@ export function leaveRoom(): void {
   remoteCameraTilesById = {};
   roomPanelHadAnyVideoActive = false;
   resetCameraQualityController();
+  // Reset the toggle chain so stale in-flight toggles from the previous session
+  // don't bleed into the next one.
+  cameraToggleChain = Promise.resolve();
   desiredSubRoomIntent = undefined;
 
   // Reset reconnect cooldown timer


### PR DESCRIPTION
This PR improves the stability and efficiency of the video feed implementation.

Key changes:
- **Stability:** Handles \OverconstrainedError\ and \getUserMedia\ timeouts gracefully. Prevents orphaned tracks and SFU m-line confusion.
- **Bandwidth:** Automatically unsubscribes from remote cameras that are not in the current sub-room view.
- **Race Conditions:** Serializes camera toggle calls to ensure state consistency.
- **Testing:** Adds regression tests for quality retries and timeouts.