### PR TITLE
feat: participant join notification improvements (#16)

### DIFF
--- a/clients/wavis-gui/src-tauri/src/debug_env.rs
+++ b/clients/wavis-gui/src-tauri/src/debug_env.rs
@@ -19,9 +19,6 @@ pub fn diagnostics_window_enabled() -> bool {
     env_flag("WAVIS_DIAGNOSTICS_WINDOW")
 }
 
-pub fn diagnostics_notifications_enabled() -> bool {
-    env_flag("WAVIS_DIAGNOSTICS_NOTIFICATIONS")
-}
 
 pub fn debug_share_audio_enabled() -> bool {
     env_flag("WAVIS_DEBUG_SHARE_AUDIO")

--- a/clients/wavis-gui/src-tauri/src/diagnostics.rs
+++ b/clients/wavis-gui/src-tauri/src/diagnostics.rs
@@ -11,7 +11,6 @@ use sysinfo::{Pid, ProcessesToUpdate, System};
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsConfig {
     pub enabled: bool,
-    pub notifications_enabled: bool,
     /// Polling interval in milliseconds (WAVIS_DIAGNOSTICS_POLL_MS, default 1000).
     pub poll_ms: u64,
     /// RSS warning threshold in MB (WAVIS_DIAGNOSTICS_MEMORY_WARN_MB, default 1200).
@@ -146,7 +145,6 @@ fn collect_process_tree_stats(sys: &System) -> (f64, f64, usize) {
 pub fn get_diagnostics_config() -> DiagnosticsConfig {
     DiagnosticsConfig {
         enabled: crate::debug_env::diagnostics_window_enabled(),
-        notifications_enabled: crate::debug_env::diagnostics_notifications_enabled(),
         poll_ms: env_u64("WAVIS_DIAGNOSTICS_POLL_MS", 1000),
         memory_warn_mb: env_f64("WAVIS_DIAGNOSTICS_MEMORY_WARN_MB", 1200.0),
         network_warn_mbps: env_f64("WAVIS_DIAGNOSTICS_NETWORK_WARN_MBPS", 20.0),

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -290,6 +290,7 @@ use cpal::traits::{DeviceTrait, HostTrait};
 use serde_json::Value;
 #[cfg(target_os = "linux")]
 use std::process::Command;
+use std::sync::atomic::Ordering;
 use tauri::{Emitter, Manager};
 
 fn main() {
@@ -366,33 +367,62 @@ fn main() {
             Ok(())
         })
         .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-                let label = window.label();
-                let app = window.app_handle();
+            match event {
+                tauri::WindowEvent::CloseRequested { api, .. } => {
+                    let label = window.label();
+                    let app = window.app_handle();
 
-                // Only the main window gets minimize-to-tray behavior
-                if label == "main" {
-                    if let Some(webview_window) = app.get_webview_window(label) {
-                        if let (Some(flag), Some(vis)) = (
-                            app.try_state::<tray::MinimizeToTrayFlag>(),
-                            app.try_state::<tray::WindowVisibility>(),
-                        ) {
-                            if tray::handle_close_requested(&webview_window, &flag, &vis) {
-                                api.prevent_close();
-                                return;
+                    // Only the main window gets minimize-to-tray behavior
+                    if label == "main" {
+                        if let Some(webview_window) = app.get_webview_window(label) {
+                            if let (Some(flag), Some(vis)) = (
+                                app.try_state::<tray::MinimizeToTrayFlag>(),
+                                app.try_state::<tray::WindowVisibility>(),
+                            ) {
+                                if tray::handle_close_requested(&webview_window, &flag, &vis) {
+                                    api.prevent_close();
+                                    return;
+                                }
+                            }
+                        }
+                        // Main window is actually closing (not minimized to tray).
+                        // Notify the frontend so it can tear down the voice session
+                        // and close child windows before the window is destroyed.
+                        let _ = app.emit("main-window-closing", ());
+
+                        // Also emit voice-session:ended directly so pop-out windows
+                        // (ScreenSharePage) self-close even if the main window's JS
+                        // listener doesn't execute in time (race condition on destroy).
+                        let _ = app.emit("voice-session:ended", ());
+                    }
+                }
+                tauri::WindowEvent::Focused(focused) => {
+                    if window.label() == "main" {
+                        let app = window.app_handle();
+                        if let Some(vis) = app.try_state::<tray::WindowVisibility>() {
+                            // Skip if already hidden to tray — tray manages its own events
+                            if !vis.hidden.load(Ordering::SeqCst) {
+                                if *focused {
+                                    let _ = window.emit(
+                                        "window-visibility-changed",
+                                        tray::WindowVisibilityPayload { visible: true },
+                                    );
+                                } else {
+                                    // Only suppress notifications when actually minimized,
+                                    // not just when the user switches to another app.
+                                    let minimized = window.is_minimized().unwrap_or(false);
+                                    if minimized {
+                                        let _ = window.emit(
+                                            "window-visibility-changed",
+                                            tray::WindowVisibilityPayload { visible: false },
+                                        );
+                                    }
+                                }
                             }
                         }
                     }
-                    // Main window is actually closing (not minimized to tray).
-                    // Notify the frontend so it can tear down the voice session
-                    // and close child windows before the window is destroyed.
-                    let _ = app.emit("main-window-closing", ());
-
-                    // Also emit voice-session:ended directly so pop-out windows
-                    // (ScreenSharePage) self-close even if the main window's JS
-                    // listener doesn't execute in time (race condition on destroy).
-                    let _ = app.emit("voice-session:ended", ());
                 }
+                _ => {}
             }
         })
         .invoke_handler(tauri::generate_handler![

--- a/clients/wavis-gui/src-tauri/src/tray.rs
+++ b/clients/wavis-gui/src-tauri/src/tray.rs
@@ -31,8 +31,8 @@ struct MinimizeToTrayPayload {
 }
 
 #[derive(Clone, Serialize)]
-struct WindowVisibilityPayload {
-    visible: bool,
+pub struct WindowVisibilityPayload {
+    pub visible: bool,
 }
 
 pub fn setup_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {

--- a/clients/wavis-gui/src/features/diagnostics/diagnostics.ts
+++ b/clients/wavis-gui/src/features/diagnostics/diagnostics.ts
@@ -21,7 +21,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import type { UnlistenFn } from '@tauri-apps/api/event';
-import { isPermissionGranted, requestPermission, sendNotification } from '@tauri-apps/plugin-notification';
 import { RingBuffer } from '@shared/ring-buffer';
 import type { NetworkStats } from '@features/voice/voice-room';
 import type { ShareStats, VideoReceiveStats } from '@features/voice/livekit-media';
@@ -32,7 +31,6 @@ const LOG = '[wavis:diagnostics]';
 
 export interface DiagnosticsConfig {
   enabled: boolean;
-  notificationsEnabled: boolean;
   pollMs: number;
   memoryWarnMb: number;
   networkWarnMbps: number;
@@ -123,7 +121,6 @@ export interface WarningEntry {
 
 interface RustDiagnosticsConfig {
   enabled: boolean;
-  notificationsEnabled: boolean;
   pollMs: number;
   memoryWarnMb: number;
   networkWarnMbps: number;
@@ -175,8 +172,6 @@ let cachedVoiceStats: DiagnosticsVoiceStatsPayload | null = null;
 /** Unlisten function for the 'diagnostics:voice-stats' event listener. */
 let unlistenVoiceStats: UnlistenFn | null = null;
 
-const WARN_SUSTAIN_MS = 8_000;
-const WARN_COOLDOWN_MS = 60_000;
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
@@ -220,39 +215,13 @@ function checkWarning(
   key: string,
   message: string,
   condition: boolean,
-  notificationsEnabled: boolean,
 ): void {
   if (condition) {
     if (!warnings.has(key)) {
       warnings.set(key, { key, message, since: Date.now(), lastNotifiedAt: 0 });
-    } else {
-      const entry = warnings.get(key)!;
-      const sustainedMs = Date.now() - entry.since;
-      if (
-        notificationsEnabled &&
-        sustainedMs >= WARN_SUSTAIN_MS &&
-        Date.now() - entry.lastNotifiedAt >= WARN_COOLDOWN_MS
-      ) {
-        entry.lastNotifiedAt = Date.now();
-        fireNotification(message).catch(() => {});
-      }
     }
   } else {
     warnings.delete(key);
-  }
-}
-
-async function fireNotification(body: string): Promise<void> {
-  try {
-    let permitted = await isPermissionGranted();
-    if (!permitted) {
-      const result = await requestPermission();
-      permitted = result === 'granted';
-    }
-    if (!permitted) return;
-    sendNotification({ title: 'Wavis Diagnostics', body });
-  } catch {
-    // Silent failure on platforms where notifications are unavailable
   }
 }
 
@@ -271,7 +240,6 @@ export async function initDiagnostics(
   const raw = await invoke<RustDiagnosticsConfig>('get_diagnostics_config');
   config = {
     enabled: raw.enabled,
-    notificationsEnabled: raw.notificationsEnabled,
     pollMs: raw.pollMs,
     memoryWarnMb: raw.memoryWarnMb,
     networkWarnMbps: raw.networkWarnMbps,
@@ -608,54 +576,45 @@ async function poll(): Promise<void> {
   pollCount++;
 
   // 8. Warnings state machine
-  const notif = config.notificationsEnabled;
   checkWarning(
     'rss_high',
     `Process memory high (${Math.round(rss?.mb ?? 0)} MB > ${config.memoryWarnMb} MB)`,
     rss !== null && rss.mb > config.memoryWarnMb,
-    notif,
   );
   checkWarning(
     'network_loss_high',
     `Packet loss high (${network?.packetLossPercent.toFixed(1) ?? '?'}%)`,
     network !== null && network.packetLossPercent > 5,
-    notif,
   );
   checkWarning(
     'share_bw_limited',
     'Screen share is bandwidth-limited',
     share !== null && share.qualityLimitationReason === 'bandwidth',
-    notif,
   );
   checkWarning(
     'jitter_buffer_high',
     `Voice lag high — jitter buffer delay ${network?.jitterBufferDelayMs ?? 0} ms`,
     network !== null && network.jitterBufferDelayMs > 150,
-    notif,
   );
   checkWarning(
     'concealment_high',
     `Audio quality degraded — ${network?.concealmentEventsPerInterval ?? 0} concealment events`,
     network !== null && network.concealmentEventsPerInterval > 10,
-    notif,
   );
   checkWarning(
     'share_resolution_low',
     'Screen share quality reduced — resolution downgraded',
     share !== null && share.frameHeight > 0 && share.frameHeight < 720,
-    notif,
   );
   checkWarning(
     'video_recv_frozen',
     `Received video is freezing — ${snap.videoReceive?.freezeCount ?? 0} freeze events`,
     snap.videoReceive !== null && snap.videoReceive.freezeCount > 0,
-    notif,
   );
   checkWarning(
     'video_recv_loss_high',
     `Received video packet loss high (${snap.videoReceive?.packetLossPercent.toFixed(1) ?? '?'}%)`,
     snap.videoReceive !== null && snap.videoReceive.packetLossPercent > 5,
-    notif,
   );
 
   // Pass history snapshot to UI every 5th poll (~5s, matching chart resolution)


### PR DESCRIPTION
## Description

Removes diagnostics notifications and implements window visibility tracking to support OS notifications for participant joins being 'room only' when the window is visible.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

- [x] This PR does not touch signaling or token paths — checklist not applicable

---

## Tests

- [x] UI logic verified manually