### PR TITLE
fixing camera

### DIFF
--- a/clients/shared/src/livekit_connection.rs
+++ b/clients/shared/src/livekit_connection.rs
@@ -295,6 +295,8 @@ impl LiveKitConnection for RealLiveKitConnection {
         let audio_cb = Arc::clone(&self.audio_cb);
         let video_frame_cb = Arc::clone(&self.video.video_frame_cb);
         let video_track_ended_cb = Arc::clone(&self.video.video_track_ended_cb);
+        let camera_frame_cb = Arc::clone(&self.video.camera_frame_cb);
+        let camera_track_ended_cb = Arc::clone(&self.video.camera_track_ended_cb);
         let connected = Arc::clone(&self.connected);
         let closing = Arc::clone(&self.closing);
         #[cfg(feature = "real-backends")]
@@ -388,34 +390,58 @@ impl LiveKitConnection for RealLiveKitConnection {
                     }
                     livekit::RoomEvent::TrackSubscribed {
                         track: RemoteTrack::Video(video_track),
+                        publication,
                         participant,
                         ..
                     } => {
+                        use livekit::track::TrackSource;
                         use livekit::webrtc::video_stream::native::NativeVideoStream;
 
                         let rtc_track = video_track.rtc_track();
                         let stream = NativeVideoStream::new(rtc_track);
                         let participant_id = participant.identity().to_string();
+                        let source = publication.source();
                         log::info!(
-                            "livekit_video: subscribed to video track from {participant_id}"
+                            "livekit_video: subscribed to video track from {participant_id}, source={source:?}"
                         );
+                        let (frame_cb, ended_cb) = if source == TrackSource::Camera {
+                            (
+                                Arc::clone(&camera_frame_cb),
+                                Arc::clone(&camera_track_ended_cb),
+                            )
+                        } else {
+                            (
+                                Arc::clone(&video_frame_cb),
+                                Arc::clone(&video_track_ended_cb),
+                            )
+                        };
 
                         tokio::spawn(super::livekit_video::run_video_receiver_task(
                             stream,
                             participant_id,
-                            Arc::clone(&video_frame_cb),
-                            Arc::clone(&video_track_ended_cb),
+                            frame_cb,
+                            ended_cb,
                             Arc::clone(&closing),
                         ));
                     }
                     livekit::RoomEvent::TrackUnsubscribed {
                         track: RemoteTrack::Video(_),
+                        publication,
                         participant,
                         ..
                     } => {
+                        use livekit::track::TrackSource;
+
                         let participant_id = participant.identity().to_string();
-                        log::info!("livekit_video: video track unsubscribed from {participant_id}");
-                        if let Some(cb) = video_track_ended_cb.lock().unwrap().as_ref() {
+                        let source = publication.source();
+                        log::info!(
+                            "livekit_video: video track unsubscribed from {participant_id}, source={source:?}"
+                        );
+                        if source == TrackSource::Camera {
+                            if let Some(cb) = camera_track_ended_cb.lock().unwrap().as_ref() {
+                                cb(&participant_id);
+                            }
+                        } else if let Some(cb) = video_track_ended_cb.lock().unwrap().as_ref() {
                             cb(&participant_id);
                         }
                     }
@@ -423,6 +449,9 @@ impl LiveKitConnection for RealLiveKitConnection {
                         let participant_id = participant.identity().to_string();
                         log::info!("livekit_video: participant disconnected: {participant_id}");
                         if let Some(cb) = video_track_ended_cb.lock().unwrap().as_ref() {
+                            cb(&participant_id);
+                        }
+                        if let Some(cb) = camera_track_ended_cb.lock().unwrap().as_ref() {
                             cb(&participant_id);
                         }
                     }
@@ -552,6 +581,8 @@ impl LiveKitConnection for RealLiveKitConnection {
         *self.published_track.lock().unwrap() = None;
         *self.video.published_video_track.lock().unwrap() = None;
         *self.video.video_source.lock().unwrap() = None;
+        *self.video.published_camera_track.lock().unwrap() = None;
+        *self.video.camera_source.lock().unwrap() = None;
         *self.published_screen_audio_track.lock().unwrap() = None;
         *self.screen_audio_source.lock().unwrap() = None;
         #[cfg(feature = "real-backends")]
@@ -573,6 +604,14 @@ impl LiveKitConnection for RealLiveKitConnection {
 
     fn on_video_track_ended(&self, cb: Box<dyn Fn(&str) + Send + 'static>) {
         *self.video.video_track_ended_cb.lock().unwrap() = Some(cb);
+    }
+
+    fn on_camera_frame(&self, cb: Box<dyn Fn(&str, &[u8], u32, u32) + Send + 'static>) {
+        *self.video.camera_frame_cb.lock().unwrap() = Some(cb);
+    }
+
+    fn on_camera_track_ended(&self, cb: Box<dyn Fn(&str) + Send + 'static>) {
+        *self.video.camera_track_ended_cb.lock().unwrap() = Some(cb);
     }
 
     // Task 4.3
@@ -981,6 +1020,134 @@ impl LiveKitConnection for RealLiveKitConnection {
         }
 
         log::info!("unpublish_video: screen share track unpublished");
+        Ok(())
+    }
+
+    fn publish_camera_video(&self, width: u32, height: u32) -> Result<(), RoomError> {
+        use livekit::options::TrackPublishOptions;
+        use livekit::webrtc::video_source::native::NativeVideoSource;
+        use livekit::webrtc::video_source::RtcVideoSource;
+        use livekit::webrtc::video_source::VideoResolution;
+        use std::sync::atomic::Ordering::SeqCst;
+
+        if !self.connected.load(SeqCst) {
+            return Err(RoomError::NotInRoom);
+        }
+
+        if self.video.published_camera_track.lock().unwrap().is_some() {
+            log::debug!("publish_camera_video: already publishing, returning Ok");
+            return Ok(());
+        }
+
+        let room_guard = self.room.lock().unwrap();
+        let room = room_guard.as_ref().ok_or(RoomError::NotInRoom)?;
+
+        let resolution = VideoResolution { width, height };
+        let source = NativeVideoSource::new(resolution, false);
+        let rtc_source = RtcVideoSource::Native(source.clone());
+        let lk_track = livekit::track::LocalVideoTrack::create_video_track("camera", rtc_source);
+
+        let publish_opts = TrackPublishOptions {
+            source: TrackSource::Camera,
+            video_codec: livekit::options::VideoCodec::VP8,
+            video_encoding: Some(livekit::options::VideoEncoding {
+                max_bitrate: 500_000,
+                max_framerate: 15.0,
+            }),
+            simulcast: false,
+            ..Default::default()
+        };
+
+        log::info!("publish_camera_video: publishing {width}x{height} camera track");
+        self.video
+            .next_camera_timestamp_us
+            .store(1, std::sync::atomic::Ordering::Relaxed);
+
+        tokio::task::block_in_place(|| {
+            self.rt_handle.block_on(async {
+                room.local_participant()
+                    .publish_track(
+                        livekit::track::LocalTrack::Video(lk_track.clone()),
+                        publish_opts,
+                    )
+                    .await
+                    .map_err(map_publish_error)
+            })
+        })?;
+
+        *self.video.published_camera_track.lock().unwrap() = Some(lk_track);
+        *self.video.camera_source.lock().unwrap() = Some(source);
+
+        log::info!("publish_camera_video: camera track published successfully");
+        Ok(())
+    }
+
+    fn feed_camera_frame(&self, data: &[u8], width: u32, height: u32) -> Result<(), RoomError> {
+        use livekit::webrtc::video_frame::{VideoFrame, VideoRotation};
+        use std::sync::atomic::Ordering::Relaxed;
+
+        let source_guard = self.video.camera_source.lock().unwrap();
+        let source = source_guard.as_ref().ok_or_else(|| {
+            RoomError::PublishFailed(
+                "no camera source — call publish_camera_video first".to_string(),
+            )
+        })?;
+
+        let expected_len = (width as usize) * (height as usize) * 4;
+        if data.len() != expected_len {
+            return Err(RoomError::PublishFailed(format!(
+                "camera RGBA data length mismatch: expected {} bytes ({}x{}x4), got {}",
+                expected_len,
+                width,
+                height,
+                data.len()
+            )));
+        }
+
+        let i420 = rgba_to_i420(data, width, height);
+        let timestamp_us = self
+            .video
+            .next_camera_timestamp_us
+            .fetch_add(66_666, Relaxed);
+
+        let frame = VideoFrame {
+            rotation: VideoRotation::VideoRotation0,
+            buffer: i420,
+            timestamp_us,
+        };
+
+        source.capture_frame(&frame);
+        Ok(())
+    }
+
+    fn unpublish_camera_video(&self) -> Result<(), RoomError> {
+        use std::sync::atomic::Ordering::SeqCst;
+
+        *self.video.camera_source.lock().unwrap() = None;
+
+        let camera_track = self.video.published_camera_track.lock().unwrap().take();
+        if camera_track.is_none() {
+            return Ok(());
+        }
+
+        if !self.connected.load(SeqCst) {
+            return Ok(());
+        }
+
+        let room_guard = self.room.lock().unwrap();
+        if let Some(room) = room_guard.as_ref() {
+            let track_sid = camera_track.as_ref().unwrap().sid();
+
+            tokio::task::block_in_place(|| {
+                self.rt_handle.block_on(async {
+                    if let Err(e) = room.local_participant().unpublish_track(&track_sid).await {
+                        warn!("unpublish_camera_video: failed to unpublish track: {e}");
+                    }
+                })
+            });
+        }
+
+        log::info!("unpublish_camera_video: camera track unpublished");
         Ok(())
     }
 

--- a/clients/shared/src/livekit_video.rs
+++ b/clients/shared/src/livekit_video.rs
@@ -26,10 +26,16 @@ pub(super) struct VideoState {
     pub(super) published_video_track: Arc<Mutex<Option<LocalVideoTrack>>>,
     /// Video source handle for feeding captured RGBA frames into the LiveKit SDK.
     pub(super) video_source: Arc<Mutex<Option<NativeVideoSource>>>,
+    /// Published local camera track handle.
+    pub(super) published_camera_track: Arc<Mutex<Option<LocalVideoTrack>>>,
+    /// Video source handle for feeding local camera RGBA frames.
+    pub(super) camera_source: Arc<Mutex<Option<NativeVideoSource>>>,
     /// Monotonic timestamp for locally fed video frames. The Rust LiveKit path
     /// must advance timestamps itself; constant timestamps can stall outbound
     /// screen-share delivery for repeated frames.
     pub(super) next_timestamp_us: Arc<AtomicI64>,
+    /// Monotonic timestamp for locally fed camera frames.
+    pub(super) next_camera_timestamp_us: Arc<AtomicI64>,
     /// Callback for receiving decoded video frames from remote screen shares.
     /// Receives (identity, rgba_data, width, height).
     #[allow(clippy::type_complexity)]
@@ -39,6 +45,15 @@ pub(super) struct VideoState {
     /// Receives (identity).
     #[allow(clippy::type_complexity)]
     pub(super) video_track_ended_cb: Arc<Mutex<Option<Box<dyn Fn(&str) + Send + 'static>>>>,
+    /// Callback for receiving decoded video frames from remote camera tracks.
+    /// Receives (identity, rgba_data, width, height).
+    #[allow(clippy::type_complexity)]
+    pub(super) camera_frame_cb:
+        Arc<Mutex<Option<Box<dyn Fn(&str, &[u8], u32, u32) + Send + 'static>>>>,
+    /// Callback for when a remote camera video track ends.
+    /// Receives (identity).
+    #[allow(clippy::type_complexity)]
+    pub(super) camera_track_ended_cb: Arc<Mutex<Option<Box<dyn Fn(&str) + Send + 'static>>>>,
 }
 
 impl VideoState {
@@ -46,9 +61,14 @@ impl VideoState {
         Self {
             published_video_track: Arc::new(Mutex::new(None)),
             video_source: Arc::new(Mutex::new(None)),
+            published_camera_track: Arc::new(Mutex::new(None)),
+            camera_source: Arc::new(Mutex::new(None)),
             next_timestamp_us: Arc::new(AtomicI64::new(1)),
+            next_camera_timestamp_us: Arc::new(AtomicI64::new(1)),
             video_frame_cb: Arc::new(Mutex::new(None)),
             video_track_ended_cb: Arc::new(Mutex::new(None)),
+            camera_frame_cb: Arc::new(Mutex::new(None)),
+            camera_track_ended_cb: Arc::new(Mutex::new(None)),
         }
     }
 }

--- a/clients/shared/src/room_session/mod.rs
+++ b/clients/shared/src/room_session/mod.rs
@@ -105,6 +105,25 @@ pub trait LiveKitConnection: Send + Sync {
         Ok(())
     }
 
+    /// Publish a camera video track. Default: returns error (not supported).
+    fn publish_camera_video(&self, _width: u32, _height: u32) -> Result<(), RoomError> {
+        Err(RoomError::PublishFailed(
+            "camera publishing not supported".to_string(),
+        ))
+    }
+
+    /// Feed a captured RGBA frame into the published camera track.
+    fn feed_camera_frame(&self, _data: &[u8], _width: u32, _height: u32) -> Result<(), RoomError> {
+        Err(RoomError::PublishFailed(
+            "camera publishing not supported".to_string(),
+        ))
+    }
+
+    /// Unpublish the camera track and clean up resources.
+    fn unpublish_camera_video(&self) -> Result<(), RoomError> {
+        Ok(())
+    }
+
     /// Register callback for receiving decoded video frames from a remote
     /// participant's screen share. The callback receives
     /// `(identity, rgba_data, width, height)`.
@@ -115,6 +134,17 @@ pub trait LiveKitConnection: Send + Sync {
     /// (unsubscribed or participant disconnected). Receives `(identity)`.
     /// Default: no-op.
     fn on_video_track_ended(&self, _cb: Box<dyn Fn(&str) + Send + 'static>) {}
+
+    /// Register callback for receiving decoded video frames from a remote
+    /// participant's camera track. The callback receives
+    /// `(identity, rgba_data, width, height)`.
+    /// Default: no-op.
+    fn on_camera_frame(&self, _cb: Box<dyn Fn(&str, &[u8], u32, u32) + Send + 'static>) {}
+
+    /// Register callback for when a remote camera video track ends
+    /// (unsubscribed or participant disconnected). Receives `(identity)`.
+    /// Default: no-op.
+    fn on_camera_track_ended(&self, _cb: Box<dyn Fn(&str) + Send + 'static>) {}
 
     /// Publish a second audio track for system audio capture (screen share audio).
     /// Creates a `NativeAudioSource` and `LocalAudioTrack` published with

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -489,11 +489,15 @@ fn main() {
             media::media_detach_screen_share_audio,
             media::media_set_master_volume,
             media::media_is_connected,
+            media::media_camera_start,
+            media::media_camera_stop,
             media::screen_share_start,
             media::screen_share_start_source,
             media::screen_share_stop,
             media::screen_share_poll_frame,
             media::media_poll_screen_share_frame,
+            media::media_poll_camera_frame,
+            media::media_poll_local_camera_frame,
             media::media_get_screen_share_stream_url,
             media::media_open_native_screen_share_viewer,
             media::media_close_native_screen_share_viewer,
@@ -809,8 +813,11 @@ async fn store_token(
     let key_for_keyring = key.clone();
     let value_for_keyring = value.clone();
     run_keyring_blocking(move || {
-        let entry = keyring::Entry::new(KEYRING_SERVICE, &key_for_keyring).map_err(|e| e.to_string())?;
-        entry.set_password(&value_for_keyring).map_err(|e| e.to_string())?;
+        let entry =
+            keyring::Entry::new(KEYRING_SERVICE, &key_for_keyring).map_err(|e| e.to_string())?;
+        entry
+            .set_password(&value_for_keyring)
+            .map_err(|e| e.to_string())?;
         Ok(())
     })
     .await?;
@@ -833,7 +840,8 @@ async fn get_token(
     // Cache miss — read from keychain once and populate the cache.
     let key_for_keyring = key.clone();
     let result = run_keyring_blocking(move || {
-        let entry = keyring::Entry::new(KEYRING_SERVICE, &key_for_keyring).map_err(|e| e.to_string())?;
+        let entry =
+            keyring::Entry::new(KEYRING_SERVICE, &key_for_keyring).map_err(|e| e.to_string())?;
         match entry.get_password() {
             Ok(val) => Ok(Some(val)),
             Err(keyring::Error::NoEntry) => Ok(None),
@@ -848,14 +856,12 @@ async fn get_token(
 }
 
 #[tauri::command]
-async fn delete_token(
-    key: String,
-    cache: tauri::State<'_, KeyringCache>,
-) -> Result<(), String> {
+async fn delete_token(key: String, cache: tauri::State<'_, KeyringCache>) -> Result<(), String> {
     cache.0.lock().unwrap().remove(&key);
     let key_for_keyring = key.clone();
     run_keyring_blocking(move || {
-        let entry = keyring::Entry::new(KEYRING_SERVICE, &key_for_keyring).map_err(|e| e.to_string())?;
+        let entry =
+            keyring::Entry::new(KEYRING_SERVICE, &key_for_keyring).map_err(|e| e.to_string())?;
         match entry.delete_credential() {
             Ok(()) => Ok(()),
             Err(keyring::Error::NoEntry) => Ok(()), // already gone — idempotent

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -15,6 +15,7 @@ use std::thread::JoinHandle as StdJoinHandle;
 use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
+    process::{Child, Command, Stdio},
     time::Duration,
 };
 use tauri::{AppHandle, Emitter, State};
@@ -176,6 +177,29 @@ struct LatestRemoteScreenShareFrame {
 }
 
 #[cfg(target_os = "linux")]
+struct LocalCameraCapture {
+    active: Arc<AtomicBool>,
+    child: Arc<Mutex<Option<Child>>>,
+    thread: Option<StdJoinHandle<()>>,
+}
+
+#[cfg(target_os = "linux")]
+impl LocalCameraCapture {
+    fn stop(mut self) {
+        self.active.store(false, Ordering::Relaxed);
+        if let Ok(mut child_guard) = self.child.lock() {
+            if let Some(child) = child_guard.as_mut() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
 #[derive(Clone, Serialize)]
 pub struct PolledScreenShareFrame {
     pub identity: String,
@@ -188,6 +212,22 @@ pub struct PolledScreenShareFrame {
 #[cfg(target_os = "linux")]
 #[derive(Clone, Serialize)]
 struct ScreenShareAvailablePayload {
+    identity: String,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Serialize)]
+pub struct PolledCameraFrame {
+    pub identity: String,
+    pub frame: String,
+    pub width: u32,
+    pub height: u32,
+    pub seq: u64,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Serialize)]
+struct CameraAvailablePayload {
     identity: String,
 }
 
@@ -458,6 +498,19 @@ pub struct MediaState {
         Arc<Mutex<std::collections::HashMap<String, LatestRemoteScreenShareFrame>>>,
     #[cfg(target_os = "linux")]
     remote_screen_share_seq: Arc<AtomicU64>,
+    /// Latest raw remote camera frame per participant. Camera frames are kept
+    /// separate from screen-share frames because a participant may publish both.
+    #[cfg(target_os = "linux")]
+    remote_camera_frames:
+        Arc<Mutex<std::collections::HashMap<String, LatestRemoteScreenShareFrame>>>,
+    #[cfg(target_os = "linux")]
+    remote_camera_seq: Arc<AtomicU64>,
+    #[cfg(target_os = "linux")]
+    local_camera_frame: Arc<Mutex<Option<LatestRemoteScreenShareFrame>>>,
+    #[cfg(target_os = "linux")]
+    local_camera_seq: Arc<AtomicU64>,
+    #[cfg(target_os = "linux")]
+    local_camera_capture: Mutex<Option<LocalCameraCapture>>,
     #[cfg(target_os = "linux")]
     remote_screen_share_stream_port: u16,
     #[cfg(target_os = "linux")]
@@ -482,19 +535,26 @@ pub struct MediaState {
 impl MediaState {
     pub fn new() -> Self {
         #[cfg(any(target_os = "linux", target_os = "windows"))]
-        let screen_share_config = Arc::new(screen_capture::frame_processor::ScreenShareConfig::new());
+        let screen_share_config =
+            Arc::new(screen_capture::frame_processor::ScreenShareConfig::new());
         #[cfg(target_os = "linux")]
-        let remote_screen_share_frames =
-            Arc::new(Mutex::new(std::collections::HashMap::<
-                String,
-                LatestRemoteScreenShareFrame,
-            >::new()));
+        let remote_screen_share_frames = Arc::new(Mutex::new(std::collections::HashMap::<
+            String,
+            LatestRemoteScreenShareFrame,
+        >::new()));
         #[cfg(target_os = "linux")]
         let remote_screen_share_stream_port = start_remote_screen_share_stream_server(
             Arc::clone(&remote_screen_share_frames),
             Arc::clone(&screen_share_config),
         )
         .unwrap_or(0);
+        #[cfg(target_os = "linux")]
+        let remote_camera_frames = Arc::new(Mutex::new(std::collections::HashMap::<
+            String,
+            LatestRemoteScreenShareFrame,
+        >::new()));
+        #[cfg(target_os = "linux")]
+        let local_camera_frame = Arc::new(Mutex::new(None));
 
         Self {
             runtime: Builder::new_multi_thread()
@@ -522,6 +582,16 @@ impl MediaState {
             remote_screen_share_frames,
             #[cfg(target_os = "linux")]
             remote_screen_share_seq: Arc::new(AtomicU64::new(0)),
+            #[cfg(target_os = "linux")]
+            remote_camera_frames,
+            #[cfg(target_os = "linux")]
+            remote_camera_seq: Arc::new(AtomicU64::new(0)),
+            #[cfg(target_os = "linux")]
+            local_camera_frame,
+            #[cfg(target_os = "linux")]
+            local_camera_seq: Arc::new(AtomicU64::new(0)),
+            #[cfg(target_os = "linux")]
+            local_camera_capture: Mutex::new(None),
             #[cfg(target_os = "linux")]
             remote_screen_share_stream_port,
             #[cfg(target_os = "linux")]
@@ -947,6 +1017,57 @@ pub fn media_connect(
                 }),
             );
         }));
+
+        let app_camera = app.clone();
+        let latest_remote_camera_frames = Arc::clone(&state.remote_camera_frames);
+        let remote_camera_seq = Arc::clone(&state.remote_camera_seq);
+        conn.on_camera_frame(Box::new(move |identity, rgba_data, width, height| {
+            let seq = remote_camera_seq.fetch_add(1, Ordering::Relaxed) + 1;
+            let identity_owned = identity.to_string();
+            let was_new_camera = {
+                let mut frames = match latest_remote_camera_frames.lock() {
+                    Ok(g) => g,
+                    Err(_) => return,
+                };
+                let was_new = !frames.contains_key(identity);
+                frames.insert(
+                    identity_owned.clone(),
+                    LatestRemoteScreenShareFrame {
+                        data: Arc::new(rgba_data.to_vec()),
+                        width,
+                        height,
+                        seq,
+                    },
+                );
+                was_new
+            };
+
+            if was_new_camera {
+                let _ = app_camera.emit_to(
+                    "main",
+                    "camera_available",
+                    CameraAvailablePayload {
+                        identity: identity_owned,
+                    },
+                );
+            }
+        }));
+
+        let app_camera_ended = app.clone();
+        let latest_remote_camera_cleanup = Arc::clone(&state.remote_camera_frames);
+        conn.on_camera_track_ended(Box::new(move |identity| {
+            log::info!("{LOG} remote camera ended: {identity}");
+            if let Ok(mut map) = latest_remote_camera_cleanup.lock() {
+                map.remove(identity);
+            }
+            let _ = app_camera_ended.emit_to(
+                "main",
+                "camera_ended",
+                serde_json::json!({
+                    "identity": identity,
+                }),
+            );
+        }));
     }
 
     // Connect
@@ -1011,6 +1132,17 @@ pub fn media_disconnect(state: State<'_, MediaState>, app: AppHandle) -> Result<
     #[cfg(target_os = "linux")]
     {
         state.stop_native_screen_share_stats();
+        let camera_capture = {
+            let mut camera_guard = state
+                .local_camera_capture
+                .lock()
+                .map_err(|e| format!("local_camera_capture lock: {e}"))?;
+            camera_guard.take()
+        };
+        if let Some(capture) = camera_capture {
+            capture.stop();
+            log::info!("{LOG} media_disconnect: stopped active camera capture");
+        }
         let capture = {
             let mut sc_guard = state
                 .screen_capture
@@ -1031,6 +1163,18 @@ pub fn media_disconnect(state: State<'_, MediaState>, app: AppHandle) -> Result<
     // Clear the denoise filter — no session active.
     if let Ok(mut dn_guard) = state.denoise.lock() {
         *dn_guard = None;
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(mut frames) = state.remote_screen_share_frames.lock() {
+            frames.clear();
+        }
+        if let Ok(mut frames) = state.remote_camera_frames.lock() {
+            frames.clear();
+        }
+        if let Ok(mut frame) = state.local_camera_frame.lock() {
+            *frame = None;
+        }
     }
     if let Ok(mut task_guard) = state.local_meter_task.lock() {
         if let Some(task) = task_guard.take() {
@@ -1059,6 +1203,245 @@ pub fn media_set_mic_enabled(enabled: bool, state: State<'_, MediaState>) -> Res
         conn.set_mic_enabled(enabled)
             .map_err(|e| format!("failed to set mic enabled: {e}"))?;
     }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn default_linux_camera_device() -> Result<String, String> {
+    for idx in 0..10 {
+        let path = format!("/dev/video{idx}");
+        if std::path::Path::new(&path).exists() {
+            return Ok(path);
+        }
+    }
+    Err("no camera device found under /dev/video*".to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_linux_camera_device(device_id: Option<String>) -> Result<String, String> {
+    match device_id.filter(|value| !value.trim().is_empty()) {
+        Some(value) => {
+            if value.starts_with("/dev/video") {
+                Ok(value)
+            } else {
+                Err(format!("unsupported native camera device id: {value}"))
+            }
+        }
+        None => default_linux_camera_device(),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn spawn_ffmpeg_camera_capture(
+    device: &str,
+    width: u32,
+    height: u32,
+    fps: u32,
+    force_input_mode: bool,
+) -> std::io::Result<Child> {
+    let mut command = Command::new("ffmpeg");
+    command.args(["-hide_banner", "-loglevel", "error", "-nostdin"]);
+    command.args(["-fflags", "nobuffer", "-flags", "low_delay"]);
+    command.args(["-f", "v4l2"]);
+    if force_input_mode {
+        command.args([
+            "-framerate",
+            &fps.to_string(),
+            "-video_size",
+            &format!("{width}x{height}"),
+        ]);
+    }
+    command.args(["-i", device]);
+    command.args([
+        "-an",
+        "-vf",
+        &format!(
+            "fps={fps},scale={width}:{height}:force_original_aspect_ratio=decrease,pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,setsar=1,format=rgba"
+        ),
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "rgba",
+        "-s",
+        &format!("{width}x{height}"),
+        "-",
+    ]);
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+}
+
+/// Start local Linux webcam capture and publish it as a LiveKit Camera track.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_camera_start(
+    device_id: Option<String>,
+    width: u32,
+    height: u32,
+    fps: u32,
+    state: State<'_, MediaState>,
+) -> Result<(), String> {
+    let width = width.clamp(160, 1280);
+    let height = height.clamp(120, 720);
+    let fps = fps.clamp(5, 30);
+    let device = resolve_linux_camera_device(device_id)?;
+
+    if Command::new("ffmpeg").arg("-version").output().is_err() {
+        return Err(
+            "Linux native camera capture requires ffmpeg with v4l2 support in PATH".to_string(),
+        );
+    }
+
+    let conn = {
+        let lk_guard = state.lk.lock().map_err(|e| format!("lock: {e}"))?;
+        lk_guard
+            .as_ref()
+            .cloned()
+            .ok_or_else(|| "media is not connected".to_string())?
+    };
+
+    {
+        let mut existing = state
+            .local_camera_capture
+            .lock()
+            .map_err(|e| format!("local_camera_capture lock: {e}"))?;
+        if let Some(capture) = existing.take() {
+            capture.stop();
+        }
+    }
+    if let Ok(mut frame) = state.local_camera_frame.lock() {
+        *frame = None;
+    }
+
+    state
+        .runtime
+        .block_on(async { conn.publish_camera_video(width, height) })
+        .map_err(|e| format!("{e}"))?;
+
+    let active = Arc::new(AtomicBool::new(true));
+    let child_slot: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(None));
+    let local_frame = Arc::clone(&state.local_camera_frame);
+    let local_seq = Arc::clone(&state.local_camera_seq);
+    let active_thread = Arc::clone(&active);
+    let child_thread = Arc::clone(&child_slot);
+    let conn_thread = Arc::clone(&conn);
+    let frame_len = (width as usize) * (height as usize) * 4;
+
+    let thread = std::thread::spawn(move || {
+        let mut child = match spawn_ffmpeg_camera_capture(&device, width, height, fps, true)
+            .or_else(|_| spawn_ffmpeg_camera_capture(&device, width, height, fps, false))
+        {
+            Ok(child) => child,
+            Err(err) => {
+                log::warn!("{LOG} failed to start ffmpeg camera capture: {err}");
+                let _ = conn_thread.unpublish_camera_video();
+                return;
+            }
+        };
+
+        let mut stdout = match child.stdout.take() {
+            Some(stdout) => stdout,
+            None => {
+                log::warn!("{LOG} ffmpeg camera capture had no stdout");
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = conn_thread.unpublish_camera_video();
+                return;
+            }
+        };
+
+        if let Ok(mut slot) = child_thread.lock() {
+            *slot = Some(child);
+        }
+
+        let mut frame = vec![0u8; frame_len];
+        while active_thread.load(Ordering::Relaxed) {
+            if let Err(err) = stdout.read_exact(&mut frame) {
+                if active_thread.load(Ordering::Relaxed) {
+                    log::warn!("{LOG} camera frame read failed: {err}");
+                }
+                break;
+            }
+
+            let rgba = frame.clone();
+            let seq = local_seq.fetch_add(1, Ordering::Relaxed) + 1;
+            if let Ok(mut latest) = local_frame.lock() {
+                *latest = Some(LatestRemoteScreenShareFrame {
+                    data: Arc::new(rgba.clone()),
+                    width,
+                    height,
+                    seq,
+                });
+            }
+            if let Err(err) = conn_thread.feed_camera_frame(&rgba, width, height) {
+                log::warn!("{LOG} feed_camera_frame failed: {err}");
+                break;
+            }
+        }
+
+        if let Ok(mut slot) = child_thread.lock() {
+            if let Some(mut child) = slot.take() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+        }
+        let _ = conn_thread.unpublish_camera_video();
+    });
+
+    *state
+        .local_camera_capture
+        .lock()
+        .map_err(|e| format!("local_camera_capture lock: {e}"))? = Some(LocalCameraCapture {
+        active,
+        child: child_slot,
+        thread: Some(thread),
+    });
+
+    log::info!("{LOG} linux camera capture started");
+    Ok(())
+}
+
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_camera_start(
+    _device_id: Option<String>,
+    _width: u32,
+    _height: u32,
+    _fps: u32,
+) -> Result<(), String> {
+    Err("native camera capture is only available on Linux".to_string())
+}
+
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_camera_stop(state: State<'_, MediaState>) -> Result<(), String> {
+    let capture = {
+        let mut guard = state
+            .local_camera_capture
+            .lock()
+            .map_err(|e| format!("local_camera_capture lock: {e}"))?;
+        guard.take()
+    };
+    if let Some(capture) = capture {
+        capture.stop();
+    } else if let Ok(lk_guard) = state.lk.lock() {
+        if let Some(conn) = lk_guard.as_ref() {
+            let _ = state
+                .runtime
+                .block_on(async { conn.unpublish_camera_video() });
+        }
+    }
+    if let Ok(mut frame) = state.local_camera_frame.lock() {
+        *frame = None;
+    }
+    Ok(())
+}
+
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_camera_stop() -> Result<(), String> {
     Ok(())
 }
 
@@ -1526,9 +1909,9 @@ pub fn screen_share_start_source(
 
     // Route to GDI or WGC capture backend.
     let capture: Box<dyn ScreenCapture> = if compatibility_mode.unwrap_or(false) {
-        let handle_val: isize = source_id.parse().map_err(|_| {
-            format!("compatibility mode: invalid source id '{source_id}'")
-        })?;
+        let handle_val: isize = source_id
+            .parse()
+            .map_err(|_| format!("compatibility mode: invalid source id '{source_id}'"))?;
         let hwnd = windows::Win32::Foundation::HWND(handle_val as *mut _);
         log::info!("{LOG} compatibility mode: using GDI capture for source {source_id}");
         Box::new(
@@ -1900,6 +2283,125 @@ pub fn media_poll_screen_share_frame(
     }))
 }
 
+/// Poll the latest remote camera frame for a participant (Linux native path).
+///
+/// Camera frames are decoded in Rust from LiveKit Camera tracks and exposed as
+/// JPEGs so the webview can paint them to a canvas-backed MediaStreamTrack.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_poll_camera_frame(
+    identity: String,
+    last_seq: Option<u64>,
+    state: State<'_, MediaState>,
+) -> Result<Option<PolledCameraFrame>, String> {
+    use base64::Engine;
+    use image::codecs::jpeg::JpegEncoder;
+    use std::io::Cursor;
+
+    let latest = {
+        let frames = state
+            .remote_camera_frames
+            .lock()
+            .map_err(|e| format!("remote_camera_frames lock: {e}"))?;
+        frames.get(&identity).cloned()
+    };
+
+    let Some(latest) = latest else {
+        return Ok(None);
+    };
+
+    if last_seq == Some(latest.seq) {
+        return Ok(None);
+    }
+
+    let pixel_count = (latest.width * latest.height) as usize;
+    let mut rgb_data = Vec::with_capacity(pixel_count * 3);
+    for rgba in latest.data.chunks_exact(4) {
+        rgb_data.push(rgba[0]);
+        rgb_data.push(rgba[1]);
+        rgb_data.push(rgba[2]);
+    }
+
+    let jpeg_quality = state.screen_share_config.jpeg_quality();
+    let mut jpeg_buf = Cursor::new(Vec::with_capacity(128 * 1024));
+    let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buf, jpeg_quality);
+    if let Err(e) = encoder.encode(
+        &rgb_data,
+        latest.width,
+        latest.height,
+        image::ExtendedColorType::Rgb8,
+    ) {
+        log::warn!("{LOG} remote camera JPEG encode failed: {e}");
+        return Ok(None);
+    }
+
+    let frame = base64::engine::general_purpose::STANDARD.encode(jpeg_buf.into_inner());
+    Ok(Some(PolledCameraFrame {
+        identity,
+        frame,
+        width: latest.width,
+        height: latest.height,
+        seq: latest.seq,
+    }))
+}
+
+/// Poll the latest local camera preview frame for Linux native publishing.
+#[tauri::command]
+#[cfg(target_os = "linux")]
+pub fn media_poll_local_camera_frame(
+    last_seq: Option<u64>,
+    state: State<'_, MediaState>,
+) -> Result<Option<PolledCameraFrame>, String> {
+    use base64::Engine;
+    use image::codecs::jpeg::JpegEncoder;
+    use std::io::Cursor;
+
+    let latest = {
+        let frame = state
+            .local_camera_frame
+            .lock()
+            .map_err(|e| format!("local_camera_frame lock: {e}"))?;
+        frame.clone()
+    };
+
+    let Some(latest) = latest else {
+        return Ok(None);
+    };
+
+    if last_seq == Some(latest.seq) {
+        return Ok(None);
+    }
+
+    let pixel_count = (latest.width * latest.height) as usize;
+    let mut rgb_data = Vec::with_capacity(pixel_count * 3);
+    for rgba in latest.data.chunks_exact(4) {
+        rgb_data.push(rgba[0]);
+        rgb_data.push(rgba[1]);
+        rgb_data.push(rgba[2]);
+    }
+
+    let mut jpeg_buf = Cursor::new(Vec::with_capacity(128 * 1024));
+    let mut encoder = JpegEncoder::new_with_quality(&mut jpeg_buf, 80);
+    if let Err(e) = encoder.encode(
+        &rgb_data,
+        latest.width,
+        latest.height,
+        image::ExtendedColorType::Rgb8,
+    ) {
+        log::warn!("{LOG} local camera JPEG encode failed: {e}");
+        return Ok(None);
+    }
+
+    let frame = base64::engine::general_purpose::STANDARD.encode(jpeg_buf.into_inner());
+    Ok(Some(PolledCameraFrame {
+        identity: "self".to_string(),
+        frame,
+        width: latest.width,
+        height: latest.height,
+        seq: latest.seq,
+    }))
+}
+
 /// Non-Linux stub for `media_poll_screen_share_frame`.
 #[tauri::command]
 #[cfg(not(target_os = "linux"))]
@@ -1907,6 +2409,25 @@ pub fn media_poll_screen_share_frame(
     _identity: String,
     _last_seq: Option<u64>,
 ) -> Result<Option<()>, String> {
+    Ok(None)
+}
+
+/// Non-Linux stub for `media_poll_camera_frame`.
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_poll_camera_frame(
+    _identity: String,
+    _last_seq: Option<u64>,
+) -> Result<Option<serde_json::Value>, String> {
+    Ok(None)
+}
+
+/// Non-Linux stub for `media_poll_local_camera_frame`.
+#[tauri::command]
+#[cfg(not(target_os = "linux"))]
+pub fn media_poll_local_camera_frame(
+    _last_seq: Option<u64>,
+) -> Result<Option<serde_json::Value>, String> {
     Ok(None)
 }
 
@@ -1943,7 +2464,10 @@ fn native_share_viewer_path() -> Result<std::path::PathBuf, String> {
     if viewer.exists() {
         Ok(viewer)
     } else {
-        Err(format!("native_share_viewer not found at {}", viewer.display()))
+        Err(format!(
+            "native_share_viewer not found at {}",
+            viewer.display()
+        ))
     }
 }
 

--- a/clients/wavis-gui/src/features/settings/__tests__/Settings-camera.test.ts
+++ b/clients/wavis-gui/src/features/settings/__tests__/Settings-camera.test.ts
@@ -30,22 +30,32 @@ describe('Feature: video-feed — Settings camera section', () => {
     expect(devices.map((d, i) => cameraOptionLabel(d, i))).toEqual([]);
   });
 
-  describe('Linux / unsupported platform gate (6.10)', () => {
-    it('supportedCapturePlatform is false on Linux user agent', () => {
+  describe('Linux / platform gate (6.10)', () => {
+    it('supportedCapturePlatform is true on Linux user agent so the UI can surface native limitations', () => {
       const linuxUa = 'Mozilla/5.0 (X11; Linux x86_64)';
-      const supported = /Windows|Macintosh/.test(linuxUa);
-      expect(supported).toBe(false);
+      const hasBrowserCameraMedia = false;
+      const supported =
+        /Windows|Macintosh/.test(linuxUa) || /Linux/.test(linuxUa) || hasBrowserCameraMedia;
+      expect(supported).toBe(true);
+    });
+
+    it('supportedCapturePlatform is true on Linux user agent with browser camera media', () => {
+      const linuxUa = 'Mozilla/5.0 (X11; Linux x86_64)';
+      const hasBrowserCameraMedia = true;
+      const supported =
+        /Windows|Macintosh/.test(linuxUa) || /Linux/.test(linuxUa) || hasBrowserCameraMedia;
+      expect(supported).toBe(true);
     });
 
     it('supportedCapturePlatform is true on Windows user agent', () => {
       const windowsUa = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)';
-      const supported = /Windows|Macintosh/.test(windowsUa);
+      const supported = /Windows|Macintosh/.test(windowsUa) || /Linux/.test(windowsUa) || false;
       expect(supported).toBe(true);
     });
 
     it('supportedCapturePlatform is true on macOS user agent', () => {
       const macUa = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)';
-      const supported = /Windows|Macintosh/.test(macUa);
+      const supported = /Windows|Macintosh/.test(macUa) || /Linux/.test(macUa) || false;
       expect(supported).toBe(true);
     });
   });

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -96,7 +96,7 @@ import { sendWavisNotification } from '@shared/notification-bridge';
 import Settings from '@features/settings/Settings';
 import { useAudioDriverInstall } from '@features/screen-share/useAudioDriverInstall';
 import { AudioDriverInstallPrompt } from '@features/screen-share/AudioDriverInstallPrompt';
-import { cameraButtonLabel, shouldMountCameraButton } from './active-room-camera';
+import { cameraButtonLabel, hasBrowserCameraMediaSupport, shouldMountCameraButton } from './active-room-camera';
 import { selectRoomPanelTab } from './voice-room';
 import { VideoTab } from './VideoTab';
 import type { VideoTileSnapshot, VideoTileViewModel } from './camera-types';
@@ -1814,7 +1814,7 @@ export default function ActiveRoom() {
   const isLinuxPlatform = typeof navigator !== 'undefined' && /Linux/.test(navigator.userAgent);
   const isMacPlatform = typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent);
   const isWindowsPlatform = typeof navigator !== 'undefined' && /Windows/.test(navigator.userAgent);
-  const supportedCapturePlatform = isWindowsPlatform || isMacPlatform;
+  const supportedCapturePlatform = isWindowsPlatform || isMacPlatform || isLinuxPlatform || hasBrowserCameraMediaSupport();
   const macShareAudioDisabledMessage =
     'System audio on macOS requires the WavisAudioTap driver — stop sharing and restart to enable audio.';
 

--- a/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
+++ b/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { emit, listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { computeGridLayout } from '@features/screen-share/watch-all-grid';
@@ -10,6 +11,13 @@ interface VideoPopoutParams {
 }
 
 const TITLE_BAR_HEIGHT = 32;
+
+interface PolledCameraFrame {
+  frame: string;
+  width: number;
+  height: number;
+  seq: number;
+}
 
 function parseHashParams(): VideoPopoutParams | null {
   try {
@@ -23,9 +31,11 @@ function parseHashParams(): VideoPopoutParams | null {
 
 function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
   const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const receiverRef = useRef<StreamReceiver | null>(null);
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [receiverError, setReceiverError] = useState(false);
+  const [nativeFallbackActive, setNativeFallbackActive] = useState(false);
   const shouldReceive = tile.hasTrack && !tile.isMuted && !tile.hasError;
 
   useEffect(() => {
@@ -36,6 +46,7 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
       receiverRef.current = null;
       setStream(null);
       setReceiverError(false);
+      setNativeFallbackActive(false);
       return;
     }
 
@@ -53,6 +64,7 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
         if (cancelled) return;
         setStream(null);
         setReceiverError(true);
+        setNativeFallbackActive(true);
       });
 
     return () => {
@@ -78,7 +90,61 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
     };
   }, [stream]);
 
+  useEffect(() => {
+    if (!shouldReceive || !nativeFallbackActive) return;
+
+    let stopped = false;
+    let lastSeq: number | null = null;
+    let busy = false;
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d') ?? null;
+    if (!canvas || !ctx) return;
+
+    const paintPayload = (payload: PolledCameraFrame) => {
+      if (canvas.width !== payload.width || canvas.height !== payload.height) {
+        canvas.width = payload.width;
+        canvas.height = payload.height;
+      }
+      const image = new Image();
+      image.onload = () => {
+        if (stopped || lastSeq !== payload.seq) return;
+        ctx.drawImage(image, 0, 0, payload.width, payload.height);
+      };
+      image.src = `data:image/jpeg;base64,${payload.frame}`;
+    };
+
+    const poll = () => {
+      if (stopped || busy) return;
+      busy = true;
+      const command = tile.isSelf ? 'media_poll_local_camera_frame' : 'media_poll_camera_frame';
+      const args = tile.isSelf
+        ? { lastSeq }
+        : { identity: tile.participantId, lastSeq };
+      invoke<PolledCameraFrame | null>(command, args)
+        .then((payload) => {
+          if (!payload || stopped) return;
+          lastSeq = payload.seq;
+          paintPayload(payload);
+        })
+        .catch(() => {
+          // Keep the placeholder visible; the bridge may reconnect or the next
+          // popout sync can replace this fallback.
+        })
+        .finally(() => {
+          busy = false;
+        });
+    };
+
+    const id = setInterval(poll, 66);
+    poll();
+    return () => {
+      stopped = true;
+      clearInterval(id);
+    };
+  }, [nativeFallbackActive, shouldReceive, tile.isSelf, tile.participantId]);
+
   const showVideo = shouldReceive && stream && !receiverError;
+  const showNativeFallback = shouldReceive && nativeFallbackActive;
 
   return (
     <div className="relative overflow-hidden bg-wavis-panel" style={{ width: '100%', height: '100%' }}>
@@ -88,6 +154,16 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
           autoPlay
           playsInline
           muted={tile.isSelf}
+          style={{
+            width: '100%',
+            height: '100%',
+            objectFit: 'contain',
+            ...(tile.isSelf ? { transform: 'scaleX(-1)' } : {}),
+          }}
+        />
+      ) : showNativeFallback ? (
+        <canvas
+          ref={canvasRef}
           style={{
             width: '100%',
             height: '100%',
@@ -119,7 +195,7 @@ function VideoPopoutTile({ tile }: { tile: VideoTileSnapshot }) {
           muted
         </div>
       )}
-      {(tile.hasError || receiverError) && (
+      {(tile.hasError || (receiverError && !nativeFallbackActive)) && (
         <div
           className="absolute top-1 left-1 text-[10px] px-1 rounded"
           style={{ background: 'rgba(0,0,0,0.65)', color: 'var(--wavis-danger)' }}

--- a/clients/wavis-gui/src/features/voice/__tests__/active-room-camera.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/active-room-camera.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { cameraButtonLabel, shouldMountCameraButton } from '../active-room-camera';
+import { cameraButtonLabel, hasBrowserCameraMediaSupport, shouldMountCameraButton } from '../active-room-camera';
 
 /* ─── Button ordering logic ─────────────────────────────────────── */
 
@@ -32,6 +32,35 @@ describe('Feature: video-feed — button stays mounted during media reconnect (R
 
   it('shouldMountCameraButton is false when voice room is not connected', () => {
     expect(shouldMountCameraButton(false, true)).toBe(false);
+  });
+});
+
+describe('Feature: video-feed — Linux browser media support', () => {
+  it('detects RTCPeerConnection + getUserMedia as camera-capable browser media', () => {
+    const originalWindow = globalThis.window;
+    const originalNavigator = globalThis.navigator;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { RTCPeerConnection: function RTCPeerConnection() {} },
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: { mediaDevices: { getUserMedia: async () => ({}) } },
+    });
+
+    try {
+      expect(hasBrowserCameraMediaSupport()).toBe(true);
+    } finally {
+      Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: originalWindow,
+      });
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        value: originalNavigator,
+      });
+    }
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/active-room-camera.ts
+++ b/clients/wavis-gui/src/features/voice/active-room-camera.ts
@@ -8,3 +8,12 @@ export function shouldMountCameraButton(
 ): boolean {
   return voiceRoomConnected && supportedCapturePlatform;
 }
+
+export function hasBrowserCameraMediaSupport(): boolean {
+  return typeof window !== 'undefined'
+    && typeof navigator !== 'undefined'
+    && 'RTCPeerConnection' in window
+    && 'mediaDevices' in navigator
+    && navigator.mediaDevices !== undefined
+    && typeof navigator.mediaDevices.getUserMedia === 'function';
+}

--- a/clients/wavis-gui/src/features/voice/native-media.ts
+++ b/clients/wavis-gui/src/features/voice/native-media.ts
@@ -10,6 +10,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { MediaCallbacks } from './livekit-media';
+import type { CameraQuality } from './camera-types';
 import { getDenoiseEnabled, inputVolumeToGain } from '@features/settings/settings-store';
 
 const LOG = '[wavis:native-media]';
@@ -28,12 +29,36 @@ interface ScreenShareEndedPayload {
   identity: string;
 }
 
+interface CameraAvailablePayload {
+  identity: string;
+}
+
+interface CameraEndedPayload {
+  identity: string;
+}
+
+interface PolledCameraFrame {
+  identity: string;
+  frame: string;
+  width: number;
+  height: number;
+  seq: number;
+}
+
 /* ─── Active Share Tracking ─────────────────────────────────────── */
 
 interface ActiveShareEntry {
   stream: MediaStream | null;
   canvas: HTMLCanvasElement | null;
   startedAtMs: number;
+}
+
+interface ActiveCameraEntry {
+  stream: MediaStream;
+  canvas: HTMLCanvasElement;
+  context: CanvasRenderingContext2D;
+  pollInterval: ReturnType<typeof setInterval> | null;
+  lastSeq: number | null;
 }
 
 export type ActiveShareInfo = {
@@ -101,8 +126,13 @@ export class NativeMediaModule {
   private unlistenFrame: UnlistenFn | null = null;
   private unlistenAvailable: UnlistenFn | null = null;
   private unlistenEnded: UnlistenFn | null = null;
+  private unlistenCameraAvailable: UnlistenFn | null = null;
+  private unlistenCameraEnded: UnlistenFn | null = null;
   private disposed = false;
   private activeShares = new Map<string, ActiveShareEntry>();
+  private activeCameras = new Map<string, ActiveCameraEntry>();
+  private localCamera: ActiveCameraEntry | null = null;
+  private localCameraTrack: MediaStreamTrack | null = null;
 
   constructor(callbacks: MediaCallbacks) {
     this.callbacks = callbacks;
@@ -196,7 +226,20 @@ export class NativeMediaModule {
       this.handleScreenShareEnded(event.payload.identity);
     });
 
-    // 5. Tell Rust to connect
+    // 5. Subscribe to remote camera availability events. The Rust native
+    // LiveKit path decodes camera frames, and this module paints them into a
+    // canvas-backed MediaStreamTrack so the existing VideoTile UI can render.
+    this.unlistenCameraAvailable = await listen<CameraAvailablePayload>('camera_available', (event) => {
+      if (this.disposed) return;
+      this.handleCameraAvailable(event.payload.identity);
+    });
+
+    this.unlistenCameraEnded = await listen<CameraEndedPayload>('camera_ended', (event) => {
+      if (this.disposed) return;
+      this.handleCameraEnded(event.payload.identity);
+    });
+
+    // 6. Tell Rust to connect
     try {
       const denoiseEnabled = await getDenoiseEnabled();
       await invoke('media_connect', { url: sfuUrl, token, denoiseEnabled });
@@ -217,11 +260,17 @@ export class NativeMediaModule {
     if (this.unlistenFrame) { this.unlistenFrame(); this.unlistenFrame = null; }
     if (this.unlistenAvailable) { this.unlistenAvailable(); this.unlistenAvailable = null; }
     if (this.unlistenEnded) { this.unlistenEnded(); this.unlistenEnded = null; }
+    if (this.unlistenCameraAvailable) { this.unlistenCameraAvailable(); this.unlistenCameraAvailable = null; }
+    if (this.unlistenCameraEnded) { this.unlistenCameraEnded(); this.unlistenCameraEnded = null; }
 
     // Clean up all active shares
     for (const identity of [...this.activeShares.keys()]) {
       this.disposeShareEntry(identity);
     }
+    for (const identity of [...this.activeCameras.keys()]) {
+      this.disposeCameraEntry(identity);
+    }
+    this.disposeLocalCameraEntry();
 
     invoke('media_disconnect').catch((err) => {
       console.warn(LOG, 'disconnect error:', err);
@@ -341,6 +390,75 @@ export class NativeMediaModule {
     await invoke('set_input_gain', { gain: inputVolumeToGain(volume) });
   }
 
+  async publishCamera(opts: {
+    deviceId: string | null;
+    quality: CameraQuality;
+  }): Promise<{ trackId: string }> {
+    const entry = this.createCameraCanvasEntry('local');
+    if (!entry) {
+      throw { kind: 'device_unavailable' };
+    }
+
+    const track = entry.stream.getVideoTracks()[0] ?? null;
+    if (!track) {
+      this.disposeCameraCanvasEntry(entry);
+      throw { kind: 'device_unavailable' };
+    }
+
+    try {
+      await invoke('media_camera_start', {
+        deviceId: opts.deviceId,
+        width: opts.quality.width,
+        height: opts.quality.height,
+        fps: opts.quality.maxFps,
+      });
+    } catch (err) {
+      this.disposeCameraCanvasEntry(entry);
+      throw this.classifyNativeCameraError(err);
+    }
+
+    this.localCamera = entry;
+    this.localCameraTrack = track;
+    entry.pollInterval = setInterval(() => {
+      void this.pollLocalCameraFrame();
+    }, 66);
+    void this.pollLocalCameraFrame();
+    return { trackId: 'native-linux-camera' };
+  }
+
+  async unpublishCamera(): Promise<void> {
+    await invoke('media_camera_stop').catch(() => {});
+    this.disposeLocalCameraEntry();
+  }
+
+  getLocalCameraTrack(): MediaStreamTrack | null {
+    return this.localCameraTrack;
+  }
+
+  applyRemoteCameraVisibility(_visibleParticipantIds: ReadonlySet<string>): void {
+    // Native Rust LiveKit subscribes to remote tracks itself. Visibility is
+    // enforced in voice-room by deciding which canvas-backed tracks are exposed.
+  }
+
+  async setCameraQuality(_quality: CameraQuality): Promise<void> {
+    // The ffmpeg/v4l2 native path is fixed at publish time for now.
+  }
+
+  async replaceCameraDevice(deviceId: string | null): Promise<{ trackId: string }> {
+    await this.unpublishCamera();
+    return this.publishCamera({
+      deviceId,
+      quality: {
+        tier: 'low',
+        width: 320,
+        height: 240,
+        maxFps: 15,
+        maxBitrate: 120_000,
+        codec: 'vp8',
+      },
+    });
+  }
+
   /** Return active remote screen shares. */
   getActiveScreenShares(): ActiveShareInfo[] {
     const result: ActiveShareInfo[] = [];
@@ -405,5 +523,152 @@ export class NativeMediaModule {
     }
 
     this.activeShares.delete(identity);
+  }
+
+  private handleCameraAvailable(identity: string): void {
+    if (this.activeCameras.has(identity)) return;
+    const entry = this.createCameraCanvasEntry(identity);
+    const track = entry?.stream.getVideoTracks()[0] ?? null;
+    if (!entry || !track) {
+      console.warn(LOG, `remote camera unavailable: canvas captureStream unsupported for ${identity}`);
+      return;
+    }
+    entry.pollInterval = setInterval(() => {
+      void this.pollCameraFrame(identity);
+    }, 66);
+    this.activeCameras.set(identity, entry);
+
+    console.log(LOG, `camera available (native viewer path): ${identity}`);
+    this.callbacks.onRemoteCameraPublished?.(identity);
+    this.callbacks.onRemoteCameraReady?.(identity, track);
+    void this.pollCameraFrame(identity);
+  }
+
+  private handleCameraEnded(identity: string): void {
+    console.log(LOG, `camera ended: ${identity}`);
+    this.disposeCameraEntry(identity);
+    this.callbacks.onRemoteCameraUnpublished?.(identity);
+  }
+
+  private async pollCameraFrame(identity: string): Promise<void> {
+    if (this.disposed) return;
+    const entry = this.activeCameras.get(identity);
+    if (!entry) return;
+
+    let payload: PolledCameraFrame | null = null;
+    try {
+      payload = await invoke<PolledCameraFrame | null>('media_poll_camera_frame', {
+        identity,
+        lastSeq: entry.lastSeq,
+      });
+    } catch (err) {
+      console.warn(LOG, `camera frame poll failed for ${identity}:`, err);
+      return;
+    }
+    if (!payload || payload.seq === entry.lastSeq) return;
+    this.paintCameraPayload(entry, payload);
+  }
+
+  private async pollLocalCameraFrame(): Promise<void> {
+    if (this.disposed || !this.localCamera) return;
+    const entry = this.localCamera;
+    let payload: PolledCameraFrame | null = null;
+    try {
+      payload = await invoke<PolledCameraFrame | null>('media_poll_local_camera_frame', {
+        lastSeq: entry.lastSeq,
+      });
+    } catch (err) {
+      console.warn(LOG, 'local camera frame poll failed:', err);
+      return;
+    }
+    if (!payload || payload.seq === entry.lastSeq) return;
+    this.paintCameraPayload(entry, payload);
+  }
+
+  private createCameraCanvasEntry(_identity: string): ActiveCameraEntry | null {
+    if (typeof document === 'undefined') return null;
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 320;
+    canvas.height = 240;
+    canvas.style.cssText = 'position:fixed;top:-9999px;left:-9999px;width:1px;height:1px;pointer-events:none;opacity:0;';
+    const context = canvas.getContext('2d');
+    const stream = typeof canvas.captureStream === 'function'
+      ? canvas.captureStream(15)
+      : null;
+    if (!context || !stream || stream.getVideoTracks().length === 0) {
+      return null;
+    }
+    document.body.appendChild(canvas);
+    context.fillStyle = '#11111f';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    return {
+      stream,
+      canvas,
+      context,
+      pollInterval: null,
+      lastSeq: null,
+    };
+  }
+
+  private paintCameraPayload(entry: ActiveCameraEntry, payload: PolledCameraFrame): void {
+    entry.lastSeq = payload.seq;
+    if (entry.canvas.width !== payload.width || entry.canvas.height !== payload.height) {
+      entry.canvas.width = payload.width;
+      entry.canvas.height = payload.height;
+    }
+
+    const image = new Image();
+    image.onload = () => {
+      if (entry.lastSeq !== payload.seq) return;
+      entry.context.drawImage(image, 0, 0, payload.width, payload.height);
+    };
+    image.src = `data:image/jpeg;base64,${payload.frame}`;
+  }
+
+  private disposeCameraEntry(identity: string): void {
+    const entry = this.activeCameras.get(identity);
+    if (!entry) return;
+
+    if (entry.pollInterval) clearInterval(entry.pollInterval);
+    for (const track of entry.stream.getTracks()) {
+      track.stop();
+    }
+    if (entry.canvas.parentNode) {
+      entry.canvas.parentNode.removeChild(entry.canvas);
+    }
+    this.activeCameras.delete(identity);
+  }
+
+  private disposeLocalCameraEntry(): void {
+    if (this.localCamera) {
+      this.disposeCameraCanvasEntry(this.localCamera);
+    }
+    this.localCamera = null;
+    this.localCameraTrack = null;
+  }
+
+  private disposeCameraCanvasEntry(entry: ActiveCameraEntry): void {
+    if (entry.pollInterval) clearInterval(entry.pollInterval);
+    for (const track of entry.stream.getTracks()) {
+      track.stop();
+    }
+    if (entry.canvas.parentNode) {
+      entry.canvas.parentNode.removeChild(entry.canvas);
+    }
+  }
+
+  private classifyNativeCameraError(err: unknown): { kind: string } {
+    const message = String(err ?? '').toLowerCase();
+    if (message.includes('no camera') || message.includes('/dev/video')) {
+      return { kind: 'no_camera_configured' };
+    }
+    if (message.includes('permission') || message.includes('denied')) {
+      return { kind: 'permission_denied' };
+    }
+    if (message.includes('busy') || message.includes('in use')) {
+      return { kind: 'device_in_use' };
+    }
+    return { kind: 'device_unavailable' };
   }
 }

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1154,8 +1154,9 @@ function startAutoSwitchPoll(): () => void {
 /**
  * Platform detection: use the native Rust media path when the webview
  * lacks usable WebRTC support. Do not force Linux into the native path:
- * some Linux/Tauri environments expose working WebRTC + getDisplayMedia,
- * and that path is more stable than the Rust PipeWire backend on Hyprland.
+ * some Linux/Tauri environments expose working WebRTC + getUserMedia even
+ * when getDisplayMedia is absent. Camera publish/receive only needs those
+ * browser media APIs; Linux screen sharing still has the native portal path.
  */
 function shouldUseNativeMedia(): boolean {
   if (typeof window === 'undefined' || typeof navigator === 'undefined') return true;
@@ -1171,12 +1172,8 @@ function shouldUseNativeMedia(): boolean {
     'mediaDevices' in navigator &&
     navigator.mediaDevices !== undefined &&
     typeof navigator.mediaDevices.getUserMedia === 'function';
-  const hasGetDisplayMedia =
-    'mediaDevices' in navigator &&
-    navigator.mediaDevices !== undefined &&
-    typeof navigator.mediaDevices.getDisplayMedia === 'function';
 
-  return !(hasRtc && hasGetUserMedia && hasGetDisplayMedia);
+  return !(hasRtc && hasGetUserMedia);
 }
 
 function isWindowsPlatform(): boolean {
@@ -1627,8 +1624,8 @@ function notify(): void {
   }
 }
 
-function getCameraMediaModule(): LiveKitModule | null {
-  return lkModule instanceof LiveKitModule ? lkModule : null;
+function getCameraMediaModule(): MediaModule | null {
+  return lkModule;
 }
 
 function resetCameraQualityController(): void {
@@ -2117,7 +2114,7 @@ export async function applyCameraQualityForShareState(): Promise<void> {
 
 async function publishLocalCamera(): Promise<void> {
   const cameraModule = getCameraMediaModule();
-  if (!cameraModule || !(isWindowsPlatform() || isMacPlatform())) {
+  if (!cameraModule) {
     state.cameraIntent = false;
     state.cameraPublication = 'idle';
     rebuildVideoTiles();
@@ -2125,11 +2122,15 @@ async function publishLocalCamera(): Promise<void> {
     return;
   }
 
-  const selectedDeviceId = await getVideoInputDevice();
+  const selectedDeviceId = isLinuxPlatform() && cameraModule instanceof NativeMediaModule
+    ? null
+    : await getVideoInputDevice();
   state.cameraSelectedDeviceId = selectedDeviceId;
 
   try {
-    const { effectiveDeviceId, warning } = await resolveCameraDeviceSelection(selectedDeviceId);
+    const { effectiveDeviceId, warning } = isLinuxPlatform() && cameraModule instanceof NativeMediaModule
+      ? { effectiveDeviceId: null, warning: null }
+      : await resolveCameraDeviceSelection(selectedDeviceId);
     if (warning) {
       surfaceCameraWarning(warning);
     }
@@ -2188,10 +2189,11 @@ async function restorePublishedCameraAfterReconnect(): Promise<void> {
 }
 
 export async function toggleCameraIntent(): Promise<void> {
-  if (!(isWindowsPlatform() || isMacPlatform())) {
-    return;
-  }
-  if (!lkModule || state.mediaState === 'disconnected' || state.mediaState === 'failed') {
+  if (
+    !getCameraMediaModule()
+    || state.mediaState === 'disconnected'
+    || state.mediaState === 'failed'
+  ) {
     return;
   }
 
@@ -2200,7 +2202,11 @@ export async function toggleCameraIntent(): Promise<void> {
   cameraToggleChain = cameraToggleChain.then(async () => {
     // Re-check lkModule and mediaState inside the chain — state may have
     // changed while we were waiting for the previous toggle to finish.
-    if (!lkModule || state.mediaState === 'disconnected' || state.mediaState === 'failed') {
+    if (
+      !getCameraMediaModule()
+      || state.mediaState === 'disconnected'
+      || state.mediaState === 'failed'
+    ) {
       return;
     }
 


### PR DESCRIPTION
 ## Description

  Adds Linux native camera support for the Wavis desktop app and fixes camera video rendering paths that were missing or broken outside Windows.

  This PR enables Linux users to publish camera video, see local camera preview, receive remote camera video tracks, and view camera streams in the popout window. The Linux implementation uses native Tauri/Rust media commands with `ffmpeg`/V4L2 capture, feeds camera frames into LiveKit as camera tracks, and bridges local/remote frames back to the React UI.

  It also fixes Linux-specific camera frame normalization so captured video does not appear to scroll/roll vertically.

  ## Type of Change

  - [x] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Dependency update
  - [ ] Documentation / config only

  ---

  ## Security Checklist

  > Complete this section for any PR that touches signaling or token paths:
  > `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
  > `domain/sfu_relay.rs`, `handlers/ws.rs`

  If this PR does **not** touch any of those files, check this box and skip the rest:
  - [x] This PR does not touch signaling or token paths — checklist not applicable

  ---

  ## Tests

  - [x] `cargo test -p wavis-backend` passes
  - [x] New property tests added for any new correctness properties
  - [x] No tests were deleted or disabled to make the build pass

  Additional checks run:

  - [x] `cargo test --workspace` passes
  - [x] `npm test` passes
  - [x] `npm run build` passes

  Note: I did not add new property tests because this change is mainly platform/media integration and UI bridge behavior, not a new domain correctness property.