### PR TITLE
[codex] Fix persistent member passthrough permission

### DIFF
--- a/clients/shared/src/call_session.rs
+++ b/clients/shared/src/call_session.rs
@@ -245,6 +245,7 @@ impl<
                 | SignalingMessage::LeaveSubRoom(_)
                 | SignalingMessage::SetPassthrough(_)
                 | SignalingMessage::ClearPassthrough(_)
+                | SignalingMessage::SetPassthroughEnabled(_)
                 | SignalingMessage::SetPassthroughVolume(_)
                 | SignalingMessage::SetPassthroughFilter(_)
                 | SignalingMessage::SubRoomState(_)

--- a/clients/wavis-gui/src/features/settings/Settings.tsx
+++ b/clients/wavis-gui/src/features/settings/Settings.tsx
@@ -9,7 +9,7 @@ import { resetAuth, logout, getServerUrl, getDeviceId, getUsername, updateUserna
 import { PROFILE_COLORS } from '@shared/colors';
 import { getProfileColor, setProfileColor, getStoreValue, setStoreValue, STORE_KEYS, getDefaultVolume, DEFAULT_VOLUME, getMinimizeToTray, setMinimizeToTray, getNotificationToggles, setNotificationToggle, getMuteHotkey, setMuteHotkey, DEFAULT_MUTE_HOTKEY, getWatchAllHotkey, setWatchAllHotkey, DEFAULT_WATCH_ALL_HOTKEY, getFocusMainHotkey, setFocusMainHotkey, DEFAULT_FOCUS_MAIN_HOTKEY, getDenoiseEnabled, setDenoiseEnabled, getNotificationVolume, setNotificationVolume, getSoundVolumes, setSoundVolumes, getInputVolume, setInputVolume, getVideoInputDevice, setVideoInputDevice } from './settings-store';
 import { updateCachedNotificationVolume, updateCachedSoundVolumes } from '@features/voice/notification-sounds';
-import { updateSessionProfileColor, updateSessionUsername, getState as getVoiceRoomState, changeSelectedCamera, setPassthroughVolume, setPassthroughFilter, setPassthrough, clearPassthrough, leaveRoom } from '@features/voice/voice-room';
+import { updateSessionProfileColor, updateSessionUsername, getState as getVoiceRoomState, changeSelectedCamera, setPassthroughEnabled, setPassthroughVolume, setPassthroughFilter, setPassthrough, clearPassthrough, leaveRoom } from '@features/voice/voice-room';
 import { VolumeSlider } from '@shared/VolumeSlider';
 import { setAudioDevice, setAudioInputVolume, setMediaDenoiseEnabled } from '@features/voice/audio-devices';
 import type { NotificationToggles } from './settings-store';
@@ -148,7 +148,6 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
   const [osPlatform, setOsPlatform] = useState<string>('—');
   const [webviewVersion, setWebviewVersion] = useState<string>('—');
   const [minimizeToTray, setMinimizeToTrayState] = useState(false);
-  const [passthroughIntent, setPassthroughIntent] = useState(false);
   const [notifyToggles, setNotifyToggles] = useState<NotificationToggles>({
     participantJoined: true,
     participantLeft: true,
@@ -510,7 +509,8 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
                 const vs = getVoiceRoomState();
                 if (!vs.selfIsHost || vs.machineState !== 'active') return null;
                 const activePassthrough = vs.passthrough;
-                const passthroughOn = !!activePassthrough || passthroughIntent;
+                const passthroughEnabled = vs.passthroughEnabled;
+                const showPassthroughControls = passthroughEnabled || !!activePassthrough;
                 const joinedSubRoomId = vs.joinedSubRoomId;
                 const otherSubRooms = vs.subRooms.filter((r) => r.id !== joinedSubRoomId);
                 return (
@@ -520,22 +520,15 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
                       <div className="flex items-center justify-between">
                         <span className="text-wavis-text-secondary">Enable passthrough</span>
                         <Switch
-                          checked={passthroughOn}
-                          onCheckedChange={(checked: boolean) => {
-                            if (checked) {
-                              setPassthroughIntent(true);
-                            } else {
-                              setPassthroughIntent(false);
-                              clearPassthrough();
-                            }
-                          }}
+                          checked={passthroughEnabled}
+                          onCheckedChange={setPassthroughEnabled}
                           aria-label="Toggle passthrough"
                         />
                       </div>
                       <p className="text-xs text-wavis-text-secondary/70">
                         Link two sub-rooms so their participants can hear each other
                       </p>
-                      {passthroughOn && (
+                      {showPassthroughControls && (
                         <>
                           <div>
                             <label className="text-wavis-text-secondary block mb-1">
@@ -591,14 +584,13 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
                                   type="button"
                                   onClick={() => {
                                     clearPassthrough();
-                                    setPassthroughIntent(false);
                                   }}
                                   className="text-xs px-2 py-0.5 border border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-wavis-bg transition-colors"
                                 >
                                   /unlink
                                 </button>
                               </div>
-                            ) : joinedSubRoomId && otherSubRooms.length > 0 ? (
+                            ) : passthroughEnabled && joinedSubRoomId && otherSubRooms.length > 0 ? (
                               <div>
                                 <span className="text-wavis-text-secondary block mb-1">Link to room</span>
                                 <div className="flex flex-wrap gap-1">
@@ -606,7 +598,7 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
                                     <button
                                       key={r.id}
                                       type="button"
-                                      onClick={() => { setPassthrough(r.id); setPassthroughIntent(false); }}
+                                      onClick={() => { setPassthrough(r.id); }}
                                       className="text-xs px-2 py-0.5 border border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg transition-colors"
                                     >
                                       Room {r.roomNumber}
@@ -614,11 +606,11 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
                                   ))}
                                 </div>
                               </div>
-                            ) : (
+                            ) : passthroughEnabled ? (
                               <p className="text-xs text-wavis-text-secondary/70">
                                 Join a sub-room to link rooms
                               </p>
-                            )}
+                            ) : null}
                           </div>
                         </>
                       )}

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -2685,8 +2685,8 @@ export default function ActiveRoom() {
             activePassthrough.sourceSubRoomId === roomState.joinedSubRoomId
             || activePassthrough.targetSubRoomId === roomState.joinedSubRoomId
           );
-        const canSetPassthrough = isHost && !activePassthrough && !!roomState.joinedSubRoomId && !isJoinedRoom;
-        const canClearPassthrough = isHost && activePassthroughInvolvesRoom && activePassthroughInvolvesLocalRoom;
+        const canSetPassthrough = roomState.passthroughEnabled && !activePassthrough && !!roomState.joinedSubRoomId && !isJoinedRoom;
+        const canClearPassthrough = activePassthroughInvolvesRoom && activePassthroughInvolvesLocalRoom;
         const passthroughDisabled = !(canSetPassthrough || canClearPassthrough);
         const passthroughLabel = activePassthroughInvolvesRoom && activePassthrough?.label
           ? `“${activePassthrough.label}”`

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
@@ -71,6 +71,7 @@ function makeState(overrides?: Partial<VoiceRoomState>): VoiceRoomState {
     sharePermission: 'anyone',
     defaultVolume: 70,
     passthroughVolume: 20,
+    passthroughEnabled: false,
     passthroughFiltersEnabled: true,
     passthroughFilterStrength: 50,
     mediaReconnectFailures: 0,

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
@@ -230,6 +230,15 @@ describe('participant_undeafened', () => {
 // ─── sub_room_state ───────────────────────────────────────────────
 
 describe('sub_room_state', () => {
+  it('synchronizes passthrough permission and defaults it off when absent', async () => {
+    await setupActiveSession();
+    inject({ type: 'sub_room_state', rooms: [], passthroughEnabled: true });
+    expect(getState().passthroughEnabled).toBe(true);
+
+    inject({ type: 'sub_room_state', rooms: [] });
+    expect(getState().passthroughEnabled).toBe(false);
+  });
+
   it('populates subRooms from the message', async () => {
     await setupActiveSession();
     inject({

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -190,6 +190,8 @@ export interface VoiceRoomState {
   defaultVolume: number;
   /** Passthrough volume (0–100): attenuates audio from paired sub-room. */
   passthroughVolume: number;
+  /** Whether channel members may create new passthrough links. */
+  passthroughEnabled: boolean;
   /** Whether paired sub-room participants are spectrally muffled. */
   passthroughFiltersEnabled: boolean;
   /** Passthrough muffle strength (0–100). */
@@ -1054,6 +1056,7 @@ const DEFAULT_STATE: VoiceRoomState = {
   sharePermission: 'anyone',
   defaultVolume: 70,
   passthroughVolume: DEFAULT_PASSTHROUGH_VOLUME,
+  passthroughEnabled: false,
   passthroughFiltersEnabled: true,
   passthroughFilterStrength: 50,
   mediaReconnectFailures: 0,
@@ -2984,6 +2987,9 @@ function dispatchMessage(raw: unknown): void {
             label: passthrough.label,
           }
         : null;
+      state.passthroughEnabled = typeof msg.passthroughEnabled === 'boolean'
+        ? msg.passthroughEnabled
+        : false;
       if (typeof msg.passthroughVolumePercent === 'number') {
         state.passthroughVolume = Math.max(0, Math.min(100, Math.round(msg.passthroughVolumePercent)));
       }
@@ -4815,6 +4821,12 @@ export function setPassthrough(targetSubRoomId: string): void {
 export function clearPassthrough(): void {
   if (!client || client.status !== 'connected') return;
   client.send({ type: 'clear_passthrough' });
+}
+
+export function setPassthroughEnabled(enabled: boolean): void {
+  if (!state.selfIsHost) return;
+  if (!client || client.status !== 'connected') return;
+  client.send({ type: 'set_passthrough_enabled', enabled });
 }
 
 export function setPassthroughVolume(volume: number): void {

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -217,6 +217,8 @@ pub enum SignalingMessage {
     SetPassthrough(SetPassthroughPayload),
     /// Client -> server request to clear the active passthrough pair.
     ClearPassthrough(ClearPassthroughPayload),
+    /// Client -> server (admin/owner) request to enable or disable passthrough linking.
+    SetPassthroughEnabled(SetPassthroughEnabledPayload),
     /// Client -> server (admin/owner) request to set the passthrough volume for all participants.
     SetPassthroughVolume(SetPassthroughVolumePayload),
     /// Client -> server (admin/owner) request to set passthrough muffle filter settings.
@@ -816,6 +818,12 @@ pub struct SetPassthroughPayload {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ClearPassthroughPayload {}
 
+/// Client (admin/owner) enables or disables new passthrough links for the channel.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SetPassthroughEnabledPayload {
+    pub enabled: bool,
+}
+
 /// Client (admin/owner) sets the passthrough volume for all participants (0–100).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SetPassthroughVolumePayload {
@@ -854,6 +862,9 @@ pub struct SubRoomStatePayload {
     /// Optional active passthrough pair for the voice session.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub passthrough: Option<PassthroughStatePayload>,
+    /// Whether channel members may create new passthrough links. Defaults off for backward compat.
+    #[serde(rename = "passthroughEnabled", default)]
+    pub passthrough_enabled: bool,
     /// Passthrough volume as a percentage (0–100). Defaults to 20 if absent (backward compat).
     #[serde(
         rename = "passthroughVolumePercent",

--- a/shared/src/signaling/proptest_support.rs
+++ b/shared/src/signaling/proptest_support.rs
@@ -706,6 +706,17 @@ impl Arbitrary for ClearPassthroughPayload {
     }
 }
 
+impl Arbitrary for SetPassthroughEnabledPayload {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        any::<bool>()
+            .prop_map(|enabled| SetPassthroughEnabledPayload { enabled })
+            .boxed()
+    }
+}
+
 impl Arbitrary for SetPassthroughVolumePayload {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
@@ -753,6 +764,7 @@ impl Arbitrary for SubRoomStatePayload {
         (
             prop::collection::vec(any::<SubRoomInfoPayload>(), 1..=6),
             prop::option::of(any::<PassthroughStatePayload>()),
+            any::<bool>(),
             any::<u8>(),
             any::<bool>(),
             0u8..=100u8,
@@ -761,12 +773,14 @@ impl Arbitrary for SubRoomStatePayload {
                 |(
                     rooms,
                     passthrough,
+                    passthrough_enabled,
                     passthrough_volume_percent,
                     passthrough_filters_enabled,
                     passthrough_filter_strength,
                 )| SubRoomStatePayload {
                     rooms,
                     passthrough,
+                    passthrough_enabled,
                     passthrough_volume_percent,
                     passthrough_filters_enabled,
                     passthrough_filter_strength,
@@ -1067,6 +1081,7 @@ impl Arbitrary for SignalingMessage {
             any::<LeaveSubRoomPayload>().prop_map(SignalingMessage::LeaveSubRoom),
             any::<SetPassthroughPayload>().prop_map(SignalingMessage::SetPassthrough),
             any::<ClearPassthroughPayload>().prop_map(SignalingMessage::ClearPassthrough),
+            any::<SetPassthroughEnabledPayload>().prop_map(SignalingMessage::SetPassthroughEnabled),
             any::<SetPassthroughVolumePayload>().prop_map(SignalingMessage::SetPassthroughVolume),
             any::<SetPassthroughFilterPayload>().prop_map(SignalingMessage::SetPassthroughFilter),
             any::<SubRoomStatePayload>().prop_map(SignalingMessage::SubRoomState),

--- a/shared/src/signaling/tests.rs
+++ b/shared/src/signaling/tests.rs
@@ -147,6 +147,15 @@ fn test_set_passthrough_volume_round_trip() {
 }
 
 #[test]
+fn test_set_passthrough_enabled_round_trip() {
+    let msg =
+        SignalingMessage::SetPassthroughEnabled(SetPassthroughEnabledPayload { enabled: true });
+    let json = to_json(&msg).unwrap();
+    assert_eq!(json, r#"{"type":"set_passthrough_enabled","enabled":true}"#);
+    assert_eq!(parse(&json).unwrap(), msg);
+}
+
+#[test]
 fn test_set_passthrough_filter_round_trip() {
     let msg = SignalingMessage::SetPassthroughFilter(SetPassthroughFilterPayload {
         enabled: true,
@@ -166,6 +175,7 @@ fn test_sub_room_state_passthrough_volume_round_trip() {
     let msg = SignalingMessage::SubRoomState(SubRoomStatePayload {
         rooms: vec![],
         passthrough: None,
+        passthrough_enabled: true,
         passthrough_volume_percent: 42,
         passthrough_filters_enabled: true,
         passthrough_filter_strength: 50,
@@ -194,6 +204,7 @@ fn test_sub_room_state_passthrough_volume_default_on_absent_field() {
     match parsed {
         SignalingMessage::SubRoomState(p) => {
             assert_eq!(p.passthrough_volume_percent, 20);
+            assert!(!p.passthrough_enabled);
             assert!(p.passthrough_filters_enabled);
             assert_eq!(p.passthrough_filter_strength, 50);
         }
@@ -239,6 +250,7 @@ fn test_sub_room_state_round_trip() {
             target_sub_room_id: "sub-room-2".to_string(),
             label: "1 - 2".to_string(),
         }),
+        passthrough_enabled: true,
         passthrough_volume_percent: 20,
         passthrough_filters_enabled: true,
         passthrough_filter_strength: 50,
@@ -431,7 +443,7 @@ proptest! {
                            "create_room", "room_created",
                            "auth", "auth_success", "auth_failed",
                            "join_voice", "create_sub_room", "join_sub_room", "leave_sub_room",
-                           "set_passthrough", "clear_passthrough", "set_passthrough_volume",
+                           "set_passthrough", "clear_passthrough", "set_passthrough_enabled", "set_passthrough_volume",
                            "set_passthrough_filter",
                            "sub_room_state", "sub_room_created", "sub_room_joined",
                            "sub_room_left", "sub_room_deleted",

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -266,6 +266,7 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
             )?;
         }
         SignalingMessage::ClearPassthrough(_) => {}
+        SignalingMessage::SetPassthroughEnabled(_) => {}
         SignalingMessage::SetPassthroughVolume(_) => {
             // volume is u8 (0–255) and clamped to 0–100 server-side; no string fields to check.
         }
@@ -804,7 +805,7 @@ mod tests {
                 "auth", "auth_success", "auth_failed",
                 "join_voice",
                 "create_sub_room", "join_sub_room", "leave_sub_room",
-                "set_passthrough", "clear_passthrough", "set_passthrough_volume",
+                "set_passthrough", "clear_passthrough", "set_passthrough_enabled", "set_passthrough_volume",
                 "set_passthrough_filter", "sub_room_state", "sub_room_created",
                 "sub_room_joined", "sub_room_left", "sub_room_deleted",
                 "sfu_cold_starting",

--- a/wavis-backend/migrations/017_add_channel_passthrough_enabled.sql
+++ b/wavis-backend/migrations/017_add_channel_passthrough_enabled.sql
@@ -1,0 +1,2 @@
+ALTER TABLE channels
+ADD COLUMN passthrough_enabled BOOLEAN NOT NULL DEFAULT FALSE;

--- a/wavis-backend/src/state.rs
+++ b/wavis-backend/src/state.rs
@@ -89,6 +89,8 @@ pub struct SubRoomState {
     pub membership_sources: HashMap<String, SubRoomMembershipSource>,
     /// Optional active passthrough pair for this voice session.
     pub active_passthrough: Option<PassthroughPair>,
+    /// Whether channel members may create new passthrough links.
+    pub passthrough_enabled: bool,
     /// Passthrough volume as a percentage (0–100), set by an admin and applied to all participants.
     pub passthrough_volume_percent: u8,
     /// Whether passthrough participants are spectrally muffled.
@@ -104,6 +106,7 @@ impl SubRoomState {
             participant_assignments: HashMap::new(),
             membership_sources: HashMap::new(),
             active_passthrough: None,
+            passthrough_enabled: false,
             passthrough_volume_percent: 20,
             passthrough_filters_enabled: true,
             passthrough_filter_strength: 50,

--- a/wavis-backend/src/voice/voice_orchestrator.rs
+++ b/wavis-backend/src/voice/voice_orchestrator.rs
@@ -226,6 +226,7 @@ fn sub_room_state_payload(state: &SubRoomState) -> SubRoomStatePayload {
     SubRoomStatePayload {
         rooms: state.rooms.iter().map(sub_room_info_payload).collect(),
         passthrough: active_passthrough_payload(state),
+        passthrough_enabled: state.passthrough_enabled,
         passthrough_volume_percent: state.passthrough_volume_percent,
         passthrough_filters_enabled: state.passthrough_filters_enabled,
         passthrough_filter_strength: state.passthrough_filter_strength,
@@ -297,6 +298,7 @@ fn schedule_empty_room_if_needed(
 ///      This is explicitly out of scope for MVP.
 ///
 /// Returns `(room_id, created)` where `created` is true if a new room was created.
+#[allow(clippy::too_many_arguments)]
 pub async fn ensure_active_room(
     active_room_map: &ActiveRoomMap,
     room_state: &InMemoryRoomState,
@@ -304,6 +306,7 @@ pub async fn ensure_active_room(
     _token_mode: &TokenMode<'_>,
     _sfu_url: &str,
     channel_id: &Uuid,
+    passthrough_enabled: bool,
     max_participants: u8,
 ) -> Result<(String, bool), VoiceJoinError> {
     let mut map = active_room_map.write().await;
@@ -314,6 +317,12 @@ pub async fn ensure_active_room(
     // create a fresh room.
     if let Some(room_id) = map.get(channel_id) {
         if room_state.get_room_info(room_id).is_some() {
+            room_state.update_room_info(room_id, |info| {
+                ensure_room_sub_rooms(info);
+                if let Some(sub_rooms) = info.sub_room_state.as_mut() {
+                    sub_rooms.passthrough_enabled = passthrough_enabled;
+                }
+            });
             return Ok((room_id.clone(), false));
         }
         // Stale mapping — room no longer exists in state. Remove and recreate.
@@ -337,7 +346,9 @@ pub async fn ensure_active_room(
 
     // Create room in InMemoryRoomState with SFU type.
     let mut info = RoomInfo::new_sfu(max_participants, sfu_handle);
-    info.sub_room_state = Some(SubRoomState::new(DEFAULT_SUB_ROOM_ID.to_string()));
+    let mut sub_rooms = SubRoomState::new(DEFAULT_SUB_ROOM_ID.to_string());
+    sub_rooms.passthrough_enabled = passthrough_enabled;
+    info.sub_room_state = Some(sub_rooms);
     let created = room_state.create_room(room_id.clone(), info);
     if !created {
         // Room already exists in state (should not happen under write lock, but guard defensively).
@@ -725,6 +736,9 @@ pub fn set_passthrough(
                 return Err("sub-room state unavailable".to_string());
             };
             clear_invalid_passthrough_locked(sub_rooms);
+            if !sub_rooms.passthrough_enabled {
+                return Err("passthrough is disabled".to_string());
+            }
 
             let source_sub_room_id = sub_rooms
                 .participant_assignments
@@ -806,6 +820,49 @@ pub fn clear_passthrough(
         "passthrough cleared"
     );
 
+    Ok(SubRoomActionResult {
+        signals: sub_room_state_signals(room_state, room_id),
+        expiry: None,
+    })
+}
+
+pub async fn set_passthrough_enabled(
+    pool: &PgPool,
+    room_state: &InMemoryRoomState,
+    room_id: &str,
+    channel_id: &str,
+    enabled: bool,
+) -> Result<SubRoomActionResult, String> {
+    let channel_id =
+        Uuid::parse_str(channel_id).map_err(|_| "invalid channel ID format".to_string())?;
+    let updated = sqlx::query("UPDATE channels SET passthrough_enabled = $1 WHERE channel_id = $2")
+        .bind(enabled)
+        .bind(channel_id)
+        .execute(pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    if updated.rows_affected() != 1 {
+        return Err("channel not found".to_string());
+    }
+
+    let changed = room_state
+        .with_room_write(room_id, |members| {
+            let Some(sub_rooms) = members.info.sub_room_state.as_mut() else {
+                return false;
+            };
+            if sub_rooms.passthrough_enabled == enabled {
+                return false;
+            }
+            sub_rooms.passthrough_enabled = enabled;
+            true
+        })
+        .map_err(|_| "voice session not found".to_string())?;
+
+    if !changed {
+        return Ok(SubRoomActionResult::default());
+    }
+
+    tracing::info!(room_id = %room_id, enabled, "passthrough permission set");
     Ok(SubRoomActionResult {
         signals: sub_room_state_signals(room_state, room_id),
         expiry: None,
@@ -957,8 +1014,11 @@ pub async fn join_voice(
     })?;
 
     // 2. DB membership check — must be non-banned member.
-    let membership: Option<(ChannelRole, Option<DateTime<Utc>>)> = sqlx::query_as(
-        "SELECT role, banned_at FROM channel_memberships WHERE channel_id = $1 AND user_id = $2",
+    let membership: Option<(ChannelRole, Option<DateTime<Utc>>, bool)> = sqlx::query_as(
+        "SELECT cm.role, cm.banned_at, c.passthrough_enabled \
+         FROM channel_memberships cm \
+         JOIN channels c ON c.channel_id = cm.channel_id \
+         WHERE cm.channel_id = $1 AND cm.user_id = $2",
     )
     .bind(channel_id)
     .bind(user_id)
@@ -974,7 +1034,7 @@ pub async fn join_voice(
         VoiceJoinError::DatabaseError(e.to_string())
     })?;
 
-    let (role, banned_at) = match membership {
+    let (role, banned_at, passthrough_enabled) = match membership {
         Some(row) => row,
         None => {
             warn!(
@@ -1008,6 +1068,7 @@ pub async fn join_voice(
         token_mode,
         sfu_url,
         &channel_id,
+        passthrough_enabled,
         max_participants,
     )
     .await?;
@@ -1496,6 +1557,82 @@ mod tests {
             set_passthrough_filter(&state, "voice-room", false, 100).expect("set filter");
         assert!(unchanged.signals.is_empty());
         assert!(unchanged.expiry.is_none());
+    }
+
+    fn prepare_passthrough_rooms(state: &InMemoryRoomState) {
+        let _ = create_sub_room(state, "voice-room").expect("create room-2");
+        let _ = create_sub_room(state, "voice-room").expect("create room-3");
+        let _ = join_sub_room(state, "voice-room", "room-1", "peer-a").expect("join room-1");
+        let _ = join_sub_room(state, "voice-room", "room-2", "peer-b").expect("join room-2");
+    }
+
+    #[test]
+    fn disabled_passthrough_creation_is_rejected() {
+        let state = sub_room_test_state();
+        prepare_passthrough_rooms(&state);
+
+        let err = set_passthrough(&state, "voice-room", "peer-a", "room-2").unwrap_err();
+
+        assert_eq!(err, "passthrough is disabled");
+    }
+
+    #[test]
+    fn enabled_passthrough_creation_succeeds_for_member() {
+        let state = sub_room_test_state();
+        prepare_passthrough_rooms(&state);
+        state.update_room_info("voice-room", |info| {
+            info.sub_room_state.as_mut().unwrap().passthrough_enabled = true;
+        });
+
+        let result = set_passthrough(&state, "voice-room", "peer-a", "room-2")
+            .expect("member can create passthrough");
+
+        assert!(!result.signals.is_empty());
+    }
+
+    #[test]
+    fn disabling_passthrough_preserves_active_pair_and_paired_member_can_clear() {
+        let state = sub_room_test_state();
+        prepare_passthrough_rooms(&state);
+        state.update_room_info("voice-room", |info| {
+            info.sub_room_state.as_mut().unwrap().passthrough_enabled = true;
+        });
+        let _ = set_passthrough(&state, "voice-room", "peer-a", "room-2").unwrap();
+        state.update_room_info("voice-room", |info| {
+            info.sub_room_state.as_mut().unwrap().passthrough_enabled = false;
+        });
+
+        let info = state.get_room_info("voice-room").unwrap();
+        assert!(info.sub_room_state.unwrap().active_passthrough.is_some());
+        let cleared =
+            clear_passthrough(&state, "voice-room", "peer-b").expect("paired member clears");
+        assert!(!cleared.signals.is_empty());
+    }
+
+    #[test]
+    fn uninvolved_member_cannot_clear_passthrough() {
+        let state = sub_room_test_state();
+        prepare_passthrough_rooms(&state);
+        state.add_peer("peer-c".to_string(), "voice-room".to_string());
+        state.update_room_info("voice-room", |info| {
+            info.participants.push(ParticipantInfo {
+                participant_id: "peer-c".to_string(),
+                display_name: "Peer C".to_string(),
+                user_id: None,
+                profile_color: None,
+                is_muted: false,
+                is_host_muted: false,
+                is_deafened: false,
+            });
+            let sub_rooms = info.sub_room_state.as_mut().unwrap();
+            sub_rooms.passthrough_enabled = true;
+        });
+        let _ = join_sub_room(&state, "voice-room", "room-3", "peer-c").unwrap();
+        let _ = set_passthrough(&state, "voice-room", "peer-a", "room-2").unwrap();
+
+        let err = clear_passthrough(&state, "voice-room", "peer-c").unwrap_err();
+
+        assert_eq!(err, "passthrough is controlled by the active room pair");
     }
 
     fn arb_channel_role() -> impl Strategy<Value = ChannelRole> {

--- a/wavis-backend/src/ws/ws.rs
+++ b/wavis-backend/src/ws/ws.rs
@@ -429,6 +429,7 @@ mod tests {
                         SignalingMessage::LeaveSubRoom(_) |
                         SignalingMessage::SetPassthrough(_) |
                         SignalingMessage::ClearPassthrough(_) |
+                        SignalingMessage::SetPassthroughEnabled(_) |
                         SignalingMessage::SetPassthroughVolume(_) |
                         SignalingMessage::SetPassthroughFilter(_) |
                         SignalingMessage::SubRoomState(_) |

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -2780,7 +2780,7 @@ pub(crate) async fn dispatch_message(
             let Some(session_ref) = ctx.session.as_ref() else {
                 return DispatchOutcome::Continue;
             };
-            let Some(ref channel_id) = session_ref.channel_id.clone() else {
+            let Some(_) = session_ref.channel_id.as_ref() else {
                 ctx.app_state.connections.send_to(
                     ctx.peer_id,
                     &SignalingMessage::Error(ErrorPayload {
@@ -2792,26 +2792,6 @@ pub(crate) async fn dispatch_message(
             if !ctx.rate_limiter.action_allow() {
                 return DispatchOutcome::Continue;
             }
-            let user_id_uuid = Uuid::parse_str(
-                session_ref
-                    .user_id
-                    .as_ref()
-                    .expect("channel session always has user_id"),
-            )
-            .expect("session user_id is always a valid UUID");
-            if require_host_role(
-                ctx.app_state,
-                ctx.peer_id,
-                channel_id,
-                user_id_uuid,
-                "set_passthrough",
-            )
-            .await
-            .is_err()
-            {
-                return DispatchOutcome::Continue;
-            }
-
             match voice_orchestrator::set_passthrough(
                 ctx.app_state.room_state.as_ref(),
                 &session_ref.room_id,
@@ -2839,7 +2819,7 @@ pub(crate) async fn dispatch_message(
             let Some(session_ref) = ctx.session.as_ref() else {
                 return DispatchOutcome::Continue;
             };
-            let Some(ref channel_id) = session_ref.channel_id.clone() else {
+            let Some(_) = session_ref.channel_id.as_ref() else {
                 ctx.app_state.connections.send_to(
                     ctx.peer_id,
                     &SignalingMessage::Error(ErrorPayload {
@@ -2851,26 +2831,6 @@ pub(crate) async fn dispatch_message(
             if !ctx.rate_limiter.action_allow() {
                 return DispatchOutcome::Continue;
             }
-            let user_id_uuid = Uuid::parse_str(
-                session_ref
-                    .user_id
-                    .as_ref()
-                    .expect("channel session always has user_id"),
-            )
-            .expect("session user_id is always a valid UUID");
-            if require_host_role(
-                ctx.app_state,
-                ctx.peer_id,
-                channel_id,
-                user_id_uuid,
-                "clear_passthrough",
-            )
-            .await
-            .is_err()
-            {
-                return DispatchOutcome::Continue;
-            }
-
             match voice_orchestrator::clear_passthrough(
                 ctx.app_state.room_state.as_ref(),
                 &session_ref.room_id,
@@ -2890,6 +2850,65 @@ pub(crate) async fn dispatch_message(
                         &SignalingMessage::Error(ErrorPayload { message }),
                     );
                 }
+            }
+            DispatchOutcome::Continue
+        }
+        SignalingMessage::SetPassthroughEnabled(payload) => {
+            let Some(session_ref) = ctx.session.as_ref() else {
+                return DispatchOutcome::Continue;
+            };
+            let Some(channel_id) = session_ref.channel_id.as_deref() else {
+                ctx.app_state.connections.send_to(
+                    ctx.peer_id,
+                    &SignalingMessage::Error(ErrorPayload {
+                        message: "set_passthrough_enabled requires a channel voice session"
+                            .to_string(),
+                    }),
+                );
+                return DispatchOutcome::Continue;
+            };
+            if !ctx.rate_limiter.action_allow() {
+                return DispatchOutcome::Continue;
+            }
+            let user_id_uuid = Uuid::parse_str(
+                session_ref
+                    .user_id
+                    .as_ref()
+                    .expect("channel session always has user_id"),
+            )
+            .expect("session user_id is always a valid UUID");
+            if require_host_role(
+                ctx.app_state,
+                ctx.peer_id,
+                channel_id,
+                user_id_uuid,
+                "set_passthrough_enabled",
+            )
+            .await
+            .is_err()
+            {
+                return DispatchOutcome::Continue;
+            }
+
+            match voice_orchestrator::set_passthrough_enabled(
+                &ctx.app_state.db_pool,
+                ctx.app_state.room_state.as_ref(),
+                &session_ref.room_id,
+                channel_id,
+                payload.enabled,
+            )
+            .await
+            {
+                Ok(result) => dispatch_signals(
+                    result.signals,
+                    &session_ref.room_id,
+                    ctx.app_state.room_state.as_ref(),
+                    ctx.app_state.connections.as_ref(),
+                ),
+                Err(message) => ctx.app_state.connections.send_to(
+                    ctx.peer_id,
+                    &SignalingMessage::Error(ErrorPayload { message }),
+                ),
             }
             DispatchOutcome::Continue
         }
@@ -3302,6 +3321,7 @@ pub(crate) fn handle_signaling_event(
         | SignalingMessage::LeaveSubRoom(_)
         | SignalingMessage::SetPassthrough(_)
         | SignalingMessage::ClearPassthrough(_)
+        | SignalingMessage::SetPassthroughEnabled(_)
         | SignalingMessage::SetPassthroughVolume(_)
         | SignalingMessage::SetPassthroughFilter(_)
         | SignalingMessage::SubRoomState(_)

--- a/wavis-backend/tests/voice_orchestration_integration.rs
+++ b/wavis-backend/tests/voice_orchestration_integration.rs
@@ -1939,6 +1939,52 @@ async fn example_last_leave_cleans_up_active_room_map() {
     );
 }
 
+#[tokio::test]
+#[ignore] // requires Postgres
+async fn passthrough_permission_persists_across_empty_session_recreation() {
+    use wavis_backend::voice::sfu_relay;
+
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let owner = register_test_user(&pool).await;
+    let channel_id = create_test_channel(&pool, owner, "passthrough-persistence").await;
+    let channel_str = channel_id.to_string();
+    let ctx = VoiceTestContext::new();
+
+    let first = ctx
+        .join_voice(&pool, &channel_str, &owner, "peer-owner-1", "Owner")
+        .await
+        .unwrap();
+    voice_orchestrator::set_passthrough_enabled(
+        &pool,
+        &ctx.room_state,
+        &first.room_id,
+        &channel_str,
+        true,
+    )
+    .await
+    .expect("enable passthrough");
+
+    sfu_relay::handle_sfu_leave(
+        ctx.sfu_bridge.as_ref(),
+        &ctx.room_state,
+        &first.room_id,
+        "peer-owner-1",
+    )
+    .await
+    .expect("leave should succeed");
+    ctx.room_state.remove_empty_room(&first.room_id);
+    ctx.active_room_map.write().await.remove(&channel_id);
+
+    let second = ctx
+        .join_voice(&pool, &channel_str, &owner, "peer-owner-2", "Owner")
+        .await
+        .unwrap();
+    let info = ctx.room_state.get_room_info(&second.room_id).unwrap();
+    assert!(info.sub_room_state.unwrap().passthrough_enabled);
+}
+
 // ---------------------------------------------------------------------------
 // Example: JoinVoice after ban â€” rejected with opaque NotAuthorized reason
 // Validates: Requirements 3.3

--- a/wavis-backend/tests/voice_ws_integration.rs
+++ b/wavis-backend/tests/voice_ws_integration.rs
@@ -936,3 +936,83 @@ async fn test_28_13_room_cleanup_on_last_leave() {
         "re-join after cleanup should get a new room"
     );
 }
+
+#[tokio::test]
+#[ignore]
+async fn passthrough_permission_allows_member_link_but_not_member_toggle() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let owner = register_test_user(&pool).await;
+    let member = register_test_user(&pool).await;
+    let channel_id = create_test_channel(&pool, owner, "passthrough-permission").await;
+    add_member(&pool, channel_id, owner, member).await;
+    let (addr, _state) = start_server(pool).await;
+
+    let (mut owner_sink, mut owner_stream) = ws_connect(addr).await;
+    ws_auth(&mut owner_sink, &mut owner_stream, &sign_test_token(&owner)).await;
+    ws_join_voice(
+        &mut owner_sink,
+        &mut owner_stream,
+        &channel_id.to_string(),
+        "Owner",
+    )
+    .await;
+
+    let (mut member_sink, mut member_stream) = ws_connect(addr).await;
+    ws_auth(
+        &mut member_sink,
+        &mut member_stream,
+        &sign_test_token(&member),
+    )
+    .await;
+    ws_join_voice(
+        &mut member_sink,
+        &mut member_stream,
+        &channel_id.to_string(),
+        "Member",
+    )
+    .await;
+
+    ws_send(&mut owner_sink, json!({"type":"create_sub_room"})).await;
+    let created = recv_type(&mut owner_stream, "sub_room_created").await;
+    let room_2 = created["room"]["subRoomId"].as_str().unwrap().to_string();
+    ws_send(
+        &mut owner_sink,
+        json!({"type":"join_sub_room","subRoomId":&room_2}),
+    )
+    .await;
+    let _ = recv_type(&mut owner_stream, "sub_room_joined").await;
+
+    ws_send(
+        &mut member_sink,
+        json!({"type":"set_passthrough","targetSubRoomId":&room_2}),
+    )
+    .await;
+    let disabled = recv_type(&mut member_stream, "error").await;
+    assert_eq!(disabled["message"], "passthrough is disabled");
+
+    ws_send(
+        &mut owner_sink,
+        json!({"type":"set_passthrough_enabled","enabled":true}),
+    )
+    .await;
+    let enabled = recv_type(&mut owner_stream, "sub_room_state").await;
+    assert_eq!(enabled["passthroughEnabled"], true);
+
+    ws_send(
+        &mut member_sink,
+        json!({"type":"set_passthrough","targetSubRoomId":&room_2}),
+    )
+    .await;
+    let linked = recv_type(&mut member_stream, "sub_room_state").await;
+    assert!(linked["passthrough"].is_object());
+
+    ws_send(
+        &mut member_sink,
+        json!({"type":"set_passthrough_enabled","enabled":false}),
+    )
+    .await;
+    let unauthorized = recv_type(&mut member_stream, "error").await;
+    assert_eq!(unauthorized["message"], "unauthorized");
+}


### PR DESCRIPTION
## Summary
- persist a channel-level passthrough_enabled permission with a new migration
- synchronize the permission through sub_room_state and add an admin-only set_passthrough_enabled action
- allow assigned channel members to create passthrough links while enabled and allow either paired room to unlink after disable
- replace settings-local passthrough intent with server-authoritative GUI state

## Root cause
Passthrough enablement existed only as component-local settings state. Closing settings lost the intent, room-panel controls were host-only, backend link and unlink actions were host-only, and active voice state had no persisted permission bit.

## Validation
- npm.cmd test from clients/wavis-gui (1234 tests passed)
- npm.cmd run build from clients/wavis-gui
- cargo test --workspace
- cargo clippy --workspace -- -D warnings
- git diff --check

## Notes
PostgreSQL-backed ignored integration tests were added and compile successfully. They could not execute locally because the configured local PostgreSQL connection timed out.