### PR TITLE
feat: persist stream volume settings

### DIFF
--- a/clients/wavis-gui/src/features/settings/settings-store.ts
+++ b/clients/wavis-gui/src/features/settings/settings-store.ts
@@ -30,6 +30,7 @@ export interface NotificationToggles {
 export interface ChannelVolumePrefs {
   master: number;
   participants: Record<string, number>;
+  streams?: Record<string, number>;
 }
 
 export type WindowsSharePathPreference = 'browser' | 'native';

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -44,6 +44,8 @@ import {
   attachScreenShareAudio,
   detachScreenShareAudio,
   setScreenShareAudioVolume,
+  persistStreamVolume,
+  getPersistedStreamVolume,
   activeShareType,
   computeStopRoute,
   isShareButtonDisabled,
@@ -791,7 +793,7 @@ export default function ActiveRoom() {
   const getSavedShareVolume = useCallback((participantId: string) => {
     // watchAllVolumesRef is updated synchronously by syncScreenShareVolume;
     // shareVolumesRef lags by one render cycle (useEffect). Prefer the sync ref.
-    return watchAllVolumesRef.current.get(participantId) ?? shareVolumesRef.current.get(participantId) ?? 70;
+    return watchAllVolumesRef.current.get(participantId) ?? shareVolumesRef.current.get(participantId) ?? getPersistedStreamVolume(participantId) ?? 70;
   }, []);
 
   const syncScreenShareVolume = useCallback((participantId: string, volume: number) => {
@@ -803,6 +805,7 @@ export default function ActiveRoom() {
     });
     watchAllVolumesRef.current.set(participantId, volume);
     setScreenShareAudioVolume(participantId, volume);
+    persistStreamVolume(participantId, volume);
     emit('watch-all:restore-volume', { participantId, volume });
     emit('screen-share:restore-volume', { participantId, volume });
   }, []);

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -228,6 +228,7 @@ vi.mock('@features/settings/settings-store', () => ({
   getMuteHotkey: vi.fn(async () => 'Ctrl+Shift+M'),
   getProfileColor: vi.fn(async () => '#E06C75'),
   getChannelVolumes: vi.fn(async () => null),
+  setChannelVolumes: vi.fn(async () => {}),
   getWindowsSharePath: vi.fn(async () => 'browser'),
   getVideoInputDevice: vi.fn(async () => null),
   setVideoInputDevice: vi.fn(async () => {}),
@@ -300,6 +301,8 @@ import {
   detachScreenShareAudio,
   startCustomShare,
   getState,
+  persistStreamVolume,
+  getPersistedStreamVolume,
 } from '../voice-room';
 import type { VoiceRoomState } from '../voice-room';
 import * as settingsStore from '@features/settings/settings-store';
@@ -2890,5 +2893,63 @@ describe('Property 10: Media reconnect cooldown enforcement', () => {
       ),
       { numRuns: 20 },
     );
+  });
+});
+
+describe('stream volume persistence', () => {
+  it('getPersistedStreamVolume returns null when no stream volumes have been saved', async () => {
+    await driveToActive();
+    expect(getPersistedStreamVolume('peer-2')).toBeNull();
+    leaveRoom();
+  });
+
+  it('persistStreamVolume stores volume keyed by userId, readable via getPersistedStreamVolume', async () => {
+    await driveToActive(); // peer-2 has userId u2
+
+    persistStreamVolume('peer-2', 40);
+
+    expect(getPersistedStreamVolume('peer-2')).toBe(40);
+    leaveRoom();
+  });
+
+  it('persistStreamVolume overwrites previous value for the same participant', async () => {
+    await driveToActive();
+
+    persistStreamVolume('peer-2', 40);
+    persistStreamVolume('peer-2', 80);
+
+    expect(getPersistedStreamVolume('peer-2')).toBe(80);
+    leaveRoom();
+  });
+
+  it('persistStreamVolume clamps volume to 0–100', async () => {
+    await driveToActive();
+
+    persistStreamVolume('peer-2', 150);
+    expect(getPersistedStreamVolume('peer-2')).toBe(100);
+
+    persistStreamVolume('peer-2', -10);
+    expect(getPersistedStreamVolume('peer-2')).toBe(0);
+    leaveRoom();
+  });
+
+  it('getPersistedStreamVolume returns null for unknown participantId', async () => {
+    await driveToActive();
+    persistStreamVolume('peer-2', 55);
+    expect(getPersistedStreamVolume('unknown-peer')).toBeNull();
+    leaveRoom();
+  });
+
+  it('getPersistedStreamVolume returns saved value loaded from channel prefs on join', async () => {
+    vi.mocked(settingsStore.getChannelVolumes).mockResolvedValueOnce({
+      master: 70,
+      participants: {},
+      streams: { u2: 55 },
+    });
+
+    await driveToActive(); // peer-2 has userId u2
+
+    expect(getPersistedStreamVolume('peer-2')).toBe(55);
+    leaveRoom();
   });
 });

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -5076,6 +5076,11 @@ export class LiveKitModule {
    * Called when the user opens the screen share viewer window.
    */
   attachScreenShareAudio(participantIdentity: string): void {
+    // Mark as pending immediately so any TrackSubscribed that fires after the
+    // in-flight setSubscribed(false) (from initial deferral) sees isPending=true
+    // and does not call setSubscribed(false) again, which would permanently
+    // silence the audio even after the viewer is open.
+    this.screenShareAudioPending.add(participantIdentity);
     const publication = this.screenShareAudioPublications.get(participantIdentity);
     if (publication && typeof publication.setSubscribed === 'function') {
       publication.setSubscribed(true);

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2014,7 +2014,7 @@ function saveVolumesDebounced(): void {
         participantVols[p.userId] = p.volume;
       }
     }
-    const prefs: ChannelVolumePrefs = { master: state.masterVolume, participants: participantVols };
+    const prefs: ChannelVolumePrefs = { master: state.masterVolume, participants: participantVols, streams: { ...(channelVolumePrefs?.streams ?? {}) } };
     channelVolumePrefs = prefs;
     setChannelVolumes(state.channelId, prefs).catch((err) => {
       console.warn(LOG, 'failed to persist channel volumes:', err);
@@ -3762,6 +3762,25 @@ export function leaveRoom(): void {
   client = null;
   unsubscribe = null;
 
+  // Flush any pending volume save before state is reset — changes made within
+  // the 300ms debounce window (e.g. a slider moved right before leaving) would
+  // otherwise be silently dropped, causing the wrong volume on the next session.
+  if (volumeSaveTimer && channelVolumePrefs && state.channelId) {
+    clearTimeout(volumeSaveTimer);
+    volumeSaveTimer = null;
+    const flushParticipantVols: Record<string, number> = { ...(channelVolumePrefs.participants ?? {}) };
+    for (const p of state.participants) {
+      if (p.userId && p.id !== state.selfParticipantId) {
+        flushParticipantVols[p.userId] = p.volume;
+      }
+    }
+    setChannelVolumes(state.channelId, {
+      master: state.masterVolume,
+      participants: flushParticipantVols,
+      streams: { ...(channelVolumePrefs.streams ?? {}) },
+    }).catch(() => {});
+  }
+
   // Reset state to defaults (fresh arrays to avoid mutating DEFAULT_STATE)
   state = { ...DEFAULT_STATE, events: [], chatMessages: [], participants: [], screenShareStreams: new Map() };
   remoteCameraTilesById = {};
@@ -4512,6 +4531,28 @@ export function setScreenShareAudioVolume(participantId: string, volume: number)
   if (lkModule && 'setScreenShareAudioVolume' in lkModule) {
     (lkModule as LiveKitModule).setScreenShareAudioVolume(participantId, clamped);
   }
+}
+
+export function persistStreamVolume(participantId: string, volume: number): void {
+  const clamped = Math.max(0, Math.min(100, Math.round(volume)));
+  const p = state.participants.find((pp) => pp.id === participantId);
+  if (p?.userId) {
+    if (!channelVolumePrefs) {
+      channelVolumePrefs = { master: state.masterVolume, participants: {} };
+    }
+    channelVolumePrefs = {
+      ...channelVolumePrefs,
+      streams: { ...(channelVolumePrefs.streams ?? {}), [p.userId]: clamped },
+    };
+  }
+  saveVolumesDebounced();
+}
+
+export function getPersistedStreamVolume(participantId: string): number | null {
+  if (!channelVolumePrefs?.streams) return null;
+  const p = state.participants.find((pp) => pp.id === participantId);
+  if (!p?.userId) return null;
+  return channelVolumePrefs.streams[p.userId] ?? null;
 }
 
 export function kickParticipant(participantId: string): void {


### PR DESCRIPTION
Implements persistence for stream volume settings. The app now remembers volume levels for individual participants across sessions by storing them in the channel preferences.