### PR TITLE
feat: implement global panic hook for crash reporting (#242)

### DIFF
--- a/clients/wavis-gui/src-tauri/src/crash_handler.rs
+++ b/clients/wavis-gui/src-tauri/src/crash_handler.rs
@@ -1,0 +1,104 @@
+//! Global panic hook for Wavis — captures backtraces and logs on crash.
+//!
+//! When a Rust panic occurs, this hook writes a `crash-report.txt` file
+//! containing the panic message, location, backtrace, and a snapshot of
+//! the recent in-memory logs.
+
+use std::panic;
+use std::fs;
+use std::sync::Mutex;
+use crate::bug_report::SharedLogBuffer;
+
+/// Shared state for the crash handler to access the AppHandle lazily.
+/// Panics can happen before the app is fully initialized.
+static APP_HANDLE: Mutex<Option<tauri::AppHandle>> = Mutex::new(None);
+
+/// Register the global AppHandle so the crash handler can resolve app-specific paths.
+pub fn register_app_handle(app: tauri::AppHandle) {
+    if let Ok(mut guard) = APP_HANDLE.lock() {
+        *guard = Some(app);
+    }
+}
+
+/// Install the global panic hook.
+pub fn install(log_buffer: SharedLogBuffer) {
+    panic::set_hook(Box::new(move |panic_info| {
+        let message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+            s.to_string()
+        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "Unknown panic message".to_string()
+        };
+
+        let location = panic_info.location().map(|loc| {
+            format!("{}:{}:{}", loc.file(), loc.line(), loc.column())
+        }).unwrap_or_else(|| "Unknown location".to_string());
+
+        let backtrace = std::backtrace::Backtrace::capture();
+        
+        let mut report = String::new();
+        report.push_str("Wavis Crash Report\n");
+        report.push_str("==================\n\n");
+        report.push_str(&format!("Message: {}\n", message));
+        report.push_str(&format!("Location: {}\n\n", location));
+        report.push_str("Backtrace:\n");
+        report.push_str("----------\n");
+        report.push_str(&format!("{:?}\n\n", backtrace));
+
+        // Get log snapshot if possible
+        if let Ok(buffer) = log_buffer.lock() {
+            report.push_str("Recent Logs:\n");
+            report.push_str("------------\n");
+            for line in buffer.snapshot() {
+                report.push_str(&line);
+                report.push_str("\n");
+            }
+            report.push_str("\n");
+        }
+
+        // Collect potential paths to write the report to
+        let mut paths = Vec::new();
+
+        // 1. Try App Data directory if AppHandle is available
+        if let Ok(guard) = APP_HANDLE.lock() {
+            if let Some(app) = &*guard {
+                use tauri::Manager;
+                if let Ok(data_dir) = app.path().app_data_dir() {
+                    paths.push(data_dir.join("crash-report.txt"));
+                }
+            }
+        }
+
+        // 2. Try Current Working Directory
+        if let Ok(cwd) = std::env::current_dir() {
+            paths.push(cwd.join("crash-report.txt"));
+        }
+
+        // 3. Fallback to a hardcoded temp path if everything else fails
+        #[cfg(target_os = "windows")]
+        paths.push(std::path::PathBuf::from("C:\\Temp\\wavis-crash.txt"));
+        #[cfg(not(target_os = "windows"))]
+        paths.push(std::path::PathBuf::from("/tmp/wavis-crash.txt"));
+
+        let mut saved = false;
+        for path in paths {
+            if let Some(parent) = path.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            if fs::write(&path, &report).is_ok() {
+                eprintln!("wavis: crash report saved to: {}", path.display());
+                saved = true;
+                // Only save to the first successful path
+                break;
+            }
+        }
+
+        if !saved {
+            eprintln!("wavis: failed to save crash report to any known location.");
+        }
+
+        // Also print the crash info to stderr for console visibility
+        eprintln!("wavis: application panicked at {}: {}", location, message);
+    }));
+}

--- a/clients/wavis-gui/src-tauri/src/crash_handler.rs
+++ b/clients/wavis-gui/src-tauri/src/crash_handler.rs
@@ -1,13 +1,23 @@
 //! Global panic hook for Wavis — captures backtraces and logs on crash.
 //!
-//! When a Rust panic occurs, this hook writes a `crash-report.txt` file
-//! containing the panic message, location, backtrace, and a snapshot of
-//! the recent in-memory logs.
+//! When a Rust panic occurs, this hook writes a `crash-report-<unix>.txt`
+//! file containing the timestamp, panic message, location, backtrace, and a
+//! snapshot of the recent in-memory logs.
+//!
+//! `eprintln!` is used intentionally here: the logging infrastructure may
+//! itself be in a broken state at crash time, so stderr is the only safe
+//! output channel.
 
 use std::panic;
 use std::fs;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
 use crate::bug_report::SharedLogBuffer;
+
+/// Guards against the hook firing twice for one crash (WebView2 background-thread
+/// panic causes a second panic on the main event-loop thread ~1s later).
+static REPORT_WRITTEN: AtomicBool = AtomicBool::new(false);
 
 /// Shared state for the crash handler to access the AppHandle lazily.
 /// Panics can happen before the app is fully initialized.
@@ -23,6 +33,11 @@ pub fn register_app_handle(app: tauri::AppHandle) {
 /// Install the global panic hook.
 pub fn install(log_buffer: SharedLogBuffer) {
     panic::set_hook(Box::new(move |panic_info| {
+        // Only write a crash report once per process lifetime.
+        if REPORT_WRITTEN.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
         let message = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
             s.to_string()
         } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
@@ -35,11 +50,16 @@ pub fn install(log_buffer: SharedLogBuffer) {
             format!("{}:{}:{}", loc.file(), loc.line(), loc.column())
         }).unwrap_or_else(|| "Unknown location".to_string());
 
-        let backtrace = std::backtrace::Backtrace::capture();
-        
+        let backtrace = std::backtrace::Backtrace::force_capture();
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
         let mut report = String::new();
         report.push_str("Wavis Crash Report\n");
         report.push_str("==================\n\n");
+        report.push_str(&format!("Timestamp (UTC unix): {}\n", timestamp));
         report.push_str(&format!("Message: {}\n", message));
         report.push_str(&format!("Location: {}\n\n", location));
         report.push_str("Backtrace:\n");
@@ -47,39 +67,45 @@ pub fn install(log_buffer: SharedLogBuffer) {
         report.push_str(&format!("{:?}\n\n", backtrace));
 
         // Get log snapshot if possible
+        report.push_str("Recent Logs:\n");
+        report.push_str("------------\n");
         if let Ok(buffer) = log_buffer.lock() {
-            report.push_str("Recent Logs:\n");
-            report.push_str("------------\n");
-            for line in buffer.snapshot() {
-                report.push_str(&line);
-                report.push_str("\n");
+            let lines = buffer.snapshot();
+            if lines.is_empty() {
+                report.push_str("(no log records captured — crash occurred before any voice/room activity)\n");
+            } else {
+                for line in lines {
+                    report.push_str(&line);
+                    report.push_str("\n");
+                }
             }
-            report.push_str("\n");
+        } else {
+            report.push_str("(log buffer unavailable — mutex poisoned)\n");
         }
+        report.push_str("\n");
 
-        // Collect potential paths to write the report to
+        let filename = format!("crash-report-{}.txt", timestamp);
+
+        // Collect candidate paths in priority order
         let mut paths = Vec::new();
 
-        // 1. Try App Data directory if AppHandle is available
+        // 1. App Data directory (platform-specific, most user-friendly)
         if let Ok(guard) = APP_HANDLE.lock() {
             if let Some(app) = &*guard {
                 use tauri::Manager;
                 if let Ok(data_dir) = app.path().app_data_dir() {
-                    paths.push(data_dir.join("crash-report.txt"));
+                    paths.push(data_dir.join(&filename));
                 }
             }
         }
 
-        // 2. Try Current Working Directory
+        // 2. Current working directory
         if let Ok(cwd) = std::env::current_dir() {
-            paths.push(cwd.join("crash-report.txt"));
+            paths.push(cwd.join(&filename));
         }
 
-        // 3. Fallback to a hardcoded temp path if everything else fails
-        #[cfg(target_os = "windows")]
-        paths.push(std::path::PathBuf::from("C:\\Temp\\wavis-crash.txt"));
-        #[cfg(not(target_os = "windows"))]
-        paths.push(std::path::PathBuf::from("/tmp/wavis-crash.txt"));
+        // 3. OS temp directory — cross-platform, always exists
+        paths.push(std::env::temp_dir().join(&filename));
 
         let mut saved = false;
         for path in paths {
@@ -89,7 +115,6 @@ pub fn install(log_buffer: SharedLogBuffer) {
             if fs::write(&path, &report).is_ok() {
                 eprintln!("wavis: crash report saved to: {}", path.display());
                 saved = true;
-                // Only save to the first successful path
                 break;
             }
         }
@@ -98,7 +123,6 @@ pub fn install(log_buffer: SharedLogBuffer) {
             eprintln!("wavis: failed to save crash report to any known location.");
         }
 
-        // Also print the crash info to stderr for console visibility
         eprintln!("wavis: application panicked at {}: {}", location, message);
     }));
 }

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -351,7 +351,21 @@ fn main() {
     tauri::Builder::default()
         .plugin(
             tauri_plugin_log::Builder::new()
-                .level(debug_env::tauri_log_level())
+                // Global minimum is always Info so the ring buffer captures
+                // voice/WebRTC/room activity for crash reports and bug reports,
+                // even without debug flags. The Stdout target filters independently
+                // so console output stays quiet in normal operation.
+                .level(log::LevelFilter::Info)
+                .clear_targets()
+                .target(
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout)
+                        .filter({
+                            let min = debug_env::tauri_log_level()
+                                .to_level()
+                                .unwrap_or(log::Level::Warn);
+                            move |metadata| metadata.level() <= min
+                        }),
+                )
                 .target(tauri_plugin_log::Target::new(
                     tauri_plugin_log::TargetKind::Dispatch(log_layer),
                 ))
@@ -532,8 +546,9 @@ fn main() {
             close_main_window,
             #[cfg(debug_assertions)]
             panic_now,
-            ])
-                .build(tauri::generate_context!())        .expect("error while building wavis")
+        ])
+        .build(tauri::generate_context!())
+        .expect("error while building wavis")
         .run(|_app, event| {
             if let tauri::RunEvent::Exit = event {
                 // Stop any active screen capture so the OS overlay is removed

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -270,6 +270,7 @@ mod screen_recording_auth {
     }
 }
 mod bug_report;
+mod crash_handler;
 mod debug_env;
 mod diagnostics;
 #[cfg(target_os = "windows")]
@@ -344,6 +345,7 @@ fn main() {
 
     // Create the shared Rust log buffer for bug report diagnostics.
     let log_buffer = bug_report::new_shared_buffer(200);
+    crash_handler::install(log_buffer.clone());
     let log_layer = bug_report::build_bug_report_log_layer(log_buffer.clone());
 
     tauri::Builder::default()
@@ -373,6 +375,7 @@ fn main() {
             sysinfo::System::new(),
         )))
         .setup(|app| {
+            crash_handler::register_app_handle(app.handle().clone());
             #[cfg(desktop)]
             {
                 if let Err(err) = app
@@ -527,9 +530,10 @@ fn main() {
             native_mic::native_mic_set_denoise_enabled,
             native_mic::native_mic_set_input_device,
             close_main_window,
-        ])
-        .build(tauri::generate_context!())
-        .expect("error while building wavis")
+            #[cfg(debug_assertions)]
+            panic_now,
+            ])
+                .build(tauri::generate_context!())        .expect("error while building wavis")
         .run(|_app, event| {
             if let tauri::RunEvent::Exit = event {
                 // Stop any active screen capture so the OS overlay is removed
@@ -952,4 +956,10 @@ fn close_main_window(app: tauri::AppHandle) {
     if let Some(window) = app.get_webview_window("main") {
         let _ = window.destroy();
     }
+}
+
+#[cfg(debug_assertions)]
+#[tauri::command]
+fn panic_now() {
+    panic!("Manual panic triggered via panic_now command");
 }

--- a/clients/wavis-gui/src/features/diagnostics/DiagnosticsPage.tsx
+++ b/clients/wavis-gui/src/features/diagnostics/DiagnosticsPage.tsx
@@ -16,6 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -877,6 +878,45 @@ export default function DiagnosticsPage() {
           Baseline set {new Date(bl.capturedAt).toLocaleTimeString()}
         </div>
       )}
+
+      {import.meta.env.DEV && <CrashTestSection />}
     </div>
+  );
+}
+
+function CrashTestSection() {
+  const [armed, setArmed] = useState(false);
+
+  const handleTrigger = () => {
+    void invoke('panic_now');
+  };
+
+  return (
+    <Section>
+      <SectionHeader>Crash Report Test (dev only)</SectionHeader>
+      <div className="text-[0.6rem] text-wavis-text-secondary/60 mb-1">
+        Triggers a Rust panic. The app will crash and write a crash-report-*.txt to app data.
+      </div>
+      {armed ? (
+        <div className="flex gap-2 items-center">
+          <button
+            onClick={handleTrigger}
+            className="text-xs border border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-white px-2 py-0.5 transition-colors"
+          >
+            Confirm — crash now
+          </button>
+          <button
+            onClick={() => { setArmed(false); }}
+            className="text-xs border border-wavis-text-secondary/40 text-wavis-text-secondary hover:border-wavis-text hover:text-wavis-text px-2 py-0.5 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      ) : (
+        <ActionButton onClick={() => { setArmed(true); }}>
+          Trigger Panic
+        </ActionButton>
+      )}
+    </Section>
   );
 }


### PR DESCRIPTION
This PR implements a robust global panic hook in the Tauri desktop client.

### Key Changes:
- **Panic Hook Implementation:** Captures panic message, location, backtrace (forced), and recent in-memory logs.
- **Deduplication:** Uses an AtomicBool to ensure only one report is written if multiple threads panic.
- **Log Buffering Improvements:** Configures 	auri-plugin-log to capture Info-level records in the ring buffer even in release builds, while keeping stdout filtering intact.
- **Crash Report Files:** Writes reports to crash-report-<unix>.txt in priority order: App Data, CWD, or OS Temp.
- **Testing UI:** Adds a 'Trigger Panic' section in the Diagnostics page (dev-only) to verify the handler.

Fixes #242