### PR TITLE
fix(gui): focus watch-all window when ready

### DIFF
--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1541,6 +1541,7 @@ export default function ActiveRoom() {
         console.log('[wavis:active-room] watch-all:ready received, readyRef was:', watchAllReadyRef.current);
         if (watchAllReadyRef.current) return; // idempotent
         watchAllReadyRef.current = true;
+        watchAllWindowRef.current?.setFocus();
         // Read fresh roomState via ref — the closure captured at
         // openWatchAllWindow time may be stale by now.
         const rs = roomStateRef.current;


### PR DESCRIPTION
Focuses the watch-all window when the 'watch-all:ready' event is received. Fixes the issue where the window doesn't get focus when opened via keyboard shortcut.