### PR TITLE
feat: remove share indicator and add native windows picker (#236)

### DIFF
--- a/clients/wavis-gui/src-tauri/src/share_sources.rs
+++ b/clients/wavis-gui/src-tauri/src/share_sources.rs
@@ -107,6 +107,7 @@ fn encode_thumbnail_jpeg(rgba: &[u8], width: u32, height: u32) -> Result<Option<
     let img: RgbaImage = ImageBuffer::from_raw(width, height, rgba.to_vec())
         .ok_or_else(|| "failed to create image from frame data".to_string())?;
 
+    // Resize before converting to save work on large screens.
     let img = if width > THUMBNAIL_MAX_DIM || height > THUMBNAIL_MAX_DIM {
         image::imageops::resize(
             &img,
@@ -118,15 +119,21 @@ fn encode_thumbnail_jpeg(rgba: &[u8], width: u32, height: u32) -> Result<Option<
         img
     };
 
+    // JPEG has no alpha channel — convert RGBA → RGB before encoding.
+    // Passing Rgba8 to JpegEncoder returns UnsupportedError in image 0.25.
+    let img_rgb = image::DynamicImage::ImageRgba8(img).to_rgb8();
+
     let mut jpeg_buf = Vec::new();
     let mut cursor = std::io::Cursor::new(&mut jpeg_buf);
 
     let encoder =
         image::codecs::jpeg::JpegEncoder::new_with_quality(&mut cursor, THUMBNAIL_JPEG_QUALITY);
-    img.write_with_encoder(encoder)
+    img_rgb
+        .write_with_encoder(encoder)
         .map_err(|e| format!("JPEG encoding failed: {e}"))?;
 
     let b64 = base64::engine::general_purpose::STANDARD.encode(&jpeg_buf);
+    crate::debug_eprintln!("[share-picker] thumbnail encoded: {}x{} → {} bytes base64", width, height, b64.len());
     Ok(Some(b64))
 }
 

--- a/clients/wavis-gui/src-tauri/src/share_sources/capture/windows.rs
+++ b/clients/wavis-gui/src-tauri/src/share_sources/capture/windows.rs
@@ -422,14 +422,17 @@ fn enumerate_window_audio_sources(
 fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32, u32)>, String> {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Gdi::{
-        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, CreateDCW, DeleteDC, DeleteObject,
-        GetMonitorInfoW, GetWindowDC, ReleaseDC, SelectObject, HMONITOR, MONITORINFO, SRCCOPY,
+        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
+        GetDC, GetMonitorInfoW, GetWindowDC, ReleaseDC, SelectObject, HMONITOR, MONITORINFO, SRCCOPY,
     };
     use windows::Win32::UI::WindowsAndMessaging::{GetClientRect, GetWindowRect};
 
     let handle_val: isize = match source_id.parse() {
         Ok(value) => value,
-        Err(_) => return Ok(None),
+        Err(_) => {
+            crate::debug_eprintln!("[share-thumb] source_id '{}' is not an isize handle", source_id);
+            return Ok(None);
+        }
     };
 
     unsafe {
@@ -438,41 +441,48 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
         let got_rect = GetClientRect(hwnd, &mut client_rect);
 
         if got_rect.is_ok() {
+            crate::debug_eprintln!("[share-thumb] capturing window handle {}", handle_val);
             let mut win_rect = std::mem::zeroed();
             if GetWindowRect(hwnd, &mut win_rect).is_err() {
+                crate::debug_eprintln!("[share-thumb] GetWindowRect failed for handle {}", handle_val);
                 return Ok(None);
             }
             let w = (win_rect.right - win_rect.left) as u32;
             let h = (win_rect.bottom - win_rect.top) as u32;
             if w == 0 || h == 0 {
+                crate::debug_eprintln!("[share-thumb] window {}x{} has zero dimension", w, h);
                 return Ok(None);
             }
 
             let wnd_dc = GetWindowDC(hwnd);
             if wnd_dc.is_invalid() {
+                crate::debug_eprintln!("[share-thumb] GetWindowDC failed");
                 return Ok(None);
             }
 
             let mem_dc = CreateCompatibleDC(wnd_dc);
             if mem_dc.is_invalid() {
                 ReleaseDC(hwnd, wnd_dc);
+                crate::debug_eprintln!("[share-thumb] CreateCompatibleDC failed (window)");
                 return Ok(None);
             }
             let bitmap = CreateCompatibleBitmap(wnd_dc, w as i32, h as i32);
             if bitmap.is_invalid() {
                 let _ = DeleteDC(mem_dc);
                 let _ = ReleaseDC(hwnd, wnd_dc);
+                crate::debug_eprintln!("[share-thumb] CreateCompatibleBitmap failed (window)");
                 return Ok(None);
             }
             let old_bmp = SelectObject(mem_dc, bitmap);
-
             let _ = BitBlt(mem_dc, 0, 0, w as i32, h as i32, wnd_dc, 0, 0, SRCCOPY);
-
-            let rgba = read_bitmap_rgba(mem_dc, bitmap, wnd_dc, w, h);
+            // Deselect before GetDIBits — GDI requires the bitmap not be selected
+            // into any DC when GetDIBits reads its pixel data.
             SelectObject(mem_dc, old_bmp);
+            let rgba = read_bitmap_rgba(bitmap, wnd_dc, w, h);
             let _ = DeleteObject(bitmap);
             let _ = DeleteDC(mem_dc);
             let _ = ReleaseDC(hwnd, wnd_dc);
+            crate::debug_eprintln!("[share-thumb] window capture {}x{}: rgba={}", w, h, rgba.is_some());
 
             return match rgba {
                 Some(data) => Ok(Some((data, w, h))),
@@ -480,42 +490,50 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
             };
         }
 
+        // Not a window — try as monitor.
+        crate::debug_eprintln!("[share-thumb] capturing monitor handle {}", handle_val);
         let monitor = HMONITOR(handle_val as *mut _);
         let mut mi = MONITORINFO {
             cbSize: std::mem::size_of::<MONITORINFO>() as u32,
             ..std::mem::zeroed()
         };
         if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
+            crate::debug_eprintln!("[share-thumb] GetMonitorInfoW failed for handle {}", handle_val);
             return Ok(None);
         }
 
         let w = (mi.rcMonitor.right - mi.rcMonitor.left) as u32;
         let h = (mi.rcMonitor.bottom - mi.rcMonitor.top) as u32;
+        crate::debug_eprintln!("[share-thumb] monitor rect ({},{}) {}x{}", mi.rcMonitor.left, mi.rcMonitor.top, w, h);
         if w == 0 || h == 0 {
+            crate::debug_eprintln!("[share-thumb] monitor has zero dimension");
             return Ok(None);
         }
 
-        let screen_dc = CreateDCW(&windows::core::HSTRING::from("DISPLAY"), None, None, None);
+        // GetDC(NULL) returns a DC for the entire virtual screen (all monitors),
+        // which is required to BitBlt from secondary monitors at non-zero offsets.
+        let screen_dc = GetDC(HWND::default());
         if screen_dc.is_invalid() {
+            crate::debug_eprintln!("[share-thumb] GetDC(NULL) failed");
             return Ok(None);
         }
         let mem_dc = CreateCompatibleDC(screen_dc);
         if mem_dc.is_invalid() {
-            let _ = DeleteDC(screen_dc);
+            ReleaseDC(HWND::default(), screen_dc);
+            crate::debug_eprintln!("[share-thumb] CreateCompatibleDC failed (monitor)");
             return Ok(None);
         }
         let bitmap = CreateCompatibleBitmap(screen_dc, w as i32, h as i32);
         if bitmap.is_invalid() {
             let _ = DeleteDC(mem_dc);
-            let _ = DeleteDC(screen_dc);
+            ReleaseDC(HWND::default(), screen_dc);
+            crate::debug_eprintln!("[share-thumb] CreateCompatibleBitmap failed (monitor)");
             return Ok(None);
         }
         let old_bmp = SelectObject(mem_dc, bitmap);
-
         let _ = BitBlt(
             mem_dc,
-            0,
-            0,
+            0, 0,
             w as i32,
             h as i32,
             screen_dc,
@@ -523,12 +541,14 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
             mi.rcMonitor.top,
             SRCCOPY,
         );
-
-        let rgba = read_bitmap_rgba(mem_dc, bitmap, screen_dc, w, h);
+        // Deselect before GetDIBits — GDI requires the bitmap not be selected
+        // into any DC when GetDIBits reads its pixel data.
         SelectObject(mem_dc, old_bmp);
+        let rgba = read_bitmap_rgba(bitmap, screen_dc, w, h);
         let _ = DeleteObject(bitmap);
         let _ = DeleteDC(mem_dc);
-        let _ = DeleteDC(screen_dc);
+        ReleaseDC(HWND::default(), screen_dc);
+        crate::debug_eprintln!("[share-thumb] monitor capture {}x{}: rgba={}", w, h, rgba.is_some());
 
         match rgba {
             Some(data) => Ok(Some((data, w, h))),
@@ -538,13 +558,14 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
 }
 
 /// Read BGRA pixel data from a GDI bitmap and convert it to RGBA.
+/// The bitmap must NOT be selected into any DC before this is called.
 unsafe fn read_bitmap_rgba(
-    _mem_dc: windows::Win32::Graphics::Gdi::HDC,
     bitmap: windows::Win32::Graphics::Gdi::HBITMAP,
-    screen_dc: windows::Win32::Graphics::Gdi::HDC,
+    dc: windows::Win32::Graphics::Gdi::HDC,
     w: u32,
     h: u32,
 ) -> Option<Vec<u8>> {
+    let screen_dc = dc;
     use windows::Win32::Graphics::Gdi::{
         GetDIBits, BITMAPINFO, BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS,
     };
@@ -563,6 +584,7 @@ unsafe fn read_bitmap_rgba(
     };
 
     let mut bgra = vec![0u8; (w * h * 4) as usize];
+    crate::debug_eprintln!("[share-thumb] GetDIBits: {}x{} ({} bytes)", w, h, bgra.len());
     let rows = GetDIBits(
         screen_dc,
         bitmap,
@@ -574,8 +596,10 @@ unsafe fn read_bitmap_rgba(
     );
 
     if rows == 0 {
+        crate::debug_eprintln!("[share-thumb] GetDIBits returned 0 rows for {}x{}", w, h);
         return None;
     }
+    crate::debug_eprintln!("[share-thumb] GetDIBits read {} rows for {}x{}", rows, w, h);
 
     for pixel in bgra.chunks_exact_mut(4) {
         pixel.swap(0, 2);
@@ -609,11 +633,11 @@ pub(super) fn fetch_thumbnail(source_id: &str) -> Result<Option<String>, String>
         Ok(Ok(Some((rgba, w, h)))) => encode_thumbnail_jpeg(&rgba, w, h),
         Ok(Ok(None)) => Ok(None),
         Ok(Err(e)) => {
-            log::debug!("thumbnail capture failed: {e}");
+            crate::debug_eprintln!("thumbnail capture failed: {e}");
             Ok(None)
         }
         Err(_) => {
-            log::debug!("thumbnail fetch timed out");
+            crate::debug_eprintln!("thumbnail fetch timed out");
             Ok(None)
         }
     }

--- a/clients/wavis-gui/src/features/screen-share/SharePicker.tsx
+++ b/clients/wavis-gui/src/features/screen-share/SharePicker.tsx
@@ -18,6 +18,8 @@ const MODES: { key: ShareMode; label: string; sourceType: ShareSourceType }[] = 
 ];
 
 const ECHO_WARNING_SUBSTRING = 'echo possible';
+const DEBUG_SCREEN_CAPTURE = import.meta.env.VITE_DEBUG_SCREEN_CAPTURE === 'true';
+const LOG = '[share-picker]';
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
@@ -261,14 +263,16 @@ export default function SharePicker(props: SharePickerProps) {
     );
 
     for (const source of visualSources) {
+      if (DEBUG_SCREEN_CAPTURE) console.log(LOG, 'fetching thumbnail for', source.id, source.name);
       invoke<string | null>('fetch_source_thumbnail', { sourceId: source.id })
         .then((thumb) => {
+          if (DEBUG_SCREEN_CAPTURE) console.log(LOG, 'thumbnail result for', source.id, thumb ? `${thumb.length} bytes` : 'null');
           if (!cancelled && thumb) {
             setThumbnails((prev) => ({ ...prev, [source.id]: thumb }));
           }
         })
-        .catch(() => {
-          // Timeout or failure — keep placeholder (no-op)
+        .catch((err: unknown) => {
+          if (DEBUG_SCREEN_CAPTURE) console.error(LOG, 'thumbnail fetch failed for', source.id, err);
         });
     }
 

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -56,6 +56,7 @@ import {
   resolveChatMessageDisplayColor,
 } from './voice-room';
 import type { ShareSelection, EnumerationResult } from '@features/screen-share/share-types';
+import SharePicker from '@features/screen-share/SharePicker';
 import type { OccupiedSlots } from '@features/screen-share/SharePicker';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
@@ -323,11 +324,11 @@ function StatusDot({ color, label }: { color: string; label: string }) {
 
 
 /**
- * Temporarily expands the Tauri window before a native getDisplayMedia picker
- * dialog opens so the picker's 2-column grid is never clipped on narrow windows,
- * then restores the original size when the dialog closes (or if it throws).
- * No-op on macOS — that platform opens getDisplayMedia as a system dialog
- * outside the WebView, so window width is irrelevant there.
+ * Temporarily expands the Tauri window before the macOS getDisplayMedia system
+ * picker opens so its grid is never clipped on narrow windows, then restores the
+ * original size when the dialog closes (or if it throws).
+ * No-op on macOS (system dialog ignores WebView width) and unused on Windows
+ * (Windows uses the inline SharePicker, not getDisplayMedia).
  */
 async function withPickerResize<T>(isMacPlatform: boolean, fn: () => Promise<T>): Promise<T> {
   const MIN_NATIVE_PICKER_WIDTH = 700;
@@ -702,8 +703,10 @@ export default function ActiveRoom() {
   const [screenShareError, setScreenShareError] = useState<string | null>(null);
   const shareErrorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shareEnumerating = useRef(false);
-  // True while waiting for the OS screen picker to appear (macOS/Windows getDisplayMedia)
+  // True while waiting for the OS screen picker to appear (macOS getDisplayMedia)
   const [sharePickerLoading, setSharePickerLoading] = useState(false);
+  // Windows: inline share picker data (replaces getDisplayMedia to suppress WebView2 capture indicator)
+  const [winSharePicker, setWinSharePicker] = useState<{ enumResult: EnumerationResult; occupied: OccupiedSlots } | null>(null);
   // macOS audio driver install prompt state
   const [showDriverPrompt, setShowDriverPrompt] = useState(false);
   const pendingShareRef = useRef<boolean>(false);
@@ -1835,12 +1838,10 @@ export default function ActiveRoom() {
 
     try {
       if (!isLinuxPlatform) {
-        // Windows/macOS: use the browser/WebView getDisplayMedia path, not the
-        // custom native-source path below. If share diagnostics or leak logging
-        // are changed, this branch must be updated too — otherwise logs will only
-        // appear for Linux/native-picker flows and Windows repros will miss them.
-        //
-        // This path is what normal Windows `/share` currently exercises.
+        // macOS: uses getDisplayMedia() via startFallbackShare() below.
+        // Windows: intercepted below by isWindowsPlatform — uses native Rust
+        //   capture pipeline (inline SharePicker → WinCapture → startNativeCapture
+        //   + startWasapiAudioBridge). getDisplayMedia() is never called on Windows.
         if (isMacPlatform) {
           const access = await invoke<{
             authorized: boolean;
@@ -1874,6 +1875,24 @@ export default function ActiveRoom() {
           return;
         }
         skipDriverCheckRef.current = false;
+
+        // Windows: use native Rust source picker to avoid getDisplayMedia() and
+        // the WebView2 capture indicator bar it triggers.
+        if (isWindowsPlatform) {
+          try {
+            const enumResult = await invoke<EnumerationResult>('list_share_sources');
+            const occupied: OccupiedSlots = {
+              videoOccupied: roomState?.activeVideoShare !== null,
+              audioOccupied: roomState?.activeAudioShare !== null,
+            };
+            setWinSharePicker({ enumResult, occupied });
+          } catch (err) {
+            const detail = err instanceof Error ? err.message : String(err);
+            showTransientScreenShareError(`Screen sharing failed: ${detail}`);
+            toast.error(`Screen sharing failed: ${detail}`);
+          }
+          return;
+        }
 
         try {
           await withPickerResize(isMacPlatform, async () => {
@@ -3154,6 +3173,34 @@ export default function ActiveRoom() {
             }
           }}
         />
+      )}
+      {winSharePicker && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-wavis-bg/80 px-4">
+          <div className="w-[640px] max-w-[90vw] h-[480px] max-h-[80vh] border border-wavis-text-secondary shadow-xl overflow-hidden flex flex-col">
+            <SharePicker
+              enumResult={winSharePicker.enumResult}
+              occupied={winSharePicker.occupied}
+              onSelect={async (selection) => {
+                setWinSharePicker(null);
+                try {
+                  await startCustomShare(selection);
+                  if (selection.mode !== 'audio_only') {
+                    if (selection.withAudio) {
+                      setShareAudioOn(true);
+                    } else {
+                      setShowPostShareAudioPrompt(true);
+                    }
+                  }
+                } catch (err) {
+                  const detail = err instanceof Error ? err.message : String(err);
+                  showTransientScreenShareError(`Screen sharing failed: ${detail}`);
+                  toast.error(`Screen sharing failed: ${detail}`);
+                }
+              }}
+              onCancel={() => setWinSharePicker(null)}
+            />
+          </div>
+        </div>
       )}
       {showPostShareAudioPrompt && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-wavis-bg/80 px-4">

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -5494,6 +5494,7 @@ export class LiveKitModule {
       publication = await this.room.localParticipant.publishTrack(videoTrack, {
         name: 'native-screen-share',
         source: Track.Source.ScreenShare,
+        stream: Track.Source.ScreenShare,
         videoCodec: pubOpts.videoCodec,
         backupCodec: pubOpts.backupCodec,
         simulcast: pubOpts.simulcast,
@@ -5556,6 +5557,16 @@ export class LiveKitModule {
     }
     if (pub && this.room) {
       const track = pub.track?.mediaStreamTrack;
+      // Capture the transceiver BEFORE unpublishing. After unpublish the sender's
+      // track is detached, making the transceiver hard to identify. We need to stop
+      // it explicitly afterwards to clear its MID from Chrome's active RTP extension
+      // ID namespace — without this the next publish collides (ERROR_CONTENT:
+      // "RTP extension ID reassignment not supported").
+      const peerConnection = this.getPublisherPeerConnection();
+      const screenShareTransceiver = track && peerConnection
+        ? peerConnection.getTransceivers().find((t) => t.sender.track === track) ?? null
+        : null;
+
       if (track) {
         if (leakSession) {
           leakSession.summary.cleanupFlags.unpublishAttempted = true;
@@ -5572,6 +5583,11 @@ export class LiveKitModule {
           leakSession.summary.cleanupFlags.trackStopped = true;
         }
         this.markNativeCaptureLeakStage('track_stopped');
+      }
+
+      // Stop the transceiver to free its MID from Chrome's extension ID tracking.
+      if (screenShareTransceiver) {
+        try { screenShareTransceiver.stop(); } catch { /* best-effort */ }
       }
     }
 

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -49,7 +49,6 @@ import { registerMuteHotkey, unregisterMuteHotkey } from '@shared/hotkey-bridge'
 import { playNotificationSound } from './notification-sounds';
 import { toast } from 'sonner';
 import { invoke } from '@tauri-apps/api/core';
-import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
 
 const LOG = '[wavis:voice-room]';
@@ -3677,12 +3676,6 @@ export function leaveRoom(): void {
       if (state.activeVideoShare.withAudio) invoke('audio_share_stop').catch(() => { });
     }
     if (state.activeAudioShare) invoke('audio_share_stop').catch(() => { });
-    // Close ShareIndicator window
-    WebviewWindow.getByLabel('share-indicator')
-      .then((win) => {
-        if (win) win.close().catch(() => { });
-      })
-      .catch(() => { });
     // Send stop_share before leave for custom shares
     if (client && client.status === 'connected') {
       client.send({ type: 'stop-share' });
@@ -4329,15 +4322,7 @@ export async function stopCustomShare(target: 'video' | 'audio' | 'all' = 'all')
     state.activeAudioShare = null;
   }
 
-  // 6. Update or close ShareIndicator
-  if (state.activeVideoShare || state.activeAudioShare) {
-    await updateShareIndicator();
-  } else {
-    try {
-      const indicatorWin = await WebviewWindow.getByLabel('share-indicator');
-      if (indicatorWin) await indicatorWin.close();
-    } catch { /* best-effort */ }
-  }
+  await updateShareIndicator();
 
   notify();
 
@@ -4350,40 +4335,9 @@ export async function stopCustomShare(target: 'video' | 'audio' | 'all' = 'all')
   });
 }
 
-/** Open or update the ShareIndicator window to reflect current share state. */
-async function updateShareIndicator(): Promise<void> {
-  const shares: Array<{ mode: ShareMode; sourceName: string }> = [];
-  if (state.activeVideoShare) {
-    shares.push({ mode: state.activeVideoShare.mode, sourceName: state.activeVideoShare.sourceName });
-  }
-  if (state.activeAudioShare) {
-    shares.push({ mode: 'audio_only', sourceName: state.activeAudioShare.sourceName });
-  }
-  if (shares.length === 0) return;
-
-  const indicatorParams = { shares };
-  const hash = encodeURIComponent(JSON.stringify(indicatorParams));
-
-  // Close existing indicator first (it may have stale data)
-  try {
-    const existing = await WebviewWindow.getByLabel('share-indicator');
-    if (existing) await existing.close();
-  } catch { /* best-effort */ }
-
-  // Small delay to let the old window fully close before creating a new one
-  await new Promise((r) => setTimeout(r, 50));
-
-  new WebviewWindow('share-indicator', {
-    url: `/share-indicator#${hash}`,
-    title: 'Wavis — Sharing',
-    width: 280,
-    height: shares.length > 1 ? 72 : 48,
-    resizable: false,
-    decorations: false,
-    alwaysOnTop: true,
-    skipTaskbar: true,
-  });
-}
+/** No-op: share indicator window removed. Stop is accessible from the main room UI. */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+async function updateShareIndicator(): Promise<void> {}
 
 export async function stopShare(): Promise<void> {
   // Clear local sharing flag immediately for responsive UI


### PR DESCRIPTION
This PR removes the separate share indicator window and implements a native Windows screen picker to avoid the WebView2 capture indicator.