### PR TITLE
fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10150,6 +10150,8 @@ dependencies = [
  "drm-fourcc",
  "fern",
  "gbm",
+ "gdk",
+ "gdk-pixbuf",
  "gtk",
  "image",
  "keyring",

--- a/clients/wavis-gui/src-tauri/Cargo.toml
+++ b/clients/wavis-gui/src-tauri/Cargo.toml
@@ -78,6 +78,8 @@ drm-fourcc = "2"
 
 # GTK3 bindings — needed for test_pw debug binary to simulate Tauri's GTK init.
 gtk = "0.18"
+gdk = "0.18"
+gdk-pixbuf = "0.18"
 
 # WebKitGTK — needed for test_pw debug binary to simulate Tauri's webview.
 webkit2gtk = "2.0"

--- a/clients/wavis-gui/src-tauri/src/bin/native_share_viewer.rs
+++ b/clients/wavis-gui/src-tauri/src/bin/native_share_viewer.rs
@@ -1,0 +1,243 @@
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("native_share_viewer is only available on Linux");
+    std::process::exit(1);
+}
+
+#[cfg(target_os = "linux")]
+use std::io::{Read, Write};
+#[cfg(target_os = "linux")]
+use std::net::TcpStream;
+#[cfg(target_os = "linux")]
+use std::cell::RefCell;
+#[cfg(target_os = "linux")]
+use std::rc::Rc;
+#[cfg(target_os = "linux")]
+use std::sync::mpsc;
+#[cfg(target_os = "linux")]
+use std::time::Duration;
+
+#[cfg(target_os = "linux")]
+use gdk_pixbuf::PixbufLoader;
+#[cfg(target_os = "linux")]
+use gtk::glib::translate::ToGlibPtr;
+#[cfg(target_os = "linux")]
+use gtk::prelude::*;
+
+#[cfg(target_os = "linux")]
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let Some(url) = args.next() else {
+        eprintln!("native_share_viewer: missing stream URL");
+        std::process::exit(2);
+    };
+    let title = args.next().unwrap_or_else(|| "Wavis screen share".to_string());
+
+    gtk::init().expect("native_share_viewer: GTK init failed");
+
+    let window = gtk::Window::new(gtk::WindowType::Toplevel);
+    window.set_title(&title);
+    window.set_default_size(960, 540);
+    window.set_resizable(true);
+
+    let latest_pixbuf: Rc<RefCell<Option<gdk_pixbuf::Pixbuf>>> = Rc::new(RefCell::new(None));
+    let drawing_area = gtk::DrawingArea::new();
+    drawing_area.set_hexpand(true);
+    drawing_area.set_vexpand(true);
+    window.add(&drawing_area);
+
+    {
+        let latest_pixbuf = Rc::clone(&latest_pixbuf);
+        drawing_area.connect_draw(move |area, cr| {
+            let allocation = area.allocation();
+            let area_w = f64::from(allocation.width()).max(1.0);
+            let area_h = f64::from(allocation.height()).max(1.0);
+
+            cr.set_source_rgb(0.11, 0.13, 0.16);
+            let _ = cr.paint();
+
+            let Some(pixbuf) = latest_pixbuf.borrow().clone() else {
+                return false.into();
+            };
+            let frame_w = f64::from(pixbuf.width()).max(1.0);
+            let frame_h = f64::from(pixbuf.height()).max(1.0);
+            let scale = (area_w / frame_w).min(area_h / frame_h);
+            let draw_w = frame_w * scale;
+            let draw_h = frame_h * scale;
+            let x = (area_w - draw_w) / 2.0;
+            let y = (area_h - draw_h) / 2.0;
+
+            let _ = cr.save();
+            cr.translate(x, y);
+            cr.scale(scale, scale);
+            unsafe {
+                gdk::ffi::gdk_cairo_set_source_pixbuf(
+                    cr.to_glib_none().0,
+                    pixbuf.to_glib_none().0,
+                    0.0,
+                    0.0,
+                );
+            }
+            cr.rectangle(0.0, 0.0, frame_w, frame_h);
+            let _ = cr.fill();
+            let _ = cr.restore();
+            false.into()
+        });
+    }
+    window.show_all();
+    window.connect_destroy(|_| {
+        gtk::main_quit();
+    });
+
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    std::thread::Builder::new()
+        .name("native-share-viewer-stream".into())
+        .spawn(move || {
+            if let Err(err) = stream_frames(&url, tx) {
+                eprintln!("native_share_viewer: stream ended: {err}");
+            }
+        })
+        .expect("native_share_viewer: failed to spawn stream thread");
+
+    gtk::glib::timeout_add_local(Duration::from_millis(1), move || {
+        let mut latest = None;
+        while let Ok(bytes) = rx.try_recv() {
+            latest = Some(bytes);
+        }
+        if let Some(bytes) = latest {
+            if let Some(pixbuf) = decode_jpeg(&bytes) {
+                *latest_pixbuf.borrow_mut() = Some(pixbuf);
+                drawing_area.queue_draw();
+            }
+        }
+        gtk::glib::ControlFlow::Continue
+    });
+
+    gtk::main();
+}
+
+fn stream_frames(url: &str, tx: mpsc::Sender<Vec<u8>>) -> Result<(), String> {
+    let parsed = parse_local_url(url)?;
+    let mut stream = TcpStream::connect(("127.0.0.1", parsed.port))
+        .map_err(|e| format!("connect failed: {e}"))?;
+    stream
+        .set_read_timeout(Some(Duration::from_secs(15)))
+        .map_err(|e| format!("set_read_timeout failed: {e}"))?;
+
+    let request = format!(
+        "GET {} HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nConnection: close\r\n\r\n",
+        parsed.target, parsed.port
+    );
+    stream
+        .write_all(request.as_bytes())
+        .map_err(|e| format!("request write failed: {e}"))?;
+
+    let mut buffer = Vec::<u8>::with_capacity(512 * 1024);
+    read_until_headers(&mut stream, &mut buffer)?;
+    loop {
+        let frame = read_multipart_frame(&mut stream, &mut buffer)?;
+        if tx.send(frame).is_err() {
+            return Ok(());
+        }
+    }
+}
+
+struct ParsedUrl {
+    port: u16,
+    target: String,
+}
+
+fn parse_local_url(url: &str) -> Result<ParsedUrl, String> {
+    let rest = url
+        .strip_prefix("http://127.0.0.1:")
+        .ok_or_else(|| "only local 127.0.0.1 URLs are supported".to_string())?;
+    let (port_str, target) = rest
+        .split_once('/')
+        .ok_or_else(|| "URL missing path".to_string())?;
+    let port = port_str
+        .parse::<u16>()
+        .map_err(|e| format!("invalid port: {e}"))?;
+    Ok(ParsedUrl {
+        port,
+        target: format!("/{target}"),
+    })
+}
+
+fn read_until_headers(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<(), String> {
+    loop {
+        if let Some(end) = find_header_end(buffer) {
+            buffer.drain(..end + 4);
+            return Ok(());
+        }
+        read_more(stream, buffer)?;
+    }
+}
+
+fn read_multipart_frame(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<Vec<u8>, String> {
+    loop {
+        if let Some(boundary) = find_bytes(buffer, b"--wavisframe") {
+            buffer.drain(..boundary + "--wavisframe".len());
+            break;
+        }
+        read_more(stream, buffer)?;
+    }
+
+    let header_end = loop {
+        if let Some(end) = find_header_end(buffer) {
+            break end;
+        }
+        read_more(stream, buffer)?;
+    };
+
+    let headers = String::from_utf8_lossy(&buffer[..header_end]);
+    let content_len = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            if name.eq_ignore_ascii_case("content-length") {
+                value.trim().parse::<usize>().ok()
+            } else {
+                None
+            }
+        })
+        .ok_or_else(|| "multipart frame missing content-length".to_string())?;
+
+    buffer.drain(..header_end + 4);
+    while buffer.len() < content_len + 2 {
+        read_more(stream, buffer)?;
+    }
+    let frame = buffer.drain(..content_len).collect::<Vec<_>>();
+    if buffer.starts_with(b"\r\n") {
+        buffer.drain(..2);
+    }
+    Ok(frame)
+}
+
+fn read_more(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<(), String> {
+    let mut chunk = [0u8; 64 * 1024];
+    let read = stream
+        .read(&mut chunk)
+        .map_err(|e| format!("read failed: {e}"))?;
+    if read == 0 {
+        return Err("stream closed".to_string());
+    }
+    buffer.extend_from_slice(&chunk[..read]);
+    Ok(())
+}
+
+fn find_header_end(bytes: &[u8]) -> Option<usize> {
+    find_bytes(bytes, b"\r\n\r\n")
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn decode_jpeg(bytes: &[u8]) -> Option<gdk_pixbuf::Pixbuf> {
+    let loader = PixbufLoader::new();
+    loader.write(bytes).ok()?;
+    loader.close().ok()?;
+    loader.pixbuf()
+}

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -135,6 +135,32 @@ mod media {
     }
 
     #[tauri::command]
+    pub fn media_poll_screen_share_frame(
+        _identity: String,
+        _last_seq: Option<u64>,
+    ) -> Result<Option<String>, String> {
+        Ok(None)
+    }
+
+    #[tauri::command]
+    pub fn media_get_screen_share_stream_url(_identity: String) -> Result<String, String> {
+        Err("remote screen share stream URL is only available on Linux".to_string())
+    }
+
+    #[tauri::command]
+    pub fn media_open_native_screen_share_viewer(
+        _identity: String,
+        _title: String,
+    ) -> Result<(), String> {
+        Err("native screen share viewer is only available on Linux".to_string())
+    }
+
+    #[tauri::command]
+    pub fn media_close_native_screen_share_viewer(_identity: String) -> Result<(), String> {
+        Ok(())
+    }
+
+    #[tauri::command]
     pub fn media_set_screen_share_quality(_quality: u8) -> Result<(), String> {
         Ok(())
     }
@@ -467,6 +493,10 @@ fn main() {
             media::screen_share_start_source,
             media::screen_share_stop,
             media::screen_share_poll_frame,
+            media::media_poll_screen_share_frame,
+            media::media_get_screen_share_stream_url,
+            media::media_open_native_screen_share_viewer,
+            media::media_close_native_screen_share_viewer,
             media::media_set_screen_share_quality,
             is_window_visible,
             share_sources::list_share_sources,

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -11,6 +11,12 @@ use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 #[cfg(target_os = "linux")]
 use std::thread::JoinHandle as StdJoinHandle;
+#[cfg(target_os = "linux")]
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    time::Duration,
+};
 use tauri::{AppHandle, Emitter, State};
 use tokio::runtime::{Builder, Runtime};
 use tokio::task::JoinHandle;
@@ -160,6 +166,236 @@ struct HeartbeatFrame {
     height: u32,
 }
 
+#[cfg(target_os = "linux")]
+#[derive(Clone)]
+struct LatestRemoteScreenShareFrame {
+    data: Arc<Vec<u8>>,
+    width: u32,
+    height: u32,
+    seq: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Serialize)]
+pub struct PolledScreenShareFrame {
+    pub identity: String,
+    pub frame: String,
+    pub width: u32,
+    pub height: u32,
+    pub seq: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Serialize)]
+struct ScreenShareAvailablePayload {
+    identity: String,
+}
+
+#[cfg(target_os = "linux")]
+fn start_remote_screen_share_stream_server(
+    frames: Arc<Mutex<std::collections::HashMap<String, LatestRemoteScreenShareFrame>>>,
+    config: Arc<screen_capture::frame_processor::ScreenShareConfig>,
+) -> Option<u16> {
+    let listener = match TcpListener::bind(("127.0.0.1", 0)) {
+        Ok(listener) => listener,
+        Err(err) => {
+            log::warn!("{LOG} failed to bind remote screen share stream server: {err}");
+            return None;
+        }
+    };
+    let port = match listener.local_addr() {
+        Ok(addr) => addr.port(),
+        Err(err) => {
+            log::warn!("{LOG} failed to read remote screen share stream server port: {err}");
+            return None;
+        }
+    };
+
+    std::thread::Builder::new()
+        .name("remote-share-mjpeg".into())
+        .spawn(move || {
+            log::info!("{LOG} remote screen share stream server listening on 127.0.0.1:{port}");
+            for stream in listener.incoming() {
+                let Ok(stream) = stream else {
+                    continue;
+                };
+                let frames = Arc::clone(&frames);
+                let config = Arc::clone(&config);
+                let _ = std::thread::Builder::new()
+                    .name("remote-share-mjpeg-client".into())
+                    .spawn(move || {
+                        if let Err(err) = handle_remote_screen_share_stream(stream, frames, config)
+                        {
+                            log::debug!("{LOG} remote screen share stream ended: {err}");
+                        }
+                    });
+            }
+        })
+        .ok()?;
+
+    Some(port)
+}
+
+#[cfg(target_os = "linux")]
+fn handle_remote_screen_share_stream(
+    mut stream: TcpStream,
+    frames: Arc<Mutex<std::collections::HashMap<String, LatestRemoteScreenShareFrame>>>,
+    config: Arc<screen_capture::frame_processor::ScreenShareConfig>,
+) -> Result<(), String> {
+    stream
+        .set_nodelay(true)
+        .map_err(|e| format!("set_nodelay failed: {e}"))?;
+
+    let mut req = Vec::with_capacity(4096);
+    while !req.windows(4).any(|window| window == b"\r\n\r\n") && req.len() < 16 * 1024 {
+        let mut chunk = [0u8; 1024];
+        let read = stream
+            .read(&mut chunk)
+            .map_err(|e| format!("stream request read failed: {e}"))?;
+        if read == 0 {
+            return Ok(());
+        }
+        req.extend_from_slice(&chunk[..read]);
+    }
+
+    let request = String::from_utf8_lossy(&req);
+    let target = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/");
+    let identity = target
+        .split_once('?')
+        .and_then(|(_, query)| query_param(query, "identity"))
+        .and_then(|value| percent_decode(&value))
+        .ok_or_else(|| "missing identity query".to_string())?;
+
+    let header = concat!(
+        "HTTP/1.1 200 OK\r\n",
+        "Content-Type: multipart/x-mixed-replace; boundary=wavisframe\r\n",
+        "Cache-Control: no-store, no-cache, must-revalidate, max-age=0\r\n",
+        "Pragma: no-cache\r\n",
+        "Connection: close\r\n",
+        "Access-Control-Allow-Origin: *\r\n",
+        "\r\n"
+    );
+    stream
+        .write_all(header.as_bytes())
+        .map_err(|e| format!("stream header write failed: {e}"))?;
+
+    let mut last_seq = 0u64;
+    loop {
+        let latest = {
+            let frames = frames
+                .lock()
+                .map_err(|e| format!("remote_screen_share_frames lock: {e}"))?;
+            frames.get(&identity).cloned()
+        };
+
+        let Some(latest) = latest else {
+            std::thread::sleep(Duration::from_millis(10));
+            continue;
+        };
+
+        if latest.seq == last_seq {
+            std::thread::sleep(Duration::from_millis(5));
+            continue;
+        }
+        last_seq = latest.seq;
+
+        let jpeg = encode_remote_frame_jpeg(&latest, config.jpeg_quality())?;
+        let part_header = format!(
+            "--wavisframe\r\nContent-Type: image/jpeg\r\nContent-Length: {}\r\n\r\n",
+            jpeg.len()
+        );
+        stream
+            .write_all(part_header.as_bytes())
+            .and_then(|_| stream.write_all(&jpeg))
+            .and_then(|_| stream.write_all(b"\r\n"))
+            .map_err(|e| format!("stream frame write failed: {e}"))?;
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn encode_remote_frame_jpeg(
+    frame: &LatestRemoteScreenShareFrame,
+    jpeg_quality: u8,
+) -> Result<Vec<u8>, String> {
+    use image::codecs::jpeg::JpegEncoder;
+    use std::io::Cursor;
+
+    let pixel_count = (frame.width * frame.height) as usize;
+    let mut rgb_data = Vec::with_capacity(pixel_count * 3);
+    for rgba in frame.data.chunks_exact(4) {
+        rgb_data.push(rgba[0]);
+        rgb_data.push(rgba[1]);
+        rgb_data.push(rgba[2]);
+    }
+
+    let mut jpeg_buf = Cursor::new(Vec::with_capacity(256 * 1024));
+    let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buf, jpeg_quality);
+    encoder
+        .encode(
+            &rgb_data,
+            frame.width,
+            frame.height,
+            image::ExtendedColorType::Rgb8,
+        )
+        .map_err(|e| format!("remote JPEG encode failed: {e}"))?;
+    Ok(jpeg_buf.into_inner())
+}
+
+#[cfg(target_os = "linux")]
+fn query_param(query: &str, key: &str) -> Option<String> {
+    query.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        if k == key {
+            Some(v.to_string())
+        } else {
+            None
+        }
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    out
+}
+
+#[cfg(target_os = "linux")]
+fn percent_decode(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16)?;
+                let lo = (bytes[i + 2] as char).to_digit(16)?;
+                out.push(((hi << 4) | lo) as u8);
+                i += 3;
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            byte => {
+                out.push(byte);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
 // ─── Managed State ─────────────────────────────────────────────────
 
 #[cfg(target_os = "linux")]
@@ -214,6 +450,18 @@ pub struct MediaState {
     native_screen_share_heartbeat_active: Arc<AtomicBool>,
     #[cfg(target_os = "linux")]
     native_screen_share_heartbeat_thread: Mutex<Option<StdJoinHandle<()>>>,
+    /// Latest raw remote screen-share frame per participant. The LiveKit
+    /// callback writes here; the webview polls and encodes only the newest
+    /// frame it is ready to render.
+    #[cfg(target_os = "linux")]
+    remote_screen_share_frames:
+        Arc<Mutex<std::collections::HashMap<String, LatestRemoteScreenShareFrame>>>,
+    #[cfg(target_os = "linux")]
+    remote_screen_share_seq: Arc<AtomicU64>,
+    #[cfg(target_os = "linux")]
+    remote_screen_share_stream_port: u16,
+    #[cfg(target_os = "linux")]
+    native_screen_share_viewers: Arc<Mutex<std::collections::HashMap<String, std::process::Child>>>,
     /// Active screen capture backend (Windows).
     #[cfg(target_os = "windows")]
     pub(crate) screen_capture: Mutex<Option<Box<dyn screen_capture::ScreenCapture>>>,
@@ -233,6 +481,21 @@ pub struct MediaState {
 
 impl MediaState {
     pub fn new() -> Self {
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        let screen_share_config = Arc::new(screen_capture::frame_processor::ScreenShareConfig::new());
+        #[cfg(target_os = "linux")]
+        let remote_screen_share_frames =
+            Arc::new(Mutex::new(std::collections::HashMap::<
+                String,
+                LatestRemoteScreenShareFrame,
+            >::new()));
+        #[cfg(target_os = "linux")]
+        let remote_screen_share_stream_port = start_remote_screen_share_stream_server(
+            Arc::clone(&remote_screen_share_frames),
+            Arc::clone(&screen_share_config),
+        )
+        .unwrap_or(0);
+
         Self {
             runtime: Builder::new_multi_thread()
                 .enable_all()
@@ -255,10 +518,18 @@ impl MediaState {
             native_screen_share_heartbeat_active: Arc::new(AtomicBool::new(false)),
             #[cfg(target_os = "linux")]
             native_screen_share_heartbeat_thread: Mutex::new(None),
+            #[cfg(target_os = "linux")]
+            remote_screen_share_frames,
+            #[cfg(target_os = "linux")]
+            remote_screen_share_seq: Arc::new(AtomicU64::new(0)),
+            #[cfg(target_os = "linux")]
+            remote_screen_share_stream_port,
+            #[cfg(target_os = "linux")]
+            native_screen_share_viewers: Arc::new(Mutex::new(std::collections::HashMap::new())),
             #[cfg(target_os = "windows")]
             screen_capture: Mutex::new(None),
             #[cfg(any(target_os = "linux", target_os = "windows"))]
-            screen_share_config: Arc::new(screen_capture::frame_processor::ScreenShareConfig::new()),
+            screen_share_config,
             #[cfg(target_os = "windows")]
             latest_frame: Arc::new(Mutex::new(None)),
             #[cfg(target_os = "windows")]
@@ -620,84 +891,52 @@ pub fn media_connect(
         );
     }));
 
-    // Wire video frame callback → encode JPEG, base64, emit screen_share_frame event.
-    // Only compiled on Linux where the image + base64 crates are available.
+    // Wire video frame callback → store the newest raw frame per participant.
+    // The webview polls this buffer when it is ready to render. That preserves
+    // smoothness when the machine can keep up, but prevents stale frame events
+    // from piling up behind the UI thread.
     #[cfg(target_os = "linux")]
     {
-        // Per-identity emit-rate cap. The Linux pipeline JPEG-encodes + base64s
-        // every remote screen-share frame, then ships it to the webview as a
-        // JSON Tauri event. Under load (multiple shares, large resolutions)
-        // this saturates CPU and lets libwebrtc's native frame queue grow
-        // unbounded — eventually segfaulting. Capping the visible refresh at
-        // 10 fps keeps the screen share usable while preventing the
-        // overload regime that triggered the crashes we observed.
-        const VIEWER_MIN_FRAME_INTERVAL: std::time::Duration =
-            std::time::Duration::from_millis(100); // 10 fps
-        let last_emit_per_identity: Arc<Mutex<std::collections::HashMap<String, std::time::Instant>>> =
-            Arc::new(Mutex::new(std::collections::HashMap::new()));
-
         let app_video = app.clone();
-        let viewer_config = state.screen_share_config.clone();
-        let throttle_state = Arc::clone(&last_emit_per_identity);
+        let latest_remote_frames = Arc::clone(&state.remote_screen_share_frames);
+        let remote_seq = Arc::clone(&state.remote_screen_share_seq);
         conn.on_video_frame(Box::new(move |identity, rgba_data, width, height| {
-            use base64::Engine;
-            use image::codecs::jpeg::JpegEncoder;
-            use std::io::Cursor;
-
-            // Drop the frame if we emitted one for this identity too recently.
-            // Cheap path: lock, look up, compare, update — no allocations on
-            // the throttled path.
-            {
-                let now = std::time::Instant::now();
-                let mut map = match throttle_state.lock() {
+            let seq = remote_seq.fetch_add(1, Ordering::Relaxed) + 1;
+            let identity_owned = identity.to_string();
+            let was_new_share = {
+                let mut frames = match latest_remote_frames.lock() {
                     Ok(g) => g,
-                    Err(_) => return, // poisoned: bail rather than panic in callback
+                    Err(_) => return,
                 };
-                if let Some(last) = map.get(identity) {
-                    if now.duration_since(*last) < VIEWER_MIN_FRAME_INTERVAL {
-                        return;
-                    }
-                }
-                map.insert(identity.to_string(), now);
+                let was_new = !frames.contains_key(identity);
+                frames.insert(
+                    identity_owned.clone(),
+                    LatestRemoteScreenShareFrame {
+                        data: Arc::new(rgba_data.to_vec()),
+                        width,
+                        height,
+                        seq,
+                    },
+                );
+                was_new
+            };
+
+            if was_new_share {
+                let _ = app_video.emit_to(
+                    "main",
+                    "screen_share_available",
+                    ScreenShareAvailablePayload {
+                        identity: identity_owned,
+                    },
+                );
             }
-
-            // Read JPEG quality from the shared config (runtime-adjustable).
-            let jpeg_quality = viewer_config.jpeg_quality();
-
-            // Encode RGBA → JPEG (strip alpha — JPEG only supports RGB).
-            let rgb_data: Vec<u8> = rgba_data
-                .chunks_exact(4)
-                .flat_map(|rgba| [rgba[0], rgba[1], rgba[2]])
-                .collect();
-            let mut jpeg_buf = Cursor::new(Vec::with_capacity(128 * 1024));
-            let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buf, jpeg_quality);
-            if let Err(e) = encoder.encode(&rgb_data, width, height, image::ExtendedColorType::Rgb8)
-            {
-                log::warn!("{LOG} JPEG encode failed: {e}");
-                return;
-            }
-
-            // Base64-encode the JPEG.
-            let b64 = base64::engine::general_purpose::STANDARD.encode(jpeg_buf.into_inner());
-
-            // Emit screen_share_frame Tauri event.
-            let _ = app_video.emit_to(
-                "main",
-                "screen_share_frame",
-                serde_json::json!({
-                    "identity": identity,
-                    "frame": b64,
-                }),
-            );
         }));
 
         let app_ended = app.clone();
-        let throttle_state_cleanup = Arc::clone(&last_emit_per_identity);
+        let latest_remote_frames_cleanup = Arc::clone(&state.remote_screen_share_frames);
         conn.on_video_track_ended(Box::new(move |identity| {
             log::info!("{LOG} remote screen share ended: {identity}");
-            // Drop this identity's throttle entry so the map doesn't grow
-            // unbounded as participants come and go.
-            if let Ok(mut map) = throttle_state_cleanup.lock() {
+            if let Ok(mut map) = latest_remote_frames_cleanup.lock() {
                 map.remove(identity);
             }
             let _ = app_ended.emit_to(
@@ -1596,6 +1835,178 @@ pub fn screen_share_poll_frame(
 #[cfg(not(target_os = "windows"))]
 pub fn screen_share_poll_frame() -> Result<Option<()>, String> {
     Ok(None)
+}
+
+/// Poll the latest remote screen-share frame for a participant (Linux viewer path).
+///
+/// The LiveKit callback stores raw RGBA frames in `remote_screen_share_frames`.
+/// This command encodes only the newest frame requested by the webview. If the
+/// caller already rendered `last_seq`, returns `None` without encoding.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_poll_screen_share_frame(
+    identity: String,
+    last_seq: Option<u64>,
+    state: State<'_, MediaState>,
+) -> Result<Option<PolledScreenShareFrame>, String> {
+    use base64::Engine;
+    use image::codecs::jpeg::JpegEncoder;
+    use std::io::Cursor;
+
+    let latest = {
+        let frames = state
+            .remote_screen_share_frames
+            .lock()
+            .map_err(|e| format!("remote_screen_share_frames lock: {e}"))?;
+        frames.get(&identity).cloned()
+    };
+
+    let Some(latest) = latest else {
+        return Ok(None);
+    };
+
+    if last_seq == Some(latest.seq) {
+        return Ok(None);
+    }
+
+    let pixel_count = (latest.width * latest.height) as usize;
+    let mut rgb_data = Vec::with_capacity(pixel_count * 3);
+    for rgba in latest.data.chunks_exact(4) {
+        rgb_data.push(rgba[0]);
+        rgb_data.push(rgba[1]);
+        rgb_data.push(rgba[2]);
+    }
+
+    let jpeg_quality = state.screen_share_config.jpeg_quality();
+    let mut jpeg_buf = Cursor::new(Vec::with_capacity(256 * 1024));
+    let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buf, jpeg_quality);
+    if let Err(e) = encoder.encode(
+        &rgb_data,
+        latest.width,
+        latest.height,
+        image::ExtendedColorType::Rgb8,
+    ) {
+        log::warn!("{LOG} remote JPEG encode failed: {e}");
+        return Ok(None);
+    }
+
+    let frame = base64::engine::general_purpose::STANDARD.encode(jpeg_buf.into_inner());
+    Ok(Some(PolledScreenShareFrame {
+        identity,
+        frame,
+        width: latest.width,
+        height: latest.height,
+        seq: latest.seq,
+    }))
+}
+
+/// Non-Linux stub for `media_poll_screen_share_frame`.
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_poll_screen_share_frame(
+    _identity: String,
+    _last_seq: Option<u64>,
+) -> Result<Option<()>, String> {
+    Ok(None)
+}
+
+/// Return a browser-native MJPEG stream URL for Linux remote screen-share viewing.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_get_screen_share_stream_url(
+    identity: String,
+    state: State<'_, MediaState>,
+) -> Result<String, String> {
+    if state.remote_screen_share_stream_port == 0 {
+        return Err("remote screen share stream server is unavailable".to_string());
+    }
+    Ok(format!(
+        "http://127.0.0.1:{}/screen-share.mjpeg?identity={}",
+        state.remote_screen_share_stream_port,
+        percent_encode(&identity)
+    ))
+}
+
+/// Non-Linux stub for `media_get_screen_share_stream_url`.
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_get_screen_share_stream_url(_identity: String) -> Result<String, String> {
+    Err("remote screen share stream URL is only available on Linux".to_string())
+}
+
+fn native_share_viewer_path() -> Result<std::path::PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|e| format!("cannot determine current exe: {e}"))?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| "cannot determine exe directory".to_string())?;
+    let viewer = dir.join("native_share_viewer");
+    if viewer.exists() {
+        Ok(viewer)
+    } else {
+        Err(format!("native_share_viewer not found at {}", viewer.display()))
+    }
+}
+
+/// Open a native GTK viewer for a remote Linux screen share, bypassing WebKit rendering.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_open_native_screen_share_viewer(
+    identity: String,
+    title: String,
+    state: State<'_, MediaState>,
+) -> Result<(), String> {
+    let url = media_get_screen_share_stream_url(identity.clone(), state.clone())?;
+    let viewer = native_share_viewer_path()?;
+
+    let mut viewers = state
+        .native_screen_share_viewers
+        .lock()
+        .map_err(|e| format!("native_screen_share_viewers lock: {e}"))?;
+    if let Some(mut old) = viewers.remove(&identity) {
+        let _ = old.kill();
+        let _ = old.wait();
+    }
+
+    let child = std::process::Command::new(viewer)
+        .arg(url)
+        .arg(title)
+        .spawn()
+        .map_err(|e| format!("failed to spawn native screen share viewer: {e}"))?;
+    viewers.insert(identity, child);
+    Ok(())
+}
+
+/// Close a native GTK viewer opened by `media_open_native_screen_share_viewer`.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_close_native_screen_share_viewer(
+    identity: String,
+    state: State<'_, MediaState>,
+) -> Result<(), String> {
+    let mut viewers = state
+        .native_screen_share_viewers
+        .lock()
+        .map_err(|e| format!("native_screen_share_viewers lock: {e}"))?;
+    if let Some(mut child) = viewers.remove(&identity) {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    Ok(())
+}
+
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_open_native_screen_share_viewer(
+    _identity: String,
+    _title: String,
+) -> Result<(), String> {
+    Err("native screen share viewer is only available on Linux".to_string())
+}
+
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_close_native_screen_share_viewer(_identity: String) -> Result<(), String> {
+    Ok(())
 }
 
 /// Apply a screen share quality preset to the native capture pipeline.

--- a/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { startReceiving, stopReceiving } from './screen-share-viewer';
@@ -28,6 +29,14 @@ interface ShareWindowParams {
   initialVolume?: number;
 }
 
+interface PolledScreenShareFrame {
+  identity: string;
+  frame: string;
+  width: number;
+  height: number;
+  seq: number;
+}
+
 interface ShareUserState {
   isMuted: boolean;
   isDeafened: boolean;
@@ -55,6 +64,7 @@ export default function ScreenSharePage() {
   const initialVolume = shareParams?.initialVolume ?? 70;
 
   const [stream, setStream] = useState<MediaStream | null>(null);
+  const [mjpegUrl, setMjpegUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [volume, setVolume] = useState(initialVolume);
   const [muted, setMuted] = useState(initialVolume === 0);
@@ -100,6 +110,7 @@ export default function ScreenSharePage() {
     let cancelled = false;
 
     if (p.canvasFallback) {
+      setMjpegUrl(null);
       // Canvas fallback: listen for screen-share-frame Tauri events directly
       // and paint onto a visible canvas element.
       //
@@ -109,10 +120,10 @@ export default function ScreenSharePage() {
       // Subscribe to both so the fallback works cross-platform.
       let frameCount = 0;
       setDebugInfo('canvas-fallback: listening');
-      const handleFrame = (payload: { identity?: string; frame: string; width?: number; height?: number }) => {
-        if (cancelled) return;
+      const handleFrame = (payload: { identity?: string; frame: string; width?: number; height?: number }): Promise<boolean> => {
+        if (cancelled) return Promise.resolve(false);
         // If identity is present (Linux path), filter by participant
-        if (payload.identity && payload.identity !== p.participantId) return;
+        if (payload.identity && payload.identity !== p.participantId) return Promise.resolve(false);
 
         frameCount++;
         if (frameCount <= 3 || frameCount % 30 === 0) {
@@ -120,30 +131,77 @@ export default function ScreenSharePage() {
         }
 
         const canvas = canvasRef.current;
-        if (!canvas) return;
+        if (!canvas) return Promise.resolve(false);
         const ctx = canvas.getContext('2d');
-        if (!ctx) return;
+        if (!ctx) return Promise.resolve(false);
 
-        const img = new Image();
-        img.onload = () => {
-          if (canvas.width !== img.width || canvas.height !== img.height) {
-            canvas.width = img.width;
-            canvas.height = img.height;
-          }
-          ctx.drawImage(img, 0, 0);
-          markFrameRendered();
-        };
-        img.src = `data:image/jpeg;base64,${payload.frame}`;
+        return new Promise((resolve) => {
+          const img = new Image();
+          img.onload = () => {
+            if (cancelled) {
+              resolve(false);
+              return;
+            }
+            if (canvas.width !== img.width || canvas.height !== img.height) {
+              canvas.width = img.width;
+              canvas.height = img.height;
+            }
+            ctx.drawImage(img, 0, 0);
+            markFrameRendered();
+            resolve(true);
+          };
+          img.onerror = () => resolve(false);
+          img.src = `data:image/jpeg;base64,${payload.frame}`;
+        });
       };
+
+      let pollFrameId: number | null = null;
+      let lastSeq: number | null = null;
+      let mjpegActive = false;
+      const pollLatestFrame = async () => {
+        if (cancelled || mjpegActive) return;
+        try {
+          const frame = await invoke<PolledScreenShareFrame | null>('media_poll_screen_share_frame', {
+            identity: p.participantId,
+            lastSeq,
+          });
+          if (frame && !cancelled) {
+            lastSeq = frame.seq;
+            await handleFrame(frame);
+          }
+        } catch {
+          // Non-Linux builds and older builds may not expose the polling command.
+        } finally {
+          if (!cancelled && !mjpegActive) {
+            pollFrameId = requestAnimationFrame(pollLatestFrame);
+          }
+        }
+      };
+      pollFrameId = requestAnimationFrame(pollLatestFrame);
+
+      invoke<string>('media_get_screen_share_stream_url', { identity: p.participantId })
+        .then((url) => {
+          if (cancelled) return;
+          mjpegActive = true;
+          if (pollFrameId !== null) {
+            cancelAnimationFrame(pollFrameId);
+            pollFrameId = null;
+          }
+          setDebugInfo('canvas-fallback: mjpeg stream');
+          setMjpegUrl(`${url}&t=${Date.now()}`);
+        })
+        .catch(() => {
+          // Older/non-Linux builds use the polling fallback above.
+        });
 
       // Subscribe to both event name variants
       const unlistenLinux = listen<{ identity: string; frame: string }>(
         'screen_share_frame',
-        (event) => handleFrame(event.payload),
+        (event) => { void handleFrame(event.payload); },
       );
       const unlistenWindows = listen<{ frame: string; width: number; height: number }>(
         'screen-share-frame',
-        (event) => handleFrame(event.payload),
+        (event) => { void handleFrame(event.payload); },
       );
 
       // Mark as "connected" immediately — frames will arrive as they come
@@ -155,6 +213,7 @@ export default function ScreenSharePage() {
 
       return () => {
         cancelled = true;
+        if (pollFrameId !== null) cancelAnimationFrame(pollFrameId);
         unlistenLinux.then((fn) => fn());
         unlistenWindows.then((fn) => fn());
       };
@@ -569,6 +628,21 @@ export default function ScreenSharePage() {
             ref={videoRef}
             autoPlay
             playsInline
+            style={{
+              width: '100%',
+              height: '100%',
+              objectFit: 'contain',
+              transform: `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`,
+              transformOrigin: 'center center',
+              willChange: zoom > 1 ? 'transform' : undefined,
+            }}
+          />
+        ) : p.canvasFallback && mjpegUrl ? (
+          <img
+            src={mjpegUrl}
+            alt=""
+            draggable={false}
+            onLoad={markFrameRendered}
             style={{
               width: '100%',
               height: '100%',

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback, memo, useMemo } from 'react';
 import { Volume2 } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { StreamReceiver } from './screen-share-viewer';
@@ -23,6 +24,14 @@ import ShareSwitchingOverlay from './ShareSwitchingOverlay';
 
 const DEBUG_SHARE_VIEW = import.meta.env.VITE_DEBUG_SCREEN_SHARE_VIEW === 'true';
 const LOG = '[wavis:watch-all]';
+
+interface PolledScreenShareFrame {
+  identity: string;
+  frame: string;
+  width: number;
+  height: number;
+  seq: number;
+}
 
 const TITLE_BAR_HEIGHT = 32;
 const LABEL_FADE_DELAY_MS = 3000;
@@ -121,6 +130,7 @@ const ShareTile = memo(function ShareTile({
   onAspectRatioDetectedRef.current = onAspectRatioDetected;
   const isDiagnosticTest = kind === 'test';
   const [stream, setStream] = useState<MediaStream | null>(null);
+  const [mjpegUrl, setMjpegUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [hovered, setHovered] = useState(false);
   const [diagnosticViewport, setDiagnosticViewport] = useState({ width: 0, height: 0 });
@@ -297,43 +307,90 @@ const ShareTile = memo(function ShareTile({
   useEffect(() => {
     if (!canvasFallback || isDiagnosticTest) return;
     let cancelled = false;
+    setMjpegUrl(null);
 
-    const handleFrame = (payload: { identity?: string; frame: string; width?: number; height?: number }) => {
-      if (cancelled) return;
-      if (payload.identity && payload.identity !== participantId) return;
+    const handleFrame = (payload: { identity?: string; frame: string; width?: number; height?: number }): Promise<boolean> => {
+      if (cancelled) return Promise.resolve(false);
+      if (payload.identity && payload.identity !== participantId) return Promise.resolve(false);
 
       const canvas = canvasRef.current;
-      if (!canvas) return;
+      if (!canvas) return Promise.resolve(false);
       const ctx = canvas.getContext('2d');
-      if (!ctx) return;
+      if (!ctx) return Promise.resolve(false);
 
-      const img = new Image();
-      img.onload = () => {
-        if (canvas.width !== img.width || canvas.height !== img.height) {
-          canvas.width = img.width;
-          canvas.height = img.height;
-          if (img.width > 0 && img.height > 0) {
-            onAspectRatioDetectedRef.current(participantId, img.width / img.height);
+      return new Promise((resolve) => {
+        const img = new Image();
+        img.onload = () => {
+          if (cancelled) {
+            resolve(false);
+            return;
           }
-        }
-        ctx.drawImage(img, 0, 0);
-        markFrameRendered();
-      };
-      img.src = `data:image/jpeg;base64,${payload.frame}`;
+          if (canvas.width !== img.width || canvas.height !== img.height) {
+            canvas.width = img.width;
+            canvas.height = img.height;
+            if (img.width > 0 && img.height > 0) {
+              onAspectRatioDetectedRef.current(participantId, img.width / img.height);
+            }
+          }
+          ctx.drawImage(img, 0, 0);
+          markFrameRendered();
+          resolve(true);
+        };
+        img.onerror = () => resolve(false);
+        img.src = `data:image/jpeg;base64,${payload.frame}`;
+      });
     };
+
+    let pollFrameId: number | null = null;
+    let lastSeq: number | null = null;
+    let mjpegActive = false;
+    const pollLatestFrame = async () => {
+      if (cancelled || mjpegActive) return;
+      try {
+        const frame = await invoke<PolledScreenShareFrame | null>('media_poll_screen_share_frame', {
+          identity: participantId,
+          lastSeq,
+        });
+        if (frame && !cancelled) {
+          lastSeq = frame.seq;
+          await handleFrame(frame);
+        }
+      } catch {
+        // Non-Linux builds and older builds may not expose the polling command.
+      } finally {
+        if (!cancelled && !mjpegActive) {
+          pollFrameId = requestAnimationFrame(pollLatestFrame);
+        }
+      }
+    };
+    pollFrameId = requestAnimationFrame(pollLatestFrame);
+
+    invoke<string>('media_get_screen_share_stream_url', { identity: participantId })
+      .then((url) => {
+        if (cancelled) return;
+        mjpegActive = true;
+        if (pollFrameId !== null) {
+          cancelAnimationFrame(pollFrameId);
+          pollFrameId = null;
+        }
+        setMjpegUrl(`${url}&t=${Date.now()}`);
+      })
+      .catch(() => {
+        // Older/non-Linux builds use the polling fallback above.
+      });
 
     const unlistenLinux = listen<{ identity: string; frame: string }>(
       `ss-frame:${participantId}`,
-      (event) => handleFrame(event.payload),
+      (event) => { void handleFrame(event.payload); },
     );
     // Also listen for the generic event names (cross-platform compat)
     const unlistenGenericLinux = listen<{ identity: string; frame: string }>(
       'screen_share_frame',
-      (event) => handleFrame(event.payload),
+      (event) => { void handleFrame(event.payload); },
     );
     const unlistenGenericWin = listen<{ frame: string; width: number; height: number }>(
       'screen-share-frame',
-      (event) => handleFrame(event.payload),
+      (event) => { void handleFrame(event.payload); },
     );
     void emitTo('main', 'screen-share-viewer:ready', {
       participantId,
@@ -342,6 +399,7 @@ const ShareTile = memo(function ShareTile({
 
     return () => {
       cancelled = true;
+      if (pollFrameId !== null) cancelAnimationFrame(pollFrameId);
       unlistenLinux.then((fn) => fn());
       unlistenGenericLinux.then((fn) => fn());
       unlistenGenericWin.then((fn) => fn());
@@ -488,6 +546,20 @@ const ShareTile = memo(function ShareTile({
             </div>
           </div>
         </div>
+      ) : canvasFallback && mjpegUrl ? (
+        <img
+          src={mjpegUrl}
+          alt=""
+          draggable={false}
+          onLoad={(event) => {
+            const img = event.currentTarget;
+            if (img.naturalWidth > 0 && img.naturalHeight > 0) {
+              onAspectRatioDetectedRef.current(participantId, img.naturalWidth / img.naturalHeight);
+            }
+            markFrameRendered();
+          }}
+          style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+        />
       ) : canvasFallback ? (
         <canvas
           ref={canvasRef}

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -717,6 +717,7 @@ export default function ActiveRoom() {
   const prevEventsLenRef = useRef(0);
   // Refs to the screen share OS windows (keyed by participantId)
   const shareWindowsRef = useRef<Map<string, ShareViewerWindow>>(new Map());
+  const nativeShareViewersRef = useRef<Set<string>>(new Set());
   const selfSharingRef = useRef(false);
   const handleStartShareRef = useRef<() => void | Promise<void>>(() => {});
   const stopShareActionRef = useRef<() => void>(() => {});
@@ -1338,6 +1339,10 @@ export default function ActiveRoom() {
     stream: MediaStream | null,
     scope: ShareViewerScope = 'direct',
   ) => {
+    if (nativeShareViewersRef.current.has(participantId)) {
+      closeShareWindow(participantId);
+    }
+
     // If already watching this participant, close it first and wait for Tauri to
     // destroy the webview before creating a new one with the same label.
     if (shareWindowsRef.current.has(participantId)) {
@@ -1362,6 +1367,25 @@ export default function ActiveRoom() {
     const windowLabel = `screen-share-${participantId}`;
 
     try {
+      if (stream === null) {
+        await invoke('media_open_native_screen_share_viewer', {
+          identity: participantId,
+          title: `${participant.displayName} — screen share`,
+        });
+
+        nativeShareViewersRef.current.add(participantId);
+        attachScreenShareAudio(participantId);
+        setScreenShareAudioVolume(participantId, getSavedShareVolume(participantId));
+        setWatchingShareIds((prev) => new Set(prev).add(participantId));
+
+        if (watchAllWindowRef.current && watchAllReadyRef.current) {
+          watchAllAttachedAudioRef.current.delete(participantId);
+          prevWatchAllStreamsRef.current.delete(participantId);
+          emit('watch-all:share-removed', { participantId });
+        }
+        return;
+      }
+
       const win = new WebviewWindow(windowLabel, {
         url: `/screen-share#${hash}`,
         title: `${participant.displayName} — screen share`,
@@ -1413,6 +1437,7 @@ export default function ActiveRoom() {
       }
     } catch (err) {
       console.error('[wavis:active-room] failed to open screen share window:', err);
+      showTransientScreenShareError(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -1421,6 +1446,9 @@ export default function ActiveRoom() {
     stopSending(participantId, `screen-share-${participantId}`);
     if (!watchAllWindowRef.current || !watchAllReadyRef.current) {
       detachScreenShareAudio(participantId);
+    }
+    if (nativeShareViewersRef.current.delete(participantId)) {
+      invoke('media_close_native_screen_share_viewer', { identity: participantId }).catch(() => {});
     }
     const shareWindow = shareWindowsRef.current.get(participantId);
     if (shareWindow) {
@@ -1442,6 +1470,11 @@ export default function ActiveRoom() {
     closeVideoPopoutWindow();
     closeWatchAllWindow(); // close Watch All window first
     stopAllSending();
+    for (const pid of nativeShareViewersRef.current) {
+      detachScreenShareAudio(pid);
+      invoke('media_close_native_screen_share_viewer', { identity: pid }).catch(() => {});
+    }
+    nativeShareViewersRef.current.clear();
     for (const [pid, shareWindow] of shareWindowsRef.current) {
       detachScreenShareAudio(pid);
       shareWindow.window.close().catch(() => { });

--- a/clients/wavis-gui/src/features/voice/native-media.ts
+++ b/clients/wavis-gui/src/features/voice/native-media.ts
@@ -10,31 +10,18 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { MediaCallbacks } from './livekit-media';
-import { startSending } from '@features/screen-share/screen-share-viewer';
 import { getDenoiseEnabled, inputVolumeToGain } from '@features/settings/settings-store';
 
 const LOG = '[wavis:native-media]';
-
-/* ─── OffscreenCanvas.captureStream() runtime detection ─────────── */
-
-/**
- * Detect whether OffscreenCanvas + captureStream() are available.
- * Requires WebKitGTK ≥ 2.44 (GNOME 46 / Ubuntu 24.04+).
- */
-const hasOffscreenCaptureStream: boolean = (() => {
-  try {
-    const test = new OffscreenCanvas(1, 1);
-    return typeof (test as unknown as { captureStream: unknown }).captureStream === 'function';
-  } catch {
-    return false;
-  }
-})();
 
 /* ─── Tauri Event Payload Types ─────────────────────────────────── */
 
 interface ScreenShareFramePayload {
   identity: string;
-  frame: string; // base64-encoded JPEG
+}
+
+interface ScreenShareAvailablePayload {
+  identity: string;
 }
 
 interface ScreenShareEndedPayload {
@@ -46,8 +33,6 @@ interface ScreenShareEndedPayload {
 interface ActiveShareEntry {
   stream: MediaStream | null;
   canvas: HTMLCanvasElement | null;
-  offscreenCanvas?: OffscreenCanvas;
-  ctx?: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D | null;
   startedAtMs: number;
 }
 
@@ -114,14 +99,14 @@ export class NativeMediaModule {
   private callbacks: MediaCallbacks;
   private unlistenMedia: UnlistenFn | null = null;
   private unlistenFrame: UnlistenFn | null = null;
+  private unlistenAvailable: UnlistenFn | null = null;
   private unlistenEnded: UnlistenFn | null = null;
   private disposed = false;
   private activeShares = new Map<string, ActiveShareEntry>();
 
   constructor(callbacks: MediaCallbacks) {
     this.callbacks = callbacks;
-    console.log(LOG, 'created (native Rust path)',
-      hasOffscreenCaptureStream ? '(OffscreenCanvas+captureStream available)' : '(canvas fallback)');
+    console.log(LOG, 'created (native Rust path)');
   }
 
   /** Connect to LiveKit SFU via the Rust-side RealLiveKitConnection. */
@@ -190,19 +175,28 @@ export class NativeMediaModule {
       }
     });
 
-    // 2. Subscribe to remote screen share frame events
+    // 2. Subscribe to remote screen share frame events for backward compatibility.
+    // The Linux native viewer path renders pixels outside WebKit; this event
+    // only marks the share as available in the room UI.
     this.unlistenFrame = await listen<ScreenShareFramePayload>('screen_share_frame', (event) => {
       if (this.disposed) return;
       this.handleScreenShareFrame(event.payload);
     });
 
-    // 3. Subscribe to remote screen share ended events
+    // 3. Subscribe to lightweight remote screen share availability events.
+    // Linux stores frames in Rust and the native GTK viewer renders them.
+    this.unlistenAvailable = await listen<ScreenShareAvailablePayload>('screen_share_available', (event) => {
+      if (this.disposed) return;
+      this.handleScreenShareAvailable(event.payload.identity);
+    });
+
+    // 4. Subscribe to remote screen share ended events
     this.unlistenEnded = await listen<ScreenShareEndedPayload>('screen_share_ended', (event) => {
       if (this.disposed) return;
       this.handleScreenShareEnded(event.payload.identity);
     });
 
-    // 4. Tell Rust to connect
+    // 5. Tell Rust to connect
     try {
       const denoiseEnabled = await getDenoiseEnabled();
       await invoke('media_connect', { url: sfuUrl, token, denoiseEnabled });
@@ -221,6 +215,7 @@ export class NativeMediaModule {
     // Clean up all event listeners
     if (this.unlistenMedia) { this.unlistenMedia(); this.unlistenMedia = null; }
     if (this.unlistenFrame) { this.unlistenFrame(); this.unlistenFrame = null; }
+    if (this.unlistenAvailable) { this.unlistenAvailable(); this.unlistenAvailable = null; }
     if (this.unlistenEnded) { this.unlistenEnded(); this.unlistenEnded = null; }
 
     // Clean up all active shares
@@ -367,118 +362,22 @@ export class NativeMediaModule {
 
   /* ─── Private: Screen Share Frame Handling ───────────────────── */
 
-  /**
-   * Handle an incoming screen_share_frame event from Rust.
-   * Primary path (OffscreenCanvas): createImageBitmap → drawImage → requestFrame
-   * Fallback path (visible canvas): Image → drawImage
-   */
   private handleScreenShareFrame(payload: ScreenShareFramePayload): void {
-    const { identity, frame } = payload;
-
-    if (hasOffscreenCaptureStream) {
-      this.handleFramePrimary(identity, frame);
-    } else {
-      this.handleFrameFallback(identity, frame);
-    }
+    this.handleScreenShareAvailable(payload.identity);
   }
 
-  /**
-   * Primary path — OffscreenCanvas + captureStream (WebKitGTK ≥ 2.44).
-   * Creates a synthetic MediaStream and feeds into the loopback bridge.
-   */
-  private handleFramePrimary(identity: string, frameData: string): void {
-    const binary = atob(frameData);
-    const bytes = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
-    const blob = new Blob([bytes], { type: 'image/jpeg' });
+  private handleScreenShareAvailable(identity: string): void {
+    if (this.activeShares.has(identity)) return;
 
-    createImageBitmap(blob).then((bitmap) => {
-      let entry = this.activeShares.get(identity);
-
-      if (!entry) {
-        // First frame for this identity — create OffscreenCanvas + stream
-        const offscreenCanvas = new OffscreenCanvas(bitmap.width, bitmap.height);
-        const ctx = offscreenCanvas.getContext('2d');
-        const stream = (offscreenCanvas as unknown as { captureStream(fps: number): MediaStream }).captureStream(0);
-
-        entry = {
-          stream,
-          canvas: null,
-          offscreenCanvas,
-          ctx,
-          startedAtMs: Date.now(),
-        };
-        this.activeShares.set(identity, entry);
-
-        console.log(LOG, `screen share subscribed (primary path): ${identity}`);
-        this.callbacks.onScreenShareSubscribed(identity, stream);
-
-        // Feed into loopback bridge for ScreenShareWindow rendering
-        startSending(identity, 'watch-all', stream).catch((err) => {
-          console.warn(LOG, `loopback bridge start failed for ${identity}:`, err);
-        });
-      }
-
-      // Resize canvas if frame dimensions changed
-      if (entry.offscreenCanvas &&
-          (entry.offscreenCanvas.width !== bitmap.width || entry.offscreenCanvas.height !== bitmap.height)) {
-        entry.offscreenCanvas.width = bitmap.width;
-        entry.offscreenCanvas.height = bitmap.height;
-      }
-
-      // Paint frame and push to stream
-      if (entry.ctx) {
-        entry.ctx.drawImage(bitmap, 0, 0);
-        const tracks = entry.stream?.getVideoTracks();
-        if (tracks && tracks.length > 0) {
-          (tracks[0] as unknown as { requestFrame(): void }).requestFrame();
-        }
-      }
-      bitmap.close();
-    }).catch((err) => {
-      console.warn(LOG, `frame decode failed for ${identity}:`, err);
-    });
-  }
-
-  /**
-   * Fallback path — visible <canvas> element (WebKitGTK < 2.44).
-   * No MediaStream — canvas is rendered directly in ScreenShareWindow.
-   */
-  private handleFrameFallback(identity: string, frameData: string): void {
-    let entry = this.activeShares.get(identity);
-
-    if (!entry) {
-      // First frame — create visible canvas
-      const canvas = document.createElement('canvas');
-      const ctx = canvas.getContext('2d');
-
-      entry = {
-        stream: null,
-        canvas,
-        ctx,
-        startedAtMs: Date.now(),
-      };
-      this.activeShares.set(identity, entry);
-
-      console.log(LOG, `screen share subscribed (canvas fallback): ${identity}`);
-      // Pass null stream — ScreenShareWindow will use the canvas directly
-      this.callbacks.onScreenShareSubscribed(identity, null as unknown as MediaStream);
-    }
-
-    // Decode base64 JPEG and paint onto canvas
-    const img = new Image();
-    img.onload = () => {
-      if (!entry) return;
-      // Resize canvas to match frame dimensions
-      if (entry.canvas && (entry.canvas.width !== img.width || entry.canvas.height !== img.height)) {
-        entry.canvas.width = img.width;
-        entry.canvas.height = img.height;
-      }
-      if (entry.ctx) {
-        (entry.ctx as CanvasRenderingContext2D).drawImage(img, 0, 0);
-      }
+    const entry: ActiveShareEntry = {
+      stream: null,
+      canvas: null,
+      startedAtMs: Date.now(),
     };
-    img.src = `data:image/jpeg;base64,${frameData}`;
+    this.activeShares.set(identity, entry);
+
+    console.log(LOG, `screen share available (native viewer path): ${identity}`);
+    this.callbacks.onScreenShareSubscribed(identity, null as unknown as MediaStream);
   }
 
   /** Handle screen_share_ended event — clean up and notify. */


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
