### PR TITLE
fix(gui): preserve screen share volume slider position when muting

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
@@ -403,9 +403,15 @@ export default function ScreenSharePage() {
   }, [p]);
 
   const handleToggleMute = useCallback(() => {
-    const nextVolume = muted ? (volume > 0 ? volume : 50) : 0;
-    handleVolumeChange(nextVolume);
-  }, [handleVolumeChange, muted, volume]);
+    if (!p) return;
+    setMuted((prev) => {
+      const nextMuted = !prev;
+      // Use local-audio so the gain is set without writing 0 into shareVolumes.
+      // This lets Watch All re-open at the slider's actual position (not muted).
+      emit('screen-share:local-audio', { participantId: p.participantId, volume: nextMuted ? 0 : volume });
+      return nextMuted;
+    });
+  }, [p, volume]);
 
   const handleVoiceVolumeChange = useCallback((participantId: string, nextVolume: number) => {
     setVoiceParticipants((prev) =>

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -501,6 +501,7 @@ export default function WatchAllPage() {
             const next = prev.map((tile) => {
               if (tile.participantId !== participantId) return tile;
               found = true;
+              // volume=0 means muted; preserve the slider position so unmute restores correctly
               return { ...tile, volume, muted: volume === 0 };
             });
             if (!found) {
@@ -606,9 +607,10 @@ export default function WatchAllPage() {
       prev.map((t) => {
         if (t.participantId !== participantId) return t;
         const nextMuted = !t.muted;
-        const nextVolume = nextMuted ? 0 : (t.volume > 0 ? t.volume : 50);
-        emit('watch-all:volume-change', { participantId, volume: nextVolume });
-        return { ...t, muted: nextMuted, volume: nextVolume };
+        // Use local-audio so the gain is set without writing 0 into shareVolumes.
+        // This lets Watch All re-open at the slider's actual position (not muted).
+        emit('watch-all:local-audio', { participantId, volume: nextMuted ? 0 : t.volume });
+        return { ...t, muted: nextMuted };
       }),
     );
   }, []);

--- a/clients/wavis-gui/src/features/screen-share/__tests__/WatchAllPage.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/WatchAllPage.test.ts
@@ -126,6 +126,7 @@ function popOutTile(
   if (!tile) return { remainingTiles: tiles, payload: null };
   return {
     remainingTiles: removeTile(tiles, participantId),
+    // Send slider position (tile.volume); mute-toggle is local-only, not inherited by pop-out
     payload: { participantId, volume: tile.volume },
   };
 }
@@ -397,6 +398,53 @@ describe('WatchAllPage tile state management', () => {
 
     expect(tiles[0].volume).toBe(70);
     expect(tiles[0].muted).toBe(false);
+  });
+
+  it('mute toggle preserves slider position (volume field unchanged)', () => {
+    let tiles: ShareTileState[] = [];
+    tiles = addTile(tiles, { participantId: 'user-1', displayName: 'Alice', color: '#E06C75', canvasFallback: false });
+    tiles = setTileVolume(tiles, 'user-1', 70);
+    expect(tiles[0].volume).toBe(70);
+
+    tiles = toggleMute(tiles, 'user-1');
+    expect(tiles[0].muted).toBe(true);
+    expect(tiles[0].volume).toBe(70); // slider position preserved
+
+    tiles = toggleMute(tiles, 'user-1');
+    expect(tiles[0].muted).toBe(false);
+    expect(tiles[0].volume).toBe(70); // unmute restores to pre-mute level, not 50
+  });
+
+  it('restore-volume with 0 sets slider to 0 and mutes', () => {
+    let tiles: ShareTileState[] = [];
+    tiles = addTile(tiles, { participantId: 'user-1', displayName: 'Alice', color: '#E06C75', canvasFallback: false });
+    tiles = setTileVolume(tiles, 'user-1', 60);
+
+    // Simulates slider explicitly dragged to 0 in another window (persisted via syncScreenShareVolume)
+    tiles = restoreTileVolume(tiles, { participantId: 'user-1', volume: 0 });
+    expect(tiles[0].muted).toBe(true);
+    expect(tiles[0].volume).toBe(0); // slider follows the explicit 0
+  });
+
+  it('pop-out of muted tile sends slider position (toggle-mute is local-only)', () => {
+    let tiles: ShareTileState[] = [];
+    tiles = addTile(tiles, { participantId: 'user-1', displayName: 'Alice', color: '#E06C75', canvasFallback: false });
+    tiles = setTileVolume(tiles, 'user-1', 80);
+    tiles = toggleMute(tiles, 'user-1');
+    expect(tiles[0].muted).toBe(true);
+    expect(tiles[0].volume).toBe(80);
+
+    const { payload } = popOutTile(tiles, 'user-1');
+    expect(payload?.volume).toBe(80); // slider position, not effective volume (mute is local)
+  });
+
+  it('pop-out of unmuted tile sends slider position', () => {
+    let tiles: ShareTileState[] = [];
+    tiles = addTile(tiles, { participantId: 'user-1', displayName: 'Alice', color: '#E06C75', canvasFallback: false });
+    tiles = setTileVolume(tiles, 'user-1', 45);
+
+    const { payload } = popOutTile(tiles, 'user-1');
+    expect(payload?.volume).toBe(45);
   });
 
   it('volume persists across pop-out and pop-back', () => {

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -787,7 +787,9 @@ export default function ActiveRoom() {
   }, []);
 
   const getSavedShareVolume = useCallback((participantId: string) => {
-    return shareVolumesRef.current.get(participantId) ?? watchAllVolumesRef.current.get(participantId) ?? 70;
+    // watchAllVolumesRef is updated synchronously by syncScreenShareVolume;
+    // shareVolumesRef lags by one render cycle (useEffect). Prefer the sync ref.
+    return watchAllVolumesRef.current.get(participantId) ?? shareVolumesRef.current.get(participantId) ?? 70;
   }, []);
 
   const syncScreenShareVolume = useCallback((participantId: string, volume: number) => {
@@ -826,7 +828,7 @@ export default function ActiveRoom() {
         next.delete(participantId);
         setScreenShareAudioVolume(participantId, saved);
       } else {
-        const current = shareVolumesRef.current.get(participantId) ?? 70;
+        const current = watchAllVolumesRef.current.get(participantId) ?? shareVolumesRef.current.get(participantId) ?? 70;
         next.set(participantId, current || 70);
         setScreenShareAudioVolume(participantId, 0);
       }
@@ -919,6 +921,15 @@ export default function ActiveRoom() {
     });
     emitWatchAllRestoreVolume(participantId);
     prevWatchAllStreamsRef.current.set(participantId, stream);
+    // Attach audio directly. If the tile already exists in Watch All,
+    // share-added is a no-op and viewer-ready never fires, so audio would be
+    // left unattached. This covers both the new-tile path (idempotent with
+    // the viewer-ready attach) and the existing-tile path.
+    if (!shareWindowsRef.current.has(participantId)) {
+      attachScreenShareAudio(participantId);
+      setScreenShareAudioVolume(participantId, getSavedShareVolume(participantId));
+      watchAllAttachedAudioRef.current.add(participantId);
+    }
   };
 
   const handleShareWindowClosed = (participantId: string) => {
@@ -926,7 +937,13 @@ export default function ActiveRoom() {
     // If another close path already removed it, skip duplicate cleanup.
     if (!shareWindowsRef.current.delete(participantId)) return;
     stopSending(participantId, `screen-share-${participantId}`);
-    detachScreenShareAudio(participantId);
+    // Skip detach when Watch All will take the stream back: detaching triggers
+    // setSubscribed(false/true) which can race TrackUnsubscribed/TrackSubscribed
+    // unpredictably. Keeping the gain node alive lets reAddStreamToWatchAll
+    // update volume immediately without any subscription churn.
+    if (!watchAllWindowRef.current || !watchAllReadyRef.current) {
+      detachScreenShareAudio(participantId);
+    }
     setWatchingShareIds((prev) => {
       const next = new Set(prev);
       next.delete(participantId);
@@ -943,7 +960,9 @@ export default function ActiveRoom() {
       // delete() returns false and we skip to avoid double-add.
       if (!shareWindowsRef.current.delete(pid)) return;
       stopSending(pid, `screen-share-${pid}`);
-      detachScreenShareAudio(pid);
+      if (!watchAllWindowRef.current || !watchAllReadyRef.current) {
+        detachScreenShareAudio(pid);
+      }
       setWatchingShareIds((prev) => {
         const next = new Set(prev);
         next.delete(pid);
@@ -995,6 +1014,17 @@ export default function ActiveRoom() {
       listen<{ participantId: string; volume: number }>('screen-share:volume-change', (event) => {
         const { participantId, volume } = event.payload;
         syncScreenShareVolume(participantId, volume);
+      }),
+    );
+    // Local mute toggle: sets gain only, does not persist to shareVolumes/watchAllVolumesRef
+    cleanups.push(
+      listen<{ participantId: string; volume: number }>('watch-all:local-audio', (event) => {
+        setScreenShareAudioVolume(event.payload.participantId, event.payload.volume);
+      }),
+    );
+    cleanups.push(
+      listen<{ participantId: string; volume: number }>('screen-share:local-audio', (event) => {
+        setScreenShareAudioVolume(event.payload.participantId, event.payload.volume);
       }),
     );
     cleanups.push(
@@ -1338,9 +1368,11 @@ export default function ActiveRoom() {
       shareWindowsRef.current.set(participantId, { window: win, scope });
       setWatchingShareIds((prev) => new Set(prev).add(participantId));
 
-      // If Watch All is open, remove this tile from the grid — the pop-out owns it now
+      // If Watch All is open, remove this tile from the grid — the pop-out owns it now.
+      // Do NOT detach audio here: the gain node and subscription remain alive so the
+      // pop-out's handleViewerReady finds them intact and only needs to set the volume.
+      // closeShareWindow handles detach when the pop-out is actually closed.
       if (watchAllWindowRef.current && watchAllReadyRef.current) {
-        detachScreenShareAudio(participantId);
         watchAllAttachedAudioRef.current.delete(participantId);
         stopSending(participantId, 'watch-all');
         prevWatchAllStreamsRef.current.delete(participantId);
@@ -1354,7 +1386,9 @@ export default function ActiveRoom() {
   /** Close a specific screen share OS window and clean up the bridge. */
   const closeShareWindow = (participantId: string) => {
     stopSending(participantId, `screen-share-${participantId}`);
-    detachScreenShareAudio(participantId);
+    if (!watchAllWindowRef.current || !watchAllReadyRef.current) {
+      detachScreenShareAudio(participantId);
+    }
     const shareWindow = shareWindowsRef.current.get(participantId);
     if (shareWindow) {
       // Delete BEFORE win.close() so the screen-share:closed handler

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -5138,7 +5138,8 @@ export class LiveKitModule {
     }
     const source = ctx.createMediaStreamSource(stream);
     const gain = ctx.createGain();
-    gain.gain.setValueAtTime(perceptualGain(70), ctx.currentTime);
+    const desiredVol = this.desiredParticipantVolumes.get(audioKey) ?? 70;
+    gain.gain.setValueAtTime(perceptualGain(desiredVol), ctx.currentTime);
     source.connect(gain);
     gain.connect(this.masterGain!);
     this.participantGains.set(audioKey, gain);
@@ -5156,6 +5157,10 @@ export class LiveKitModule {
     if (publication && typeof publication.setSubscribed === 'function') {
       publication.setSubscribed(false);
     }
+    // Delete synchronously so that a follow-up attachScreenShareAudio always
+    // goes through the pending path (fresh track from TrackSubscribed) rather
+    // than reusing a stale entry that TrackUnsubscribed will tear down later.
+    this.screenShareAudioTracks.delete(participantIdentity);
     this.cleanupParticipantAudio(`${participantIdentity}:screen-share`);
     console.log(LOG, `detached screen share audio for ${participantIdentity}`);
   }


### PR DESCRIPTION
### Description
This PR fixes a bug where opening 'Watch All' after muting a single stream would reset that stream's volume.

### Changes
- Updated mute toggles in ScreenSharePage and WatchAllPage to use local-audio events, setting gain to zero without overwriting the persisted volume.
- Added local-audio event listeners in ActiveRoom to handle synchronous volume updates.
- Refactored audio attachment and detachment logic to prevent volume resets and subscription churn when transitioning between 'Watch All' and individual pop-outs.
- Fixed race conditions in LiveKitModule by synchronously deleting tracks on detachment.
- Added comprehensive unit tests for volume persistence and state management in WatchAllPage.