### PR TITLE
feat(gui): camera popout and UI polish

### DIFF
--- a/clients/cli-test/src/main.rs
+++ b/clients/cli-test/src/main.rs
@@ -487,7 +487,7 @@ async fn run_sfu_mode(
                                 }
                             }
                             "stop-share" => {
-                                let json = r#"{"type":"stop_share"}"#;
+                                let json = r#"{"type":"stop-share"}"#;
                                 if let Err(e) = repl_ws.send_text(json) {
                                     warn!("failed to send stop-share: {e}");
                                 }
@@ -504,7 +504,7 @@ async fn run_sfu_mode(
                                     warn!("usage: stop-share <participant_id>");
                                 } else {
                                     let json = format!(
-                                        r#"{{"type":"stop_share","targetParticipantId":"{}"}}"#,
+                                        r#"{{"type":"stop-share","targetParticipantId":"{}"}}"#,
                                         target_id
                                     );
                                     if let Err(e) = repl_ws.send_text(&json) {

--- a/clients/wavis-gui/src-tauri/capabilities/default.json
+++ b/clients/wavis-gui/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Default capabilities for all windows (production)",
-  "windows": ["main", "screen-share-*", "share-picker", "share-indicator", "watch-all", "diagnostics"],
+  "windows": ["main", "screen-share-*", "share-picker", "share-indicator", "watch-all", "camera-popout", "diagnostics"],
   "permissions": [
     "core:default",
     "core:window:default",

--- a/clients/wavis-gui/src/App.tsx
+++ b/clients/wavis-gui/src/App.tsx
@@ -20,6 +20,7 @@ function isChromelessWindow(): boolean {
     p.startsWith('/share-picker') ||
     p.startsWith('/share-indicator') ||
     p.startsWith('/watch-all') ||
+    p.startsWith('/video-popout') ||
     p.startsWith('/diagnostics')
   );
 }

--- a/clients/wavis-gui/src/App.tsx
+++ b/clients/wavis-gui/src/App.tsx
@@ -20,7 +20,7 @@ function isChromelessWindow(): boolean {
     p.startsWith('/share-picker') ||
     p.startsWith('/share-indicator') ||
     p.startsWith('/watch-all') ||
-    p.startsWith('/video-popout') ||
+    p.startsWith('/camera-popout') ||
     p.startsWith('/diagnostics')
   );
 }

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -96,6 +96,7 @@ import { AudioDriverInstallPrompt } from '@features/screen-share/AudioDriverInst
 import { cameraButtonLabel, shouldMountCameraButton } from './active-room-camera';
 import { selectRoomPanelTab } from './voice-room';
 import { VideoTab } from './VideoTab';
+import type { VideoTileSnapshot, VideoTileViewModel } from './camera-types';
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
 function voiceIcon(p: RoomParticipant, isDeafened?: boolean): { char: string; color: string; strikethrough?: boolean; transform?: string } {
@@ -218,6 +219,28 @@ type ShareViewerScope = 'direct' | 'watch-all';
 interface ShareViewerWindow {
   scope: ShareViewerScope;
   window: WebviewWindow;
+}
+
+function buildVideoTileSnapshot(tile: VideoTileViewModel): VideoTileSnapshot {
+  return {
+    participantId: tile.participantId,
+    displayName: tile.displayName,
+    color: tile.color,
+    hasTrack: tile.track !== null,
+    isSelf: tile.isSelf,
+    isMuted: tile.isMuted,
+    hasError: tile.hasError,
+  };
+}
+
+function areVideoTileSnapshotsEqual(a: VideoTileSnapshot, b: VideoTileSnapshot): boolean {
+  return a.participantId === b.participantId
+    && a.displayName === b.displayName
+    && a.color === b.color
+    && a.hasTrack === b.hasTrack
+    && a.isSelf === b.isSelf
+    && a.isMuted === b.isMuted
+    && a.hasError === b.hasError;
 }
 
 /* ─── Sub-components ────────────────────────────────────────────── */
@@ -649,6 +672,10 @@ export default function ActiveRoom() {
   const watchAllReadyUnlistenRef = useRef<(() => void) | null>(null);
   const [watchAllOpen, setWatchAllOpen] = useState(false);
   const watchAllReadyRef = useRef(false);
+  const videoPopoutWindowRef = useRef<WebviewWindow | null>(null);
+  const videoPopoutReadyUnlistenRef = useRef<(() => void) | null>(null);
+  const [videoPopoutOpen, setVideoPopoutOpen] = useState(false);
+  const videoPopoutReadyRef = useRef(false);
   const watchAllHotkeyRef = useRef<string | null>(null);
   const focusMainHotkeyRef = useRef<string | null>(null);
   const toggleWatchAllRef = useRef<() => void>(() => { });
@@ -750,6 +777,13 @@ export default function ActiveRoom() {
     }
     prevStreamsRef.current = new Map(roomState.screenShareStreams);
   }, [watchingShareIds, roomState?.screenShareStreams]);
+
+  useEffect(() => {
+    const unlisten = listen('video-popout:closed', () => {
+      closeVideoPopoutWindow(true);
+    });
+    return () => { unlisten.then((fn) => fn?.()); };
+  }, []);
 
   const getSavedShareVolume = useCallback((participantId: string) => {
     return shareVolumesRef.current.get(participantId) ?? watchAllVolumesRef.current.get(participantId) ?? 70;
@@ -1317,6 +1351,7 @@ export default function ActiveRoom() {
 
   /** Close all share windows. */
   const closeAllShareWindows = () => {
+    closeVideoPopoutWindow();
     closeWatchAllWindow(); // close Watch All window first
     stopAllSending();
     for (const [pid, shareWindow] of shareWindowsRef.current) {
@@ -1330,6 +1365,123 @@ export default function ActiveRoom() {
   // Ref to latest roomState so the ready callback always reads fresh data
   const roomStateRef = useRef(roomState);
   roomStateRef.current = roomState;
+  const prevVideoPopoutTracksRef = useRef<Map<string, MediaStreamTrack | null>>(new Map());
+  const prevVideoPopoutTilesRef = useRef<Map<string, VideoTileSnapshot>>(new Map());
+
+  const closeVideoPopoutWindow = (alreadyDestroyed = false) => {
+    if (!videoPopoutWindowRef.current) return;
+    if (videoPopoutReadyUnlistenRef.current) {
+      videoPopoutReadyUnlistenRef.current();
+      videoPopoutReadyUnlistenRef.current = null;
+    }
+    videoPopoutReadyRef.current = false;
+    stopSendingForWindow('video-popout');
+    if (!alreadyDestroyed) {
+      videoPopoutWindowRef.current.close().catch(() => { });
+    }
+    videoPopoutWindowRef.current = null;
+    setVideoPopoutOpen(false);
+    prevVideoPopoutTracksRef.current = new Map();
+    prevVideoPopoutTilesRef.current = new Map();
+  };
+
+  const syncVideoPopoutSnapshot = useCallback((nextTilesById: Record<string, VideoTileViewModel>) => {
+    const prevTracks = prevVideoPopoutTracksRef.current;
+    const prevTiles = prevVideoPopoutTilesRef.current;
+    const nextTracks = new Map<string, MediaStreamTrack | null>();
+    const nextTiles = new Map<string, VideoTileSnapshot>();
+
+    for (const tile of Object.values(nextTilesById)) {
+      const snapshot = buildVideoTileSnapshot(tile);
+      const sendableTrack = snapshot.hasTrack && !snapshot.isMuted && !snapshot.hasError ? tile.track : null;
+      nextTracks.set(tile.participantId, sendableTrack);
+      nextTiles.set(tile.participantId, snapshot);
+
+      const prevSnapshot = prevTiles.get(tile.participantId);
+      if (!prevSnapshot) {
+        void emitTo('video-popout', 'video-popout:tile-added', snapshot);
+      } else if (!areVideoTileSnapshotsEqual(prevSnapshot, snapshot)) {
+        void emitTo('video-popout', 'video-popout:tile-updated', snapshot);
+      }
+
+      const prevTrack = prevTracks.get(tile.participantId) ?? null;
+      if (sendableTrack && !prevTrack) {
+        void startSending(tile.participantId, 'video-popout', new MediaStream([sendableTrack]));
+      } else if (sendableTrack && prevTrack !== sendableTrack) {
+        void resendStream(tile.participantId, 'video-popout', new MediaStream([sendableTrack]));
+      } else if (!sendableTrack && prevTrack) {
+        stopSending(tile.participantId, 'video-popout');
+      }
+    }
+
+    for (const participantId of prevTiles.keys()) {
+      if (!nextTiles.has(participantId)) {
+        stopSending(participantId, 'video-popout');
+        void emitTo('video-popout', 'video-popout:tile-removed', { participantId });
+      }
+    }
+
+    prevVideoPopoutTracksRef.current = nextTracks;
+    prevVideoPopoutTilesRef.current = nextTiles;
+  }, []);
+
+  const openVideoPopoutWindow = useCallback(async () => {
+    if (videoPopoutWindowRef.current) {
+      videoPopoutWindowRef.current.setFocus().catch(() => { });
+      return;
+    }
+
+    const rs = roomStateRef.current;
+    if (!rs) return;
+
+    const hash = encodeURIComponent(JSON.stringify({ channelName: rs.channelName }));
+
+    try {
+      videoPopoutReadyRef.current = false;
+      const unlistenReady = await listen('video-popout:ready', () => {
+        if (videoPopoutReadyRef.current) return;
+        videoPopoutReadyRef.current = true;
+        syncVideoPopoutSnapshot(roomStateRef.current?.videoTilesById ?? {});
+      });
+      videoPopoutReadyUnlistenRef.current = unlistenReady;
+
+      const win = new WebviewWindow('video-popout', {
+        url: `/video-popout#${hash}`,
+        title: `Video — ${rs.channelName}`,
+        width: 960,
+        height: 540,
+        minWidth: 480,
+        minHeight: 320,
+        resizable: true,
+        decorations: true,
+        center: true,
+      });
+
+      win.once('tauri://error', (event) => {
+        console.error('[wavis:active-room] video popout window error:', event);
+        closeVideoPopoutWindow(true);
+      });
+
+      win.once('tauri://destroyed', () => {
+        closeVideoPopoutWindow(true);
+      });
+
+      videoPopoutWindowRef.current = win;
+      setVideoPopoutOpen(true);
+    } catch (err) {
+      console.error('[wavis:active-room] failed to open video popout window:', err);
+    }
+  }, [syncVideoPopoutSnapshot]);
+
+  useEffect(() => {
+    if (!videoPopoutOpen) {
+      prevVideoPopoutTracksRef.current = new Map();
+      prevVideoPopoutTilesRef.current = new Map();
+      return;
+    }
+    if (!videoPopoutReadyRef.current) return;
+    syncVideoPopoutSnapshot(roomState?.videoTilesById ?? {});
+  }, [roomState?.videoTilesById, syncVideoPopoutSnapshot, videoPopoutOpen]);
 
   /** Open the Watch All window showing all active screen shares in a grid. */
   const openWatchAllWindow = async () => {
@@ -1538,7 +1690,7 @@ export default function ActiveRoom() {
     : false;
   const showCameraButton = shouldMountCameraButton(voiceRoomConnected, supportedCapturePlatform);
   const videoButtonLabel = cameraButtonLabel(roomState?.cameraIntent ?? false);
-  const cameraLabel = roomState?.cameraIntent ? '/stopcamera' : '/camera';
+  const cameraLabel = `/${videoButtonLabel}`;
   const sharers = roomState?.participants.filter((p) => p.isSharing) ?? [];
   const watchAllScope = getWatchAllScope(roomState);
   const shareEnabled = roomState
@@ -2111,6 +2263,8 @@ export default function ActiveRoom() {
   const renderParticipantRow = (p: RoomParticipant) => {
     const isSelf = p.id === roomState.selfParticipantId;
     const icon = voiceIcon(p, isSelf ? roomState.isDeafened : p.isDeafened);
+    const videoTile = roomState.videoTilesById[p.id];
+    const cameraOn = !!videoTile && !videoTile.isMuted && !videoTile.hasError;
 
     return (
       <div key={p.id} className="pl-2">
@@ -2130,6 +2284,26 @@ export default function ActiveRoom() {
           }}>{p.displayName}</span>
           <span style={{ color: icon.color, textDecoration: icon.strikethrough ? 'line-through' : undefined, ...(icon.transform ? { display: 'inline-block', transform: icon.transform } : {}) }}>{icon.char}</span>
           <div className="ml-auto flex items-center gap-1">
+            {cameraOn && (
+              <span
+                aria-label={isSelf ? 'your camera is on' : `${p.displayName}'s camera is on`}
+                title={isSelf ? 'your camera is on' : `${p.displayName}'s camera is on`}
+                style={{
+                  display: 'inline-block',
+                  width: '0.75rem',
+                  height: '0.75rem',
+                  backgroundColor: 'var(--wavis-accent)',
+                  WebkitMaskImage: 'url(/video-camera.png)',
+                  WebkitMaskSize: 'contain',
+                  WebkitMaskRepeat: 'no-repeat',
+                  WebkitMaskPosition: 'center',
+                  maskImage: 'url(/video-camera.png)',
+                  maskSize: 'contain',
+                  maskRepeat: 'no-repeat',
+                  maskPosition: 'center',
+                }}
+              />
+            )}
             {isSelf && p.isSharing && (
               <span
                 className="text-sm leading-none"
@@ -2448,7 +2622,7 @@ export default function ActiveRoom() {
                 <button
                   onClick={toggleCameraIntent}
                   className="px-1.5 h-5 flex items-center justify-center hover:opacity-70 transition-opacity"
-                  style={{ color: roomState.cameraIntent ? 'var(--wavis-accent)' : 'var(--wavis-text-secondary)' }}
+                  style={{ color: roomState.cameraIntent ? 'var(--wavis-danger)' : 'var(--wavis-text-secondary)' }}
                   title={cameraLabel}
                   aria-label={videoButtonLabel}
                 ><span style={{
@@ -2488,7 +2662,7 @@ export default function ActiveRoom() {
             {showCameraButton && (
               <button
                 onClick={toggleCameraIntent}
-                className={`w-full py-0.5 px-1 text-xs text-center transition-colors border ${roomState.cameraIntent ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
+                className={`w-full py-0.5 px-1 text-xs text-center transition-colors border ${roomState.cameraIntent ? 'border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
               >
                 {cameraLabel}
               </button>
@@ -2727,6 +2901,11 @@ export default function ActiveRoom() {
               role="tab"
               aria-selected={active}
               onClick={() => selectRoomPanelTab(tab)}
+              onDoubleClick={() => {
+                if (tab !== 'video') return;
+                selectRoomPanelTab('video');
+                void openVideoPopoutWindow();
+              }}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
@@ -2746,7 +2925,17 @@ export default function ActiveRoom() {
       </div>
       {/* ── Tab body ── */}
       {currentPanelTab === 'video' ? (
-        <VideoTab videoTilesById={videoTilesById} />
+        <>
+          <VideoTab videoTilesById={videoTilesById} />
+          <div className="h-[4.5rem] px-4 border-t border-wavis-text-secondary flex items-center">
+            <button
+              onClick={() => { void openVideoPopoutWindow(); }}
+              className={`w-full py-1 px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
+            >
+              {videoPopoutOpen ? '/focus_video_window' : '/pop_out_video'}
+            </button>
+          </div>
+        </>
       ) : (
         logsContent
       )}
@@ -2796,6 +2985,11 @@ export default function ActiveRoom() {
               <button
                 key={tab}
                 onClick={() => setMobileTab(tab)}
+                onDoubleClick={() => {
+                  if (tab !== 'video') return;
+                  setMobileTab('video');
+                  void openVideoPopoutWindow();
+                }}
                 className="flex-1 py-2 text-center border-r border-wavis-text-secondary last:border-r-0 text-xs"
                 style={{ color, backgroundColor: active ? 'rgba(46,160,67,0.08)' : 'transparent' }}
               >
@@ -2824,7 +3018,19 @@ export default function ActiveRoom() {
               {mobileTab === 'participants' && <div className="flex flex-col flex-1 min-h-0">{participantsSections}{youBar}</div>}
               {mobileTab === 'chat' && chatPanel}
               {mobileTab === 'log' && logsContent}
-              {mobileTab === 'video' && <VideoTab videoTilesById={videoTilesById} />}
+              {mobileTab === 'video' && (
+                <div className="flex flex-col flex-1 min-h-0">
+                  <VideoTab videoTilesById={videoTilesById} />
+                  <div className="h-[4.5rem] px-4 border-t border-wavis-text-secondary flex items-center">
+                    <button
+                      onClick={() => { void openVideoPopoutWindow(); }}
+                      className={`w-full py-1 px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
+                    >
+                      {videoPopoutOpen ? '/focus_video_window' : '/pop_out_video'}
+                    </button>
+                  </div>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -779,7 +779,7 @@ export default function ActiveRoom() {
   }, [watchingShareIds, roomState?.screenShareStreams]);
 
   useEffect(() => {
-    const unlisten = listen('video-popout:closed', () => {
+    const unlisten = listen('camera-popout:closed', () => {
       closeVideoPopoutWindow(true);
     });
     return () => { unlisten.then((fn) => fn?.()); };
@@ -1375,7 +1375,7 @@ export default function ActiveRoom() {
       videoPopoutReadyUnlistenRef.current = null;
     }
     videoPopoutReadyRef.current = false;
-    stopSendingForWindow('video-popout');
+    stopSendingForWindow('camera-popout');
     if (!alreadyDestroyed) {
       videoPopoutWindowRef.current.close().catch(() => { });
     }
@@ -1399,25 +1399,25 @@ export default function ActiveRoom() {
 
       const prevSnapshot = prevTiles.get(tile.participantId);
       if (!prevSnapshot) {
-        void emitTo('video-popout', 'video-popout:tile-added', snapshot);
+        void emit('camera-popout:tile-added', snapshot);
       } else if (!areVideoTileSnapshotsEqual(prevSnapshot, snapshot)) {
-        void emitTo('video-popout', 'video-popout:tile-updated', snapshot);
+        void emit('camera-popout:tile-updated', snapshot);
       }
 
       const prevTrack = prevTracks.get(tile.participantId) ?? null;
       if (sendableTrack && !prevTrack) {
-        void startSending(tile.participantId, 'video-popout', new MediaStream([sendableTrack]));
+        void startSending(tile.participantId, 'camera-popout', new MediaStream([sendableTrack]));
       } else if (sendableTrack && prevTrack !== sendableTrack) {
-        void resendStream(tile.participantId, 'video-popout', new MediaStream([sendableTrack]));
+        void resendStream(tile.participantId, 'camera-popout', new MediaStream([sendableTrack]));
       } else if (!sendableTrack && prevTrack) {
-        stopSending(tile.participantId, 'video-popout');
+        stopSending(tile.participantId, 'camera-popout');
       }
     }
 
     for (const participantId of prevTiles.keys()) {
       if (!nextTiles.has(participantId)) {
-        stopSending(participantId, 'video-popout');
-        void emitTo('video-popout', 'video-popout:tile-removed', { participantId });
+        stopSending(participantId, 'camera-popout');
+        void emit('camera-popout:tile-removed', { participantId });
       }
     }
 
@@ -1438,22 +1438,22 @@ export default function ActiveRoom() {
 
     try {
       videoPopoutReadyRef.current = false;
-      const unlistenReady = await listen('video-popout:ready', () => {
+      const unlistenReady = await listen('camera-popout:ready', () => {
         if (videoPopoutReadyRef.current) return;
         videoPopoutReadyRef.current = true;
         syncVideoPopoutSnapshot(roomStateRef.current?.videoTilesById ?? {});
       });
       videoPopoutReadyUnlistenRef.current = unlistenReady;
 
-      const win = new WebviewWindow('video-popout', {
-        url: `/video-popout#${hash}`,
-        title: `Video — ${rs.channelName}`,
+      const win = new WebviewWindow('camera-popout', {
+        url: `/camera-popout#${hash}`,
+        title: `Camera — ${rs.channelName}`,
         width: 960,
         height: 540,
         minWidth: 480,
         minHeight: 320,
         resizable: true,
-        decorations: true,
+        decorations: false,
         center: true,
       });
 
@@ -1468,6 +1468,8 @@ export default function ActiveRoom() {
 
       videoPopoutWindowRef.current = win;
       setVideoPopoutOpen(true);
+      // Switch away from the video tab — it's now in the pop-out window
+      selectRoomPanelTab('logs');
     } catch (err) {
       console.error('[wavis:active-room] failed to open video popout window:', err);
     }
@@ -2892,7 +2894,7 @@ export default function ActiveRoom() {
     <div className="flex-1 flex flex-col min-h-0">
       {/* ── Tab header ── */}
       <div className="flex h-[4.5rem] border-b border-wavis-text-secondary">
-        {(['logs', 'video'] as const).map((tab) => {
+        {(['logs', 'video'] as const).filter((tab) => !(tab === 'video' && videoPopoutOpen)).map((tab) => {
           const label = tab === 'logs' ? 'LOGS' : 'VIDEOS';
           const active = currentPanelTab === tab;
           return (
@@ -2924,7 +2926,7 @@ export default function ActiveRoom() {
         })}
       </div>
       {/* ── Tab body ── */}
-      {currentPanelTab === 'video' ? (
+      {currentPanelTab === 'video' && !videoPopoutOpen ? (
         <>
           <VideoTab videoTilesById={videoTilesById} />
           <div className="h-[4.5rem] px-4 border-t border-wavis-text-secondary flex items-center">
@@ -2932,7 +2934,7 @@ export default function ActiveRoom() {
               onClick={() => { void openVideoPopoutWindow(); }}
               className={`w-full py-1 px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
             >
-              {videoPopoutOpen ? '/focus_video_window' : '/pop_out_video'}
+              /pop-out
             </button>
           </div>
         </>
@@ -2978,7 +2980,7 @@ export default function ActiveRoom() {
 
         {/* Tab bar */}
         <div className="flex border-b border-wavis-text-secondary bg-wavis-panel">
-          {(['participants', 'chat', 'log', 'video'] as const).map((tab) => {
+          {(['participants', 'chat', 'log', 'video'] as const).filter((tab) => !(tab === 'video' && videoPopoutOpen)).map((tab) => {
             const active = mobileTab === tab;
             const color = active ? 'var(--wavis-accent)' : 'var(--wavis-text-secondary)';
             return (
@@ -3018,7 +3020,7 @@ export default function ActiveRoom() {
               {mobileTab === 'participants' && <div className="flex flex-col flex-1 min-h-0">{participantsSections}{youBar}</div>}
               {mobileTab === 'chat' && chatPanel}
               {mobileTab === 'log' && logsContent}
-              {mobileTab === 'video' && (
+              {mobileTab === 'video' && !videoPopoutOpen && (
                 <div className="flex flex-col flex-1 min-h-0">
                   <VideoTab videoTilesById={videoTilesById} />
                   <div className="h-[4.5rem] px-4 border-t border-wavis-text-secondary flex items-center">
@@ -3026,7 +3028,7 @@ export default function ActiveRoom() {
                       onClick={() => { void openVideoPopoutWindow(); }}
                       className={`w-full py-1 px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
                     >
-                      {videoPopoutOpen ? '/focus_video_window' : '/pop_out_video'}
+                      /pop-out
                     </button>
                   </div>
                 </div>

--- a/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
+++ b/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
@@ -9,6 +9,8 @@ interface VideoPopoutParams {
   channelName: string;
 }
 
+const TITLE_BAR_HEIGHT = 32;
+
 function parseHashParams(): VideoPopoutParams | null {
   try {
     const hash = window.location.hash.slice(1);
@@ -38,7 +40,7 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
     }
 
     receiverRef.current?.stop();
-    const receiver = new StreamReceiver(tile.participantId, 'video-popout');
+    const receiver = new StreamReceiver(tile.participantId, 'camera-popout');
     receiverRef.current = receiver;
     setReceiverError(false);
 
@@ -79,15 +81,19 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
   const showVideo = shouldReceive && stream && !receiverError;
 
   return (
-    <div className="relative aspect-video overflow-hidden border border-wavis-text-secondary bg-wavis-panel">
+    <div className="relative overflow-hidden bg-wavis-panel" style={{ width: '100%', height: '100%' }}>
       {showVideo ? (
         <video
           ref={videoRef}
           autoPlay
           playsInline
           muted={tile.isSelf}
-          className="w-full h-full object-cover"
-          style={tile.isSelf ? { transform: 'scaleX(-1)' } : undefined}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+            ...(tile.isSelf ? { transform: 'scaleX(-1)' } : {}),
+          }}
         />
       ) : (
         <div className="w-full h-full flex items-center justify-center">
@@ -145,20 +151,20 @@ export default function VideoPopoutPage() {
 
   useEffect(() => {
     const cleanups = [
-      listen<VideoTileSnapshot>('video-popout:tile-added', (event) => {
+      listen<VideoTileSnapshot>('camera-popout:tile-added', (event) => {
         setTilesById((prev) => ({ ...prev, [event.payload.participantId]: event.payload }));
       }),
-      listen<VideoTileSnapshot>('video-popout:tile-updated', (event) => {
+      listen<VideoTileSnapshot>('camera-popout:tile-updated', (event) => {
         setTilesById((prev) => ({ ...prev, [event.payload.participantId]: event.payload }));
       }),
-      listen<{ participantId: string }>('video-popout:tile-removed', (event) => {
+      listen<{ participantId: string }>('camera-popout:tile-removed', (event) => {
         setTilesById((prev) => {
           const next = { ...prev };
           delete next[event.payload.participantId];
           return next;
         });
       }),
-      listen('video-popout:close', () => {
+      listen('camera-popout:close', () => {
         getCurrentWindow().close().catch(() => { });
       }),
       listen('voice-session:ended', () => {
@@ -166,7 +172,7 @@ export default function VideoPopoutPage() {
       }),
     ];
 
-    void emit('video-popout:ready', {});
+    void emit('camera-popout:ready', {});
 
     return () => {
       for (const cleanup of cleanups) {
@@ -178,7 +184,7 @@ export default function VideoPopoutPage() {
   useEffect(() => {
     const win = getCurrentWindow();
     const unlisten = win.onCloseRequested(async () => {
-      await emit('video-popout:closed', {});
+      await emit('camera-popout:closed', {});
     });
     return () => { unlisten.then((fn) => fn()); };
   }, []);
@@ -187,13 +193,35 @@ export default function VideoPopoutPage() {
   const layout = tiles.length > 0 && gridSize.width > 0 && gridSize.height > 0
     ? computeGridLayout(tiles.length, gridSize.width, gridSize.height)
     : null;
+  const handleClose = () => {
+    getCurrentWindow().close();
+  };
 
   return (
-    <div className="h-full flex flex-col bg-wavis-bg font-mono text-wavis-text">
+    <div className="h-screen flex flex-col bg-wavis-overlay-base font-mono text-wavis-text overflow-hidden select-none">
+      <div
+        data-tauri-drag-region
+        className="flex items-center justify-between px-2 border-b border-wavis-text-secondary bg-wavis-panel text-xs shrink-0"
+        style={{ height: TITLE_BAR_HEIGHT }}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span style={{ color: 'var(--wavis-purple)' }}>▲</span>
+          <span className="truncate text-wavis-text">
+            Camera — {paramsRef.current?.channelName ?? 'wavis'}
+          </span>
+        </div>
+        <button
+          onClick={handleClose}
+          className="inline-flex items-center justify-center w-8 h-8 hover:bg-wavis-danger hover:text-wavis-text-contrast text-wavis-danger shrink-0 transition-colors"
+          aria-label="Close camera window"
+        >
+          [x]
+        </button>
+      </div>
       <div ref={gridRef} className="flex-1 overflow-hidden relative">
         {tiles.length === 0 ? (
           <div className="h-full flex items-center justify-center text-wavis-text-secondary text-sm">
-            {paramsRef.current?.channelName ? `${paramsRef.current.channelName}: no video active` : 'No video active'}
+            {paramsRef.current?.channelName ? `${paramsRef.current.channelName}: no camera active` : 'No camera active'}
           </div>
         ) : layout ? (
           <div
@@ -208,15 +236,7 @@ export default function VideoPopoutPage() {
               <VideoPopoutTile key={tile.participantId} tile={tile} />
             ))}
           </div>
-        ) : (
-          <div className="flex flex-wrap gap-2 p-2">
-            {tiles.map((tile) => (
-              <div key={tile.participantId} className="flex-1 min-w-[120px]">
-                <VideoPopoutTile tile={tile} />
-              </div>
-            ))}
-          </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
+++ b/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { emit, listen } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
+import { computeGridLayout } from '@features/screen-share/watch-all-grid';
+import { StreamReceiver } from '@features/screen-share/screen-share-viewer';
+import type { VideoTileSnapshot } from './camera-types';
+
+interface VideoPopoutParams {
+  channelName: string;
+}
+
+function parseHashParams(): VideoPopoutParams | null {
+  try {
+    const hash = window.location.hash.slice(1);
+    if (!hash) return null;
+    return JSON.parse(decodeURIComponent(hash));
+  } catch {
+    return null;
+  }
+}
+
+function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const receiverRef = useRef<StreamReceiver | null>(null);
+  const [stream, setStream] = useState<MediaStream | null>(null);
+  const [receiverError, setReceiverError] = useState(false);
+  const shouldReceive = tile.hasTrack && !tile.isMuted && !tile.hasError;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!shouldReceive) {
+      receiverRef.current?.stop();
+      receiverRef.current = null;
+      setStream(null);
+      setReceiverError(false);
+      return;
+    }
+
+    receiverRef.current?.stop();
+    const receiver = new StreamReceiver(tile.participantId, 'video-popout');
+    receiverRef.current = receiver;
+    setReceiverError(false);
+
+    receiver.start()
+      .then((nextStream) => {
+        if (cancelled) return;
+        setStream(nextStream);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStream(null);
+        setReceiverError(true);
+      });
+
+    return () => {
+      cancelled = true;
+      receiver.stop();
+      if (receiverRef.current === receiver) {
+        receiverRef.current = null;
+      }
+    };
+  }, [shouldReceive, tile.participantId]);
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+    if (!stream) {
+      el.srcObject = null;
+      return;
+    }
+    el.srcObject = stream;
+    el.play().catch(() => { });
+    return () => {
+      el.srcObject = null;
+    };
+  }, [stream]);
+
+  const showVideo = shouldReceive && stream && !receiverError;
+
+  return (
+    <div className="relative aspect-video overflow-hidden border border-wavis-text-secondary bg-wavis-panel">
+      {showVideo ? (
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted={tile.isSelf}
+          className="w-full h-full object-cover"
+          style={tile.isSelf ? { transform: 'scaleX(-1)' } : undefined}
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <span className="text-2xl" style={{ color: tile.color }}>
+            {tile.isMuted ? '⊘' : '◻'}
+          </span>
+        </div>
+      )}
+      <div
+        className="absolute bottom-0 left-0 right-0 px-1 py-0.5 text-xs truncate"
+        style={{
+          background: 'rgba(0,0,0,0.55)',
+          color: tile.color,
+        }}
+      >
+        {tile.displayName || tile.participantId}
+      </div>
+      {tile.isMuted && (
+        <div
+          className="absolute top-1 right-1 text-[10px] px-1 rounded"
+          style={{ background: 'rgba(0,0,0,0.65)', color: 'var(--wavis-danger)' }}
+        >
+          muted
+        </div>
+      )}
+      {(tile.hasError || receiverError) && (
+        <div
+          className="absolute top-1 left-1 text-[10px] px-1 rounded"
+          style={{ background: 'rgba(0,0,0,0.65)', color: 'var(--wavis-danger)' }}
+        >
+          video_error
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function VideoPopoutPage() {
+  const paramsRef = useRef(parseHashParams());
+  const gridRef = useRef<HTMLDivElement>(null);
+  const [gridSize, setGridSize] = useState({ width: 0, height: 0 });
+  const [tilesById, setTilesById] = useState<Record<string, VideoTileSnapshot>>({});
+
+  useEffect(() => {
+    const el = gridRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      setGridSize({ width: entry.contentRect.width, height: entry.contentRect.height });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const cleanups = [
+      listen<VideoTileSnapshot>('video-popout:tile-added', (event) => {
+        setTilesById((prev) => ({ ...prev, [event.payload.participantId]: event.payload }));
+      }),
+      listen<VideoTileSnapshot>('video-popout:tile-updated', (event) => {
+        setTilesById((prev) => ({ ...prev, [event.payload.participantId]: event.payload }));
+      }),
+      listen<{ participantId: string }>('video-popout:tile-removed', (event) => {
+        setTilesById((prev) => {
+          const next = { ...prev };
+          delete next[event.payload.participantId];
+          return next;
+        });
+      }),
+      listen('video-popout:close', () => {
+        getCurrentWindow().close().catch(() => { });
+      }),
+      listen('voice-session:ended', () => {
+        getCurrentWindow().close().catch(() => { });
+      }),
+    ];
+
+    void emit('video-popout:ready', {});
+
+    return () => {
+      for (const cleanup of cleanups) {
+        cleanup.then((fn) => fn());
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const win = getCurrentWindow();
+    const unlisten = win.onCloseRequested(async () => {
+      await emit('video-popout:closed', {});
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, []);
+
+  const tiles = useMemo(() => Object.values(tilesById), [tilesById]);
+  const layout = tiles.length > 0 && gridSize.width > 0 && gridSize.height > 0
+    ? computeGridLayout(tiles.length, gridSize.width, gridSize.height)
+    : null;
+
+  return (
+    <div className="h-full flex flex-col bg-wavis-bg font-mono text-wavis-text">
+      <div ref={gridRef} className="flex-1 overflow-hidden relative">
+        {tiles.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-wavis-text-secondary text-sm">
+            {paramsRef.current?.channelName ? `${paramsRef.current.channelName}: no video active` : 'No video active'}
+          </div>
+        ) : layout ? (
+          <div
+            className="w-full h-full"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: `repeat(${layout.columns}, 1fr)`,
+              gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
+            }}
+          >
+            {tiles.map((tile) => (
+              <VideoPopoutTile key={tile.participantId} tile={tile} />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2 p-2">
+            {tiles.map((tile) => (
+              <div key={tile.participantId} className="flex-1 min-w-[120px]">
+                <VideoPopoutTile tile={tile} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clients/wavis-gui/src/features/voice/VideoTab.tsx
+++ b/clients/wavis-gui/src/features/voice/VideoTab.tsx
@@ -1,63 +1,34 @@
-import { useRef, useState, useEffect } from 'react';
 import type { VideoTileViewModel } from './camera-types';
 import { VideoTile } from './VideoTile';
-import { computeGridLayout } from '@features/screen-share/watch-all-grid';
 
 interface VideoTabProps {
   videoTilesById: Record<string, VideoTileViewModel>;
 }
 
 export function VideoTab({ videoTilesById }: VideoTabProps) {
-  const gridRef = useRef<HTMLDivElement>(null);
-  const [gridSize, setGridSize] = useState({ width: 0, height: 0 });
-
-  useEffect(() => {
-    const el = gridRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      setGridSize({ width: entry.contentRect.width, height: entry.contentRect.height });
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, []);
-
   const tiles = Object.values(videoTilesById);
 
-  const layout =
-    tiles.length > 0 && gridSize.width > 0 && gridSize.height > 0
-      ? computeGridLayout(tiles.length, gridSize.width, gridSize.height)
-      : null;
+  if (tiles.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-wavis-text-secondary text-sm">
+        No video active
+      </div>
+    );
+  }
 
   return (
-    <div ref={gridRef} className="flex-1 overflow-hidden relative">
-      {tiles.length === 0 ? (
-        <div className="h-full flex items-center justify-center text-wavis-text-secondary text-sm">
-          No video active
-        </div>
-      ) : layout ? (
-        <div
-          className="w-full h-full"
-          style={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(${layout.columns}, 1fr)`,
-            gridTemplateRows: `repeat(${layout.rows}, 1fr)`,
-          }}
-        >
-          {tiles.map((tile) => (
-            <VideoTile key={tile.participantId} tile={tile} />
-          ))}
-        </div>
-      ) : (
-        <div className="flex flex-wrap gap-2 p-2">
-          {tiles.map((tile) => (
-            <div key={tile.participantId} className="flex-1 min-w-[120px]">
-              <VideoTile tile={tile} />
-            </div>
-          ))}
-        </div>
-      )}
+    <div className="flex-1 overflow-y-auto overflow-x-hidden">
+      <div className="flex flex-col">
+        {tiles.map((tile) => (
+          <div
+            key={tile.participantId}
+            className="w-full shrink-0"
+            style={{ aspectRatio: '16 / 9' }}
+          >
+            <VideoTile tile={tile} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/clients/wavis-gui/src/features/voice/VideoTile.tsx
+++ b/clients/wavis-gui/src/features/voice/VideoTile.tsx
@@ -24,7 +24,7 @@ class TileErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundary
     if (this.state.hasError) {
       return (
         <div
-          className="aspect-video flex items-center justify-center text-xs border"
+          className="w-full h-full flex items-center justify-center text-xs border"
           style={{ color: 'var(--wavis-danger)', borderColor: 'var(--wavis-danger)' }}
         >
           video error
@@ -60,7 +60,7 @@ function VideoTileInner({ tile }: VideoTileProps) {
 
   return (
     <div
-      className="relative aspect-video overflow-hidden border border-wavis-text-secondary bg-wavis-panel"
+      className="relative w-full h-full overflow-hidden bg-wavis-panel"
     >
       {tile.track && !tile.isMuted ? (
         <video

--- a/clients/wavis-gui/src/features/voice/__tests__/active-room-camera.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/active-room-camera.property.test.ts
@@ -3,9 +3,9 @@ import * as fc from 'fast-check';
 
 import { cameraButtonLabel, shouldMountCameraButton } from '../active-room-camera';
 
-describe('Feature: video-feed, Property 4: Button label depends only on intent', () => {
-  it('returns Stop Video iff camera intent is true, regardless of publication state', () => {
-    const publicationStateArb = fc.constantFrom<'idle' | 'opening' | 'publishing' | 'published' | 'failing'>(
+  describe('Feature: video-feed, Property 4: Button label depends only on intent', () => {
+    it('returns camera-off iff camera intent is true, regardless of publication state', () => {
+      const publicationStateArb = fc.constantFrom<'idle' | 'opening' | 'publishing' | 'published' | 'failing'>(
       'idle',
       'opening',
       'publishing',
@@ -14,12 +14,12 @@ describe('Feature: video-feed, Property 4: Button label depends only on intent',
     );
 
     fc.assert(
-      fc.property(fc.boolean(), publicationStateArb, (cameraIntent, cameraPublication) => {
-        expect(cameraButtonLabel(cameraIntent)).toBe(cameraIntent ? 'Stop Video' : 'Start Video');
+        fc.property(fc.boolean(), publicationStateArb, (cameraIntent, cameraPublication) => {
+          expect(cameraButtonLabel(cameraIntent)).toBe(cameraIntent ? 'camera-off' : 'camera-on');
 
-        void cameraPublication;
-        expect(cameraButtonLabel(cameraIntent)).toBe(cameraIntent ? 'Stop Video' : 'Start Video');
-      }),
+          void cameraPublication;
+          expect(cameraButtonLabel(cameraIntent)).toBe(cameraIntent ? 'camera-off' : 'camera-on');
+        }),
       { numRuns: 100 },
     );
   });

--- a/clients/wavis-gui/src/features/voice/__tests__/active-room-camera.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/active-room-camera.test.ts
@@ -37,15 +37,15 @@ describe('Feature: video-feed — button stays mounted during media reconnect (R
 
 /* ─── Button label ──────────────────────────────────────────────── */
 
-describe('Feature: video-feed — button label (Req 1.7, 1.8)', () => {
-  it('returns "Start Video" when intent is false', () => {
-    expect(cameraButtonLabel(false)).toBe('Start Video');
-  });
+  describe('Feature: video-feed — button label (Req 1.7, 1.8)', () => {
+    it('returns "camera-on" when intent is false', () => {
+      expect(cameraButtonLabel(false)).toBe('camera-on');
+    });
 
-  it('returns "Stop Video" when intent is true', () => {
-    expect(cameraButtonLabel(true)).toBe('Stop Video');
+    it('returns "camera-off" when intent is true', () => {
+      expect(cameraButtonLabel(true)).toBe('camera-off');
+    });
   });
-});
 
 /* ─── Panel tab defaults ────────────────────────────────────────── */
 

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -2233,7 +2233,7 @@ describe('Edge case unit tests', () => {
       await tick();
 
       expect(lastLkModule!.stopScreenShareCalls).toBe(1);
-      expect(sentMessages).toContainEqual({ type: 'stop_share' });
+      expect(sentMessages).toContainEqual({ type: 'stop-share' });
       expect(playNotificationSoundCalls).not.toContain('share-stop');
 
       messageHandler!({ type: 'share_stopped', participantId: 'self-peer', displayName: 'TestUser' });
@@ -2269,7 +2269,7 @@ describe('Edge case unit tests', () => {
       await tick();
 
       expect(lastLkModule!.stopScreenShareCalls).toBe(0);
-      expect(sentMessages.filter(m => m.type === 'stop_share')).toHaveLength(0);
+      expect(sentMessages.filter(m => m.type === 'stop-share')).toHaveLength(0);
 
       leaveRoom();
     });
@@ -2285,7 +2285,7 @@ describe('Edge case unit tests', () => {
       lastLkModule!.callbacks.onLocalScreenShareEnded();
       await tick();
 
-      const stopMessages = sentMessages.filter(m => m.type === 'stop_share');
+      const stopMessages = sentMessages.filter(m => m.type === 'stop-share');
       expect(stopMessages).toHaveLength(1);
 
       leaveRoom();

--- a/clients/wavis-gui/src/features/voice/active-room-camera.ts
+++ b/clients/wavis-gui/src/features/voice/active-room-camera.ts
@@ -1,5 +1,5 @@
-export function cameraButtonLabel(cameraIntent: boolean): 'Start Video' | 'Stop Video' {
-  return cameraIntent ? 'Stop Video' : 'Start Video';
+export function cameraButtonLabel(cameraIntent: boolean): 'camera-off' | 'camera-on' {
+  return cameraIntent ? 'camera-off' : 'camera-on';
 }
 
 export function shouldMountCameraButton(

--- a/clients/wavis-gui/src/features/voice/camera-types.ts
+++ b/clients/wavis-gui/src/features/voice/camera-types.ts
@@ -44,6 +44,16 @@ export interface VideoTileViewModel {
   hasError: boolean;
 }
 
+export interface VideoTileSnapshot {
+  participantId: string;
+  displayName: string;
+  color: string;
+  hasTrack: boolean;
+  isSelf: boolean;
+  isMuted: boolean;
+  hasError: boolean;
+}
+
 export interface PanelTabInput {
   anyVideoActive: boolean;
   manualOverride: 'logs' | 'video' | null;

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1555,7 +1555,7 @@ function setupExternalShareHelperListeners(): void {
       self.isSharing = false;
     }
     if (!localStopShareSent && client) {
-      client.send({ type: 'stop_share' });
+      client.send({ type: 'stop-share' });
     }
     localStopShareSent = false;
     notify();
@@ -2394,7 +2394,7 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
       // Only send stop_share if we didn't already send it from stopShare()
       // and we're not in the middle of changing the share source
       if (!localStopShareSent && !localSourceChanging && client) {
-        client.send({ type: 'stop_share' });
+        client.send({ type: 'stop-share' });
       }
       localStopShareSent = false;
     },
@@ -3640,7 +3640,7 @@ export function leaveRoom(): void {
       .catch(() => { });
     // Send stop_share before leave for custom shares
     if (client && client.status === 'connected') {
-      client.send({ type: 'stop_share' });
+      client.send({ type: 'stop-share' });
     }
     // Clear state synchronously
     state.activeVideoShare = null;
@@ -3655,7 +3655,7 @@ export function leaveRoom(): void {
     externalShareHelperActive = false;
     // Fallback share is active — send stop_share signaling before leave
     if (client && client.status === 'connected') {
-      client.send({ type: 'stop_share' });
+      client.send({ type: 'stop-share' });
     }
     selfP.isSharing = false;
     state.shareQualityInfo = null;
@@ -4251,7 +4251,7 @@ export async function stopCustomShare(target: 'video' | 'audio' | 'all' = 'all')
 
   // 4. Send stop_share signaling
   if (client) {
-    client.send({ type: 'stop_share' });
+    client.send({ type: 'stop-share' });
   }
 
   // 5. Clear affected slot(s)
@@ -4340,7 +4340,7 @@ export async function stopShare(): Promise<void> {
   await invoke('audio_share_stop').catch(() => { });
   await lkModule?.stopScreenShare();
   if (client) {
-    client.send({ type: 'stop_share' });
+    client.send({ type: 'stop-share' });
   }
 }
 
@@ -4386,7 +4386,7 @@ export async function changeShareSource(): Promise<boolean> {
       // local media is already dead (e.g. replaceTrack threw after teardown).
       const stillActive = (lkModule as LiveKitModule).hasActiveScreenShareTrack();
       if (!stillActive) {
-        client.send({ type: 'stop_share' });
+        client.send({ type: 'stop-share' });
         localStopShareSent = true;
       }
     }
@@ -4490,7 +4490,7 @@ export function unmuteParticipant(participantId: string): void {
 export function stopParticipantShare(participantId: string): void {
   if (!state.selfIsHost) return;
   if (!client) return;
-  client.send({ type: 'stop_share', targetParticipantId: participantId });
+  client.send({ type: 'stop-share', targetParticipantId: participantId });
 }
 
 export function stopAllShares(): void {

--- a/clients/wavis-gui/src/routes.ts
+++ b/clients/wavis-gui/src/routes.ts
@@ -52,7 +52,7 @@ export const router = createBrowserRouter([
     },
   },
   {
-    path: '/video-popout',
+    path: '/camera-popout',
     lazy: async () => {
       const { default: Component } = await import('@features/voice/VideoPopoutPage');
       return withFallback({ Component });

--- a/clients/wavis-gui/src/routes.ts
+++ b/clients/wavis-gui/src/routes.ts
@@ -52,6 +52,13 @@ export const router = createBrowserRouter([
     },
   },
   {
+    path: '/video-popout',
+    lazy: async () => {
+      const { default: Component } = await import('@features/voice/VideoPopoutPage');
+      return withFallback({ Component });
+    },
+  },
+  {
     path: '/share-picker',
     lazy: async () => {
       const { default: Component } = await import('@features/screen-share/SharePicker');

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -174,6 +174,7 @@ pub enum SignalingMessage {
     /// Server -> all participants broadcast that a share started.
     ShareStarted(ShareStartedPayload),
     /// Client -> server request to stop a share.
+    #[serde(rename = "stop-share")]
     StopShare(StopSharePayload),
     /// Server -> all participants broadcast that a share stopped.
     ShareStopped(ShareStoppedPayload),

--- a/shared/src/signaling/tests.rs
+++ b/shared/src/signaling/tests.rs
@@ -361,7 +361,7 @@ proptest! {
                            "room_state", "media_token", "kick_participant", "mute_participant",
                            "unmute_participant",
                            "participant_kicked", "participant_muted", "participant_unmuted",
-                           "start_share", "share_started", "stop_share", "share_stopped",
+                           "start_share", "share_started", "stop-share", "share_stopped",
                            "create_room", "room_created",
                            "auth", "auth_success", "auth_failed",
                            "join_voice", "create_sub_room", "join_sub_room", "leave_sub_room",

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -767,7 +767,7 @@ mod tests {
                 "peer_left", "leave", "error", "participant_joined", "participant_left",
                 "room_state", "media_token", "kick_participant", "mute_participant",
                 "participant_kicked", "participant_muted",
-                "start_share", "share_started", "stop_share", "share_stopped",
+                "start_share", "share_started", "stop-share", "share_stopped",
                 "stop_all_shares", "share_state",
                 "create_room", "room_created",
                 "auth", "auth_success", "auth_failed",

--- a/tools/stress/src/scenarios/host_directed_stop.rs
+++ b/tools/stress/src/scenarios/host_directed_stop.rs
@@ -165,7 +165,7 @@ impl Scenario for HostDirectedStopScenario {
                 guests[0]
                     .0
                     .send_json(&serde_json::json!({
-                        "type": "stop_share",
+                        "type": "stop-share",
                         "targetParticipantId": target_pid,
                     }))
                     .await
@@ -194,7 +194,7 @@ impl Scenario for HostDirectedStopScenario {
             for pid in &guest_peer_ids {
                 host.0
                     .send_json(&serde_json::json!({
-                        "type": "stop_share",
+                        "type": "stop-share",
                         "targetParticipantId": pid,
                     }))
                     .await

--- a/tools/stress/src/scenarios/multi_share_flood.rs
+++ b/tools/stress/src/scenarios/multi_share_flood.rs
@@ -108,7 +108,7 @@ impl Scenario for MultiShareFloodScenario {
                                 .await
                                 .ok();
                         } else {
-                            c.send_json(&serde_json::json!({ "type": "stop_share" }))
+                            c.send_json(&serde_json::json!({ "type": "stop-share" }))
                                 .await
                                 .ok();
                         }

--- a/tools/stress/src/scenarios/screen_share_race.rs
+++ b/tools/stress/src/scenarios/screen_share_race.rs
@@ -461,7 +461,7 @@ impl Scenario for ScreenShareRaceScenario {
             let sharer_task = tokio::spawn(async move {
                 b1.wait().await;
                 sharer
-                    .send_json(&serde_json::json!({ "type": "stop_share" }))
+                    .send_json(&serde_json::json!({ "type": "stop-share" }))
                     .await
                     .ok();
                 // Drain briefly

--- a/tools/stress/src/scenarios/share_state_consistency.rs
+++ b/tools/stress/src/scenarios/share_state_consistency.rs
@@ -127,7 +127,7 @@ impl Scenario for ShareStateConsistencyScenario {
             // This creates a window where the share_state snapshot might be inconsistent.
             sharers[0]
                 .0
-                .send_json(&serde_json::json!({ "type": "stop_share" }))
+                .send_json(&serde_json::json!({ "type": "stop-share" }))
                 .await
                 .ok();
 

--- a/wavis-backend/tests/phase3_manual_tests_integration.rs
+++ b/wavis-backend/tests/phase3_manual_tests_integration.rs
@@ -502,7 +502,7 @@ async fn test18c_stop_share_by_owner() {
     drain(&mut r_guest).await;
 
     // Owner stops share
-    ws_send(&mut s_host, json!({"type":"stop_share"})).await;
+    ws_send(&mut s_host, json!({"type":"stop-share"})).await;
     let stopped_host = recv_type(&mut r_host, "share_stopped").await;
     assert_eq!(stopped_host["participantId"], host_id);
 
@@ -546,7 +546,7 @@ async fn test18d_stop_share_host_override() {
     // Host stops guest's share (override)
     ws_send(
         &mut s_host,
-        json!({"type":"stop_share","targetParticipantId": &guest_id}),
+        json!({"type":"stop-share","targetParticipantId": &guest_id}),
     )
     .await;
     let stopped = recv_type(&mut r_host, "share_stopped").await;
@@ -588,7 +588,7 @@ async fn test18e_stop_share_non_owner_noop() {
     drain(&mut r_guest).await;
 
     // Guest tries to stop â€” should be silent no-op (no error, no share_stopped)
-    ws_send(&mut s_guest, json!({"type":"stop_share"})).await;
+    ws_send(&mut s_guest, json!({"type":"stop-share"})).await;
 
     // Verify no share_stopped or error arrives for the guest within a short window
     let response = try_recv_type(&mut r_guest, "share_stopped", 500).await;
@@ -924,7 +924,7 @@ async fn test21c_oversized_participant_id_in_stop_share() {
     let long_id = "x".repeat(200);
     ws_send(
         &mut sink,
-        json!({"type":"stop_share","targetParticipantId": long_id}),
+        json!({"type":"stop-share","targetParticipantId": long_id}),
     )
     .await;
     let err = recv_type(&mut stream, "error").await;
@@ -968,7 +968,7 @@ async fn test22a_start_share_before_auth() {
     assert_eq!(err["message"], "not authenticated");
 
     // Connection should still be open
-    ws_send(&mut sink, json!({"type":"stop_share"})).await;
+    ws_send(&mut sink, json!({"type":"stop-share"})).await;
     let err2 = recv_type(&mut stream, "error").await;
     assert_eq!(err2["message"], "not authenticated");
 }

--- a/wavis-backend/tests/screen_share_ws_integration.rs
+++ b/wavis-backend/tests/screen_share_ws_integration.rs
@@ -326,7 +326,7 @@ async fn test_13_stop_share_broadcast() {
     drain(&mut stream2).await;
 
     // Stop sharing
-    ws_send(&mut sink1, json!({"type":"stop_share"})).await;
+    ws_send(&mut sink1, json!({"type":"stop-share"})).await;
 
     let stopped1 = recv_type(&mut stream1, "share_stopped").await;
     let stopped2 = recv_type(&mut stream2, "share_stopped").await;
@@ -351,7 +351,7 @@ async fn test_13_host_directed_stop() {
     // Host stops guest's share via targetParticipantId
     ws_send(
         &mut sink1,
-        json!({"type":"stop_share","targetParticipantId": guest_id}),
+        json!({"type":"stop-share","targetParticipantId": guest_id}),
     )
     .await;
 
@@ -378,7 +378,7 @@ async fn test_13_non_host_targeted_stop_rejected() {
     // Guest tries to stop host's share â†’ error
     ws_send(
         &mut sink2,
-        json!({"type":"stop_share","targetParticipantId": host_id}),
+        json!({"type":"stop-share","targetParticipantId": host_id}),
     )
     .await;
 


### PR DESCRIPTION
This PR introduces the camera popout feature and several UI improvements:

- Implement camera popout window (camera-popout)
- Add custom chromeless title bar for the popout window with drag region and close button
- Improve UI synchronization between the main window and the popout window
- Rename 'video-popout' to 'camera-popout' for consistency
- Automatically switch to 'logs' tab and hide the 'video' tab when popping out
- Simplify VideoTab layout to a vertical list of tiles