### PR TITLE
fix(gui): persist remote stream mute state

### DIFF
--- a/clients/wavis-gui/src-tauri/src/bug_report.rs
+++ b/clients/wavis-gui/src-tauri/src/bug_report.rs
@@ -397,7 +397,6 @@ async fn capture_via_portal_async() -> Result<Vec<u8>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Write as _;
 
     #[test]
     fn new_buffer_is_empty() {

--- a/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
@@ -28,6 +28,7 @@ interface ShareWindowParams {
   isOwner: boolean;
   canvasFallback?: boolean;
   initialVolume?: number;
+  initialMuted?: boolean;
 }
 
 interface PolledScreenShareFrame {
@@ -68,7 +69,7 @@ export default function ScreenSharePage() {
   const [mjpegUrl, setMjpegUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [volume, setVolume] = useState(initialVolume);
-  const [muted, setMuted] = useState(initialVolume === 0);
+  const [muted, setMuted] = useState(shareParams?.initialMuted ?? (initialVolume === 0));
   const [quality, setQuality] = useState<ShareQuality>('high');
   const [sharingAudio, setSharingAudio] = useState(false);
   const [userState, setUserState] = useState<ShareUserState>({
@@ -324,10 +325,10 @@ export default function ScreenSharePage() {
 
   useEffect(() => {
     if (!p) return;
-    const unlisten = listen<{ participantId: string; volume: number }>('screen-share:restore-volume', (event) => {
+    const unlisten = listen<{ participantId: string; volume: number; muted: boolean }>('screen-share:restore-volume', (event) => {
       if (event.payload.participantId !== p.participantId) return;
       setVolume(event.payload.volume);
-      setMuted(event.payload.volume === 0);
+      setMuted(event.payload.muted);
     });
     return () => { unlisten.then((fn) => fn()); };
   }, [p]);
@@ -466,9 +467,7 @@ export default function ScreenSharePage() {
     if (!p) return;
     setMuted((prev) => {
       const nextMuted = !prev;
-      // Use local-audio so the gain is set without writing 0 into shareVolumes.
-      // This lets Watch All re-open at the slider's actual position (not muted).
-      emit('screen-share:local-audio', { participantId: p.participantId, volume: nextMuted ? 0 : volume });
+      emit('screen-share:mute-change', { participantId: p.participantId, muted: nextMuted });
       return nextMuted;
     });
   }, [p, volume]);

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -104,7 +104,7 @@ interface ShareTileProps {
   aspectRatio: number;
   onToggleMute: (participantId: string) => void;
   onVolumeChange: (participantId: string, volume: number) => void;
-  onPopOut: (participantId: string, volume: number) => void;
+  onPopOut: (participantId: string, volume: number, muted: boolean) => void;
   onAspectRatioDetected: (participantId: string, ratio: number) => void;
 }
 
@@ -478,8 +478,8 @@ const ShareTile = memo(function ShareTile({
 
   const handleDoubleClick = useCallback(() => {
     if (isDiagnosticTest) return;
-    onPopOut(participantId, volume);
-  }, [isDiagnosticTest, onPopOut, participantId, volume]);
+    onPopOut(participantId, volume, muted);
+  }, [isDiagnosticTest, muted, onPopOut, participantId, volume]);
 
   /* ── Render ── */
 
@@ -593,7 +593,7 @@ const ShareTile = memo(function ShareTile({
       {hovered && !isDiagnosticTest && (
         <button
           className="absolute top-1 right-1 text-wavis-text hover:text-wavis-accent text-xs bg-wavis-overlay-base/60 px-1 py-0.5 rounded"
-          onClick={(e) => { e.stopPropagation(); onPopOut(participantId, volume); }}
+          onClick={(e) => { e.stopPropagation(); onPopOut(participantId, volume, muted); }}
           aria-label={`Pop out ${displayName}`}
         >
           ⧉
@@ -705,7 +705,7 @@ export default function WatchAllPage() {
   const params = useRef(parseHashParams());
   const [tiles, setTiles] = useState<ShareTileState[]>([]);
   const [audioTiles, setAudioTiles] = useState<AudioTileState[]>([]);
-  const pendingRestoreVolumesRef = useRef<Map<string, number>>(new Map());
+  const pendingRestoreVolumesRef = useRef<Map<string, { volume: number; muted: boolean }>>(new Map());
   const gridRef = useRef<HTMLDivElement>(null);
   const [gridSize, setGridSize] = useState({ width: 0, height: 0 });
   const [userState, setUserState] = useState<ShareUserState>({
@@ -773,8 +773,8 @@ export default function WatchAllPage() {
           const { participantId, displayName, color, canvasFallback } = event.payload;
           setTiles((prev) => {
             if (prev.some((t) => t.participantId === participantId)) return prev;
-            const restoredVolume = pendingRestoreVolumesRef.current.get(participantId);
-            if (restoredVolume !== undefined) {
+            const restored = pendingRestoreVolumesRef.current.get(participantId);
+            if (restored !== undefined) {
               pendingRestoreVolumesRef.current.delete(participantId);
             }
             const baseTile = {
@@ -791,9 +791,9 @@ export default function WatchAllPage() {
             };
             return [
               ...prev,
-              restoredVolume === undefined
+              restored === undefined
                 ? baseTile
-                : { ...baseTile, muted: restoredVolume === 0, volume: restoredVolume },
+                : { ...baseTile, muted: restored.muted, volume: restored.volume },
             ];
           });
         },
@@ -820,33 +820,39 @@ export default function WatchAllPage() {
         },
       );
 
-      const unlistenRestoreVolume = await listen<{ participantId: string; volume: number }>(
+      const unlistenRestoreVolume = await listen<{ participantId: string; volume: number; muted: boolean }>(
         'watch-all:restore-volume',
         (event) => {
-          const { participantId, volume } = event.payload;
+          const { participantId, volume, muted } = event.payload;
           setTiles((prev) => {
             let found = false;
             const next = prev.map((tile) => {
               if (tile.participantId !== participantId) return tile;
               found = true;
-              // volume=0 means muted; preserve the slider position so unmute restores correctly
-              return { ...tile, volume, muted: volume === 0 };
+              return { ...tile, volume, muted };
             });
             if (!found) {
-              pendingRestoreVolumesRef.current.set(participantId, volume);
+              pendingRestoreVolumesRef.current.set(participantId, { volume, muted });
             }
             return next;
           });
+          setAudioTiles((prev) =>
+            prev.map((tile) =>
+              tile.participantId === participantId
+                ? { ...tile, volume, muted }
+                : tile,
+            ),
+          );
         },
       );
 
-      const unlistenAudioAdded = await listen<{ participantId: string; displayName: string; color: string; volume: number }>(
+      const unlistenAudioAdded = await listen<{ participantId: string; displayName: string; color: string; volume: number; muted: boolean }>(
         'watch-all:audio-share-added',
         (event) => {
-          const { participantId, displayName, color, volume } = event.payload;
+          const { participantId, displayName, color, volume, muted } = event.payload;
           setAudioTiles((prev) => {
             if (prev.some((t) => t.participantId === participantId)) return prev;
-            return [...prev, { participantId, displayName, color, muted: false, volume }];
+            return [...prev, { participantId, displayName, color, muted, volume }];
           });
         },
       );
@@ -961,7 +967,7 @@ export default function WatchAllPage() {
         if (t.participantId !== participantId) return t;
         handled = true;
         const nextMuted = !t.muted;
-        emit('watch-all:local-audio', { participantId, volume: nextMuted ? 0 : t.volume });
+        emit('watch-all:mute-change', { participantId, muted: nextMuted });
         return { ...t, muted: nextMuted };
       });
       return handled ? next : prev;
@@ -971,7 +977,7 @@ export default function WatchAllPage() {
         prev.map((t) => {
           if (t.participantId !== participantId) return t;
           const nextMuted = !t.muted;
-          emit('watch-all:local-audio', { participantId, volume: nextMuted ? 0 : t.volume });
+          emit('watch-all:mute-change', { participantId, muted: nextMuted });
           return { ...t, muted: nextMuted };
         }),
       );
@@ -1064,8 +1070,8 @@ export default function WatchAllPage() {
 
   /* ── Pop-out ── */
 
-  const handlePopOut = useCallback((participantId: string, volume: number) => {
-    emit('watch-all:pop-out', { participantId, volume });
+  const handlePopOut = useCallback((participantId: string, volume: number, muted: boolean) => {
+    emit('watch-all:pop-out', { participantId, volume, muted });
   }, []);
 
   /* ── Close button ── */

--- a/clients/wavis-gui/src/features/screen-share/__tests__/WatchAllPage.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/WatchAllPage.test.ts
@@ -125,23 +125,22 @@ function setTileVolume(
 function popOutTile(
   tiles: ShareTileState[],
   participantId: string,
-): { remainingTiles: ShareTileState[]; payload: { participantId: string; volume: number } | null } {
+): { remainingTiles: ShareTileState[]; payload: { participantId: string; volume: number; muted: boolean } | null } {
   const tile = tiles.find((t) => t.participantId === participantId) ?? null;
   if (!tile) return { remainingTiles: tiles, payload: null };
   return {
     remainingTiles: removeTile(tiles, participantId),
-    // Send slider position (tile.volume); mute-toggle is local-only, not inherited by pop-out
-    payload: { participantId, volume: tile.volume },
+    payload: { participantId, volume: tile.volume, muted: tile.muted },
   };
 }
 
 function restoreTileVolume(
   tiles: ShareTileState[],
-  payload: { participantId: string; volume: number },
+  payload: { participantId: string; volume: number; muted: boolean },
 ): ShareTileState[] {
   return tiles.map((t) =>
     t.participantId === payload.participantId
-      ? { ...t, volume: payload.volume, muted: payload.volume === 0 }
+      ? { ...t, volume: payload.volume, muted: payload.muted }
       : t,
   );
 }
@@ -325,11 +324,11 @@ describe('WatchAllPage tile state management', () => {
   /* ── Double-click emits pop-out event ── */
 
   it('double-click emits watch-all:pop-out event', () => {
-    // WatchAllPage's handlePopOut calls emit('watch-all:pop-out', { participantId })
+    // WatchAllPage's handlePopOut includes the durable slider and mute state.
     // We test the logic: given a participantId, the emitted payload is correct
     const participantId = 'user-1';
-    const payload = { participantId };
-    expect(payload).toEqual({ participantId: 'user-1' });
+    const payload = { participantId, volume: 80, muted: true };
+    expect(payload).toEqual({ participantId: 'user-1', volume: 80, muted: true });
   });
 
   /* ── Canvas fallback tile hides mute toggle ── */
@@ -387,7 +386,7 @@ describe('WatchAllPage tile state management', () => {
 
   /* ── Mute reset to default when tile removed and re-added (Req 15.5) ── */
 
-  it('mute reset to default when tile removed and re-added', () => {
+  it('mute restored when tile removed and re-added', () => {
     let tiles: ShareTileState[] = [];
 
     // Add tile
@@ -415,8 +414,9 @@ describe('WatchAllPage tile state management', () => {
       color: '#E06C75',
       canvasFallback: false,
     });
+    tiles = restoreTileVolume(tiles, { participantId: 'user-1', volume: 70, muted: true });
 
-    expect(tiles[0].muted).toBe(false);
+    expect(tiles[0].muted).toBe(true);
     expect(tiles[0].volume).toBe(70);
   });
 
@@ -454,12 +454,12 @@ describe('WatchAllPage tile state management', () => {
     tiles = setTileVolume(tiles, 'user-1', 60);
 
     // Simulates slider explicitly dragged to 0 in another window (persisted via syncScreenShareVolume)
-    tiles = restoreTileVolume(tiles, { participantId: 'user-1', volume: 0 });
+    tiles = restoreTileVolume(tiles, { participantId: 'user-1', volume: 0, muted: true });
     expect(tiles[0].muted).toBe(true);
     expect(tiles[0].volume).toBe(0); // slider follows the explicit 0
   });
 
-  it('pop-out of muted tile sends slider position (toggle-mute is local-only)', () => {
+  it('pop-out of muted tile sends slider position and mute state', () => {
     let tiles: ShareTileState[] = [];
     tiles = addTile(tiles, { participantId: 'user-1', displayName: 'Alice', color: '#E06C75', canvasFallback: false });
     tiles = setTileVolume(tiles, 'user-1', 80);
@@ -468,7 +468,7 @@ describe('WatchAllPage tile state management', () => {
     expect(tiles[0].volume).toBe(80);
 
     const { payload } = popOutTile(tiles, 'user-1');
-    expect(payload?.volume).toBe(80); // slider position, not effective volume (mute is local)
+    expect(payload).toEqual({ participantId: 'user-1', volume: 80, muted: true });
   });
 
   it('pop-out of unmuted tile sends slider position', () => {
@@ -477,7 +477,7 @@ describe('WatchAllPage tile state management', () => {
     tiles = setTileVolume(tiles, 'user-1', 45);
 
     const { payload } = popOutTile(tiles, 'user-1');
-    expect(payload?.volume).toBe(45);
+    expect(payload).toEqual({ participantId: 'user-1', volume: 45, muted: false });
   });
 
   it('volume persists across pop-out and pop-back', () => {
@@ -494,7 +494,7 @@ describe('WatchAllPage tile state management', () => {
     expect(tiles[0].muted).toBe(false);
 
     const { remainingTiles, payload } = popOutTile(tiles, 'user-1');
-    expect(payload).toEqual({ participantId: 'user-1', volume: 50 });
+    expect(payload).toEqual({ participantId: 'user-1', volume: 50, muted: false });
     expect(remainingTiles).toHaveLength(0);
 
     let restoredTiles = addTile(remainingTiles, {
@@ -507,6 +507,29 @@ describe('WatchAllPage tile state management', () => {
 
     expect(restoredTiles[0].volume).toBe(50);
     expect(restoredTiles[0].muted).toBe(false);
+  });
+
+  it('mute persists across pop-out and pop-back without losing slider position', () => {
+    let tiles = addTile([], {
+      participantId: 'user-1',
+      displayName: 'Alice',
+      color: '#E06C75',
+      canvasFallback: false,
+    });
+    tiles = setTileVolume(tiles, 'user-1', 80);
+    tiles = toggleMute(tiles, 'user-1');
+
+    const { remainingTiles, payload } = popOutTile(tiles, 'user-1');
+    let restoredTiles = addTile(remainingTiles, {
+      participantId: 'user-1',
+      displayName: 'Alice',
+      color: '#E06C75',
+      canvasFallback: false,
+    });
+    restoredTiles = restoreTileVolume(restoredTiles, payload!);
+
+    expect(restoredTiles[0].volume).toBe(80);
+    expect(restoredTiles[0].muted).toBe(true);
   });
 
   /* ── Duplicate add is a no-op ── */

--- a/clients/wavis-gui/src/features/settings/settings-store.ts
+++ b/clients/wavis-gui/src/features/settings/settings-store.ts
@@ -32,6 +32,7 @@ export interface ChannelVolumePrefs {
   master: number;
   participants: Record<string, number>;
   streams?: Record<string, number>;
+  streamMutes?: Record<string, boolean>;
 }
 
 export type WindowsSharePathPreference = 'browser' | 'native';

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -47,6 +47,8 @@ import {
   setScreenShareAudioVolume,
   persistStreamVolume,
   getPersistedStreamVolume,
+  persistStreamMuted,
+  getPersistedStreamMuted,
   activeShareType,
   computeStopRoute,
   startFallbackShare,
@@ -716,9 +718,10 @@ export default function ActiveRoom() {
   const [shareVolumes, setShareVolumes] = useState<Map<string, number>>(new Map());
   const shareVolumesRef = useRef(shareVolumes);
   const watchAllVolumesRef = useRef<Map<string, number>>(new Map());
+  const [shareMuted, setShareMuted] = useState<Map<string, boolean>>(new Map());
+  const shareMutedRef = useRef(shareMuted);
   // Local mute state: key = participantId, value = pre-mute volume (presence means muted).
   const [localMicMuted, setLocalMicMuted] = useState<Map<string, number>>(new Map());
-  const [localSysMuted, setLocalSysMuted] = useState<Map<string, number>>(new Map());
   const watchAllAttachedAudioRef = useRef<Set<string>>(new Set());
   const [shareQualityState, setShareQualityState] = useState<ShareQuality>('high');
   const [shareAudioOn, setShareAudioOn] = useState(false);
@@ -798,6 +801,10 @@ export default function ActiveRoom() {
     shareVolumesRef.current = shareVolumes;
   }, [shareVolumes]);
 
+  useEffect(() => {
+    shareMutedRef.current = shareMuted;
+  }, [shareMuted]);
+
   const prevStreamsRef = useRef<Map<string, MediaStream | null>>(new Map());
   useEffect(() => {
     if (!roomState) return;
@@ -813,7 +820,8 @@ export default function ActiveRoom() {
           shareVolumesRef.current.get(id) ??
           getPersistedStreamVolume(id) ??
           70;
-        setScreenShareAudioVolume(id, volume);
+        const muted = shareMutedRef.current.get(id) ?? getPersistedStreamMuted(id) ?? (volume === 0);
+        setScreenShareAudioVolume(id, muted ? 0 : volume);
       }
     }
     prevStreamsRef.current = new Map(roomState.screenShareStreams);
@@ -832,6 +840,40 @@ export default function ActiveRoom() {
     return watchAllVolumesRef.current.get(participantId) ?? shareVolumesRef.current.get(participantId) ?? getPersistedStreamVolume(participantId) ?? 70;
   }, []);
 
+  const getSavedShareMuted = useCallback((participantId: string) => {
+    return shareMutedRef.current.get(participantId) ?? getPersistedStreamMuted(participantId) ?? (getSavedShareVolume(participantId) === 0);
+  }, [getSavedShareVolume]);
+
+  const applySavedScreenShareAudio = useCallback((participantId: string) => {
+    const volume = getSavedShareVolume(participantId);
+    setScreenShareAudioVolume(participantId, getSavedShareMuted(participantId) ? 0 : volume);
+  }, [getSavedShareMuted, getSavedShareVolume]);
+
+  const syncScreenShareMuted = useCallback((participantId: string, muted: boolean) => {
+    const savedVolume = getSavedShareVolume(participantId);
+    const restoredVolume = !muted && savedVolume === 0 ? 70 : savedVolume;
+    if (restoredVolume !== savedVolume) {
+      watchAllVolumesRef.current.set(participantId, restoredVolume);
+      setShareVolumes((prev) => {
+        const next = new Map(prev);
+        next.set(participantId, restoredVolume);
+        return next;
+      });
+      persistStreamVolume(participantId, restoredVolume);
+    }
+    shareMutedRef.current.set(participantId, muted);
+    setShareMuted((prev) => {
+      if (prev.get(participantId) === muted) return prev;
+      const next = new Map(prev);
+      next.set(participantId, muted);
+      return next;
+    });
+    persistStreamMuted(participantId, muted);
+    setScreenShareAudioVolume(participantId, muted ? 0 : restoredVolume);
+    emit('watch-all:restore-volume', { participantId, volume: restoredVolume, muted });
+    emit('screen-share:restore-volume', { participantId, volume: restoredVolume, muted });
+  }, [getSavedShareVolume]);
+
   const syncScreenShareVolume = useCallback((participantId: string, volume: number) => {
     setShareVolumes((prev) => {
       if (prev.get(participantId) === volume) return prev;
@@ -840,10 +882,19 @@ export default function ActiveRoom() {
       return next;
     });
     watchAllVolumesRef.current.set(participantId, volume);
-    setScreenShareAudioVolume(participantId, volume);
+    const muted = volume === 0;
+    shareMutedRef.current.set(participantId, muted);
+    setShareMuted((prev) => {
+      if (prev.get(participantId) === muted) return prev;
+      const next = new Map(prev);
+      next.set(participantId, muted);
+      return next;
+    });
+    setScreenShareAudioVolume(participantId, muted ? 0 : volume);
     persistStreamVolume(participantId, volume);
-    emit('watch-all:restore-volume', { participantId, volume });
-    emit('screen-share:restore-volume', { participantId, volume });
+    persistStreamMuted(participantId, muted);
+    emit('watch-all:restore-volume', { participantId, volume, muted });
+    emit('screen-share:restore-volume', { participantId, volume, muted });
   }, []);
 
   const toggleLocalMicMute = useCallback((participantId: string, currentVolume: number) => {
@@ -861,28 +912,13 @@ export default function ActiveRoom() {
     });
   }, []);
 
-  const toggleLocalSysMute = useCallback((participantId: string) => {
-    setLocalSysMuted((prev) => {
-      const next = new Map(prev);
-      if (next.has(participantId)) {
-        const saved = next.get(participantId)!;
-        next.delete(participantId);
-        setScreenShareAudioVolume(participantId, saved);
-      } else {
-        const current = watchAllVolumesRef.current.get(participantId) ?? shareVolumesRef.current.get(participantId) ?? 70;
-        next.set(participantId, current || 70);
-        setScreenShareAudioVolume(participantId, 0);
-      }
-      return next;
-    });
-  }, []);
-
   const emitWatchAllRestoreVolume = useCallback((participantId: string) => {
     emit('watch-all:restore-volume', {
       participantId,
       volume: getSavedShareVolume(participantId),
+      muted: getSavedShareMuted(participantId),
     });
-  }, [getSavedShareVolume]);
+  }, [getSavedShareMuted, getSavedShareVolume]);
 
   const getWatchAllScope = useCallback((currentState: VoiceRoomState | null) => {
     if (!currentState || !currentState.joinedSubRoomId) {
@@ -933,7 +969,7 @@ export default function ActiveRoom() {
       }
       console.log('[wavis:active-room] handleViewerReady: attaching watch-all audio for', participantId);
       attachScreenShareAudio(participantId);
-      setScreenShareAudioVolume(participantId, getSavedShareVolume(participantId));
+      applySavedScreenShareAudio(participantId);
       watchAllAttachedAudioRef.current.add(participantId);
       void emit('share:user-state', shareUserStateRef.current);
       void emit('watch-all:voice-participants', watchAllVoiceParticipantsRef.current);
@@ -943,10 +979,10 @@ export default function ActiveRoom() {
     const shareWindow = shareWindowsRef.current.get(participantId);
     if (!shareWindow || shareWindow.window.label !== windowLabel) return;
     attachScreenShareAudio(participantId);
-    setScreenShareAudioVolume(participantId, getSavedShareVolume(participantId));
+    applySavedScreenShareAudio(participantId);
     void emit('share:user-state', shareUserStateRef.current);
     void emit('share:voice-participants', voiceParticipantsRef.current);
-  }, [getSavedShareVolume]);
+  }, [applySavedScreenShareAudio]);
 
   /** Re-add a participant's stream to the Watch All grid after their pop-out closes. */
   const reAddStreamToWatchAll = (participantId: string) => {
@@ -975,7 +1011,7 @@ export default function ActiveRoom() {
     // the viewer-ready attach) and the existing-tile path.
     if (!shareWindowsRef.current.has(participantId)) {
       attachScreenShareAudio(participantId);
-      setScreenShareAudioVolume(participantId, getSavedShareVolume(participantId));
+      applySavedScreenShareAudio(participantId);
       watchAllAttachedAudioRef.current.add(participantId);
     }
   };
@@ -1078,15 +1114,14 @@ export default function ActiveRoom() {
         syncScreenShareVolume(participantId, volume);
       }),
     );
-    // Local mute toggle: sets gain only, does not persist to shareVolumes/watchAllVolumesRef
     cleanups.push(
-      listen<{ participantId: string; volume: number }>('watch-all:local-audio', (event) => {
-        setScreenShareAudioVolume(event.payload.participantId, event.payload.volume);
+      listen<{ participantId: string; muted: boolean }>('watch-all:mute-change', (event) => {
+        syncScreenShareMuted(event.payload.participantId, event.payload.muted);
       }),
     );
     cleanups.push(
-      listen<{ participantId: string; volume: number }>('screen-share:local-audio', (event) => {
-        setScreenShareAudioVolume(event.payload.participantId, event.payload.volume);
+      listen<{ participantId: string; muted: boolean }>('screen-share:mute-change', (event) => {
+        syncScreenShareMuted(event.payload.participantId, event.payload.muted);
       }),
     );
     cleanups.push(
@@ -1118,7 +1153,7 @@ export default function ActiveRoom() {
     return () => {
       for (const p of cleanups) p.then((fn) => fn());
     };
-  }, [syncScreenShareVolume]); // syncScreenShareVolume is stable (useCallback[]) but listed for exhaustive-deps
+  }, [syncScreenShareMuted, syncScreenShareVolume]);
 
   useEffect(() => {
     const unlisten = listen<{ participantId: string; windowLabel: string }>('screen-share-viewer:ready', (event) => {
@@ -1151,10 +1186,13 @@ export default function ActiveRoom() {
 
   // Watch All: listen for pop-out request from WatchAllPage
   useEffect(() => {
-    const unlisten = listen<{ participantId: string; volume?: number }>('watch-all:pop-out', (event) => {
+    const unlisten = listen<{ participantId: string; volume?: number; muted?: boolean }>('watch-all:pop-out', (event) => {
       const pid = event.payload.participantId;
       if (typeof event.payload.volume === 'number') {
         syncScreenShareVolume(pid, event.payload.volume);
+      }
+      if (typeof event.payload.muted === 'boolean') {
+        syncScreenShareMuted(pid, event.payload.muted);
       }
       const rs = roomStateRef.current;
       const participant = rs?.participants.find((p) => p.id === pid);
@@ -1169,7 +1207,7 @@ export default function ActiveRoom() {
       openShareWindow(pid, participant, rs?.screenShareStreams.get(pid) ?? null, 'watch-all');
     });
     return () => { unlisten.then((fn) => fn?.()); };
-  }, [syncScreenShareVolume]);
+  }, [syncScreenShareMuted, syncScreenShareVolume]);
 
   useEffect(() => {
     const unlisten = listen<{ participantId: string }>('watch-all:request-resend', (event) => {
@@ -1238,7 +1276,7 @@ export default function ActiveRoom() {
           console.log(LOG_SS, `resendStream(${pid}, 'watch-all') — stream: ${stream?.id}, prevStream: ${prevStream?.id ?? 'none'}, active: ${stream?.active}, ts: ${Date.now()}`);
           resendStream(pid, 'watch-all', stream);
           attachScreenShareAudio(pid);
-          setScreenShareAudioVolume(pid, getSavedShareVolume(pid));
+          applySavedScreenShareAudio(pid);
           watchAllAttachedAudioRef.current.add(pid);
         }
       }
@@ -1267,15 +1305,16 @@ export default function ActiveRoom() {
       const participant = roomState.participants.find((p) => p.id === identity);
       if (!participant) continue;
       const vol = getSavedShareVolume(identity);
-      setScreenShareAudioVolume(identity, vol);
-      void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol });
+      const muted = getSavedShareMuted(identity);
+      applySavedScreenShareAudio(identity);
+      void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted });
     }
     for (const identity of prev) {
       if (curr.has(identity)) continue;
       void emit('watch-all:audio-share-removed', { participantId: identity });
     }
     prevAudioOnlySharersRef.current = new Set(curr);
-  }, [watchAllOpen, roomState?.audioOnlySharers, roomState?.participants, getSavedShareVolume]);
+  }, [applySavedScreenShareAudio, getSavedShareMuted, getSavedShareVolume, watchAllOpen, roomState?.audioOnlySharers, roomState?.participants]);
 
   // Watch All: emit share-updated when participant info changes
   const prevParticipantsRef = useRef<Map<string, { displayName: string; color: string }>>(new Map());
@@ -1418,6 +1457,7 @@ export default function ActiveRoom() {
       isOwner: isSelf,
       canvasFallback: stream === null,
       initialVolume: getSavedShareVolume(participantId),
+      initialMuted: getSavedShareMuted(participantId),
     };
     const hash = encodeURIComponent(JSON.stringify(params));
     const windowLabel = `screen-share-${participantId}`;
@@ -1431,7 +1471,7 @@ export default function ActiveRoom() {
 
         nativeShareViewersRef.current.add(participantId);
         attachScreenShareAudio(participantId);
-        setScreenShareAudioVolume(participantId, getSavedShareVolume(participantId));
+        applySavedScreenShareAudio(participantId);
         setWatchingShareIds((prev) => new Set(prev).add(participantId));
 
         if (watchAllWindowRef.current && watchAllReadyRef.current) {
@@ -1730,8 +1770,9 @@ export default function ActiveRoom() {
           const participant = scope.participants.find((p) => p.id === identity);
           if (!participant) continue;
           const vol = getSavedShareVolume(identity);
-          setScreenShareAudioVolume(identity, vol);
-          void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol });
+          const muted = getSavedShareMuted(identity);
+          applySavedScreenShareAudio(identity);
+          void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted });
         }
         prevAudioOnlySharersRef.current = new Set(rs.audioOnlySharers);
       });
@@ -2619,21 +2660,20 @@ export default function ActiveRoom() {
                 <span className="text-wavis-text-secondary shrink-0">share vol</span>
                 <div className="flex-1">
                   <VolumeSlider
-                    value={shareVolumes.get(p.id) ?? 70}
+                    value={shareVolumes.get(p.id) ?? getSavedShareVolume(p.id)}
                     onChange={(v) => {
-                      if (localSysMuted.has(p.id)) setLocalSysMuted((prev) => { const next = new Map(prev); next.delete(p.id); return next; });
                       syncScreenShareVolume(p.id, v);
                     }}
                     color={p.color}
                   />
                 </div>
-                <span className="text-wavis-text-secondary w-6 text-right">{localSysMuted.has(p.id) ? 0 : (shareVolumes.get(p.id) ?? 70)}</span>
+                <span className="text-wavis-text-secondary w-6 text-right">{getSavedShareMuted(p.id) ? 0 : (shareVolumes.get(p.id) ?? getSavedShareVolume(p.id))}</span>
                 <button
-                  onClick={() => toggleLocalSysMute(p.id)}
+                  onClick={() => syncScreenShareMuted(p.id, !getSavedShareMuted(p.id))}
                   className="text-xs border px-1 py-0.5 transition-colors hover:opacity-70 shrink-0"
-                  style={localSysMuted.has(p.id) ? { color: 'var(--wavis-warn)', borderColor: 'var(--wavis-warn)' } : undefined}
-                  title={localSysMuted.has(p.id) ? 'unmute sys audio (local)' : 'mute sys audio (local)'}
-                >{localSysMuted.has(p.id) ? '/unmute' : '/mute'}</button>
+                  style={getSavedShareMuted(p.id) ? { color: 'var(--wavis-warn)', borderColor: 'var(--wavis-warn)' } : undefined}
+                  title={getSavedShareMuted(p.id) ? 'unmute sys audio (local)' : 'mute sys audio (local)'}
+                >{getSavedShareMuted(p.id) ? '/unmute' : '/mute'}</button>
               </div>
             )}
             {isHost && (

--- a/clients/wavis-gui/src/features/voice/__tests__/ActiveRoom-watchall-audio.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/ActiveRoom-watchall-audio.test.ts
@@ -14,6 +14,7 @@ interface ViewerAudioState {
   watchAllOpen: boolean;
   watchAllReady: boolean;
   savedVolumes: Map<string, number>;
+  savedMuted: Map<string, boolean>;
   watchAllAttachedAudio: Set<string>;
 }
 
@@ -24,6 +25,7 @@ function createState(overrides: Partial<ViewerAudioState> = {}): ViewerAudioStat
     watchAllOpen: false,
     watchAllReady: false,
     savedVolumes: new Map(),
+    savedMuted: new Map(),
     watchAllAttachedAudio: new Set(),
     ...overrides,
   };
@@ -81,7 +83,8 @@ function onViewerReady(
     if (!state.watchAllOpen || !state.watchAllReady) return;
     if (state.shareWindows.has(event.participantId)) return;
     deps.attachScreenShareAudio(event.participantId);
-    deps.setScreenShareAudioVolume(event.participantId, state.savedVolumes.get(event.participantId) ?? 70);
+    const volume = state.savedVolumes.get(event.participantId) ?? 70;
+    deps.setScreenShareAudioVolume(event.participantId, state.savedMuted.get(event.participantId) ? 0 : volume);
     state.watchAllAttachedAudio.add(event.participantId);
     return;
   }
@@ -90,7 +93,8 @@ function onViewerReady(
   if (currentWindowLabel !== event.windowLabel) return;
 
   deps.attachScreenShareAudio(event.participantId);
-  deps.setScreenShareAudioVolume(event.participantId, state.savedVolumes.get(event.participantId) ?? 70);
+  const volume = state.savedVolumes.get(event.participantId) ?? 70;
+  deps.setScreenShareAudioVolume(event.participantId, state.savedMuted.get(event.participantId) ? 0 : volume);
 }
 
 function onDirectViewerStreamChanged(
@@ -171,6 +175,23 @@ describe('ActiveRoom viewer audio orchestration', () => {
 
     expect(attachScreenShareAudio).toHaveBeenCalledWith('user-1');
     expect(setScreenShareAudioVolume).toHaveBeenCalledWith('user-1', 55);
+  });
+
+  it('attaches muted pop-out audio at zero without overwriting its saved slider volume', () => {
+    const state = createState({
+      activeShares: new Set(['user-1']),
+      shareWindows: new Map([['user-1', 'screen-share-user-1']]),
+      savedVolumes: new Map([['user-1', 55]]),
+      savedMuted: new Map([['user-1', true]]),
+    });
+
+    onViewerReady(state, { participantId: 'user-1', windowLabel: 'screen-share-user-1' }, {
+      attachScreenShareAudio,
+      setScreenShareAudioVolume,
+    });
+
+    expect(setScreenShareAudioVolume).toHaveBeenCalledWith('user-1', 0);
+    expect(state.savedVolumes.get('user-1')).toBe(55);
   });
 
   it('ignores stale pop-out ready events after the window is gone', () => {

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -311,6 +311,8 @@ import {
   getState,
   persistStreamVolume,
   getPersistedStreamVolume,
+  persistStreamMuted,
+  getPersistedStreamMuted,
 } from '../voice-room';
 import type { VoiceRoomState } from '../voice-room';
 import * as settingsStore from '@features/settings/settings-store';
@@ -3068,6 +3070,44 @@ describe('stream volume persistence', () => {
     await driveToActive(); // peer-2 has userId u2
 
     expect(getPersistedStreamVolume('peer-2')).toBe(55);
+    leaveRoom();
+  });
+
+  it('persistStreamMuted stores mute separately from the slider volume', async () => {
+    await driveToActive();
+
+    persistStreamVolume('peer-2', 65);
+    persistStreamMuted('peer-2', true);
+
+    expect(getPersistedStreamVolume('peer-2')).toBe(65);
+    expect(getPersistedStreamMuted('peer-2')).toBe(true);
+    leaveRoom();
+  });
+
+  it('getPersistedStreamMuted returns saved mute loaded from channel prefs on join', async () => {
+    vi.mocked(settingsStore.getChannelVolumes).mockResolvedValueOnce({
+      master: 70,
+      participants: {},
+      streams: { u2: 55 },
+      streamMutes: { u2: true },
+    });
+
+    await driveToActive();
+
+    expect(getPersistedStreamMuted('peer-2')).toBe(true);
+    leaveRoom();
+  });
+
+  it('getPersistedStreamMuted treats legacy saved volume 0 as muted', async () => {
+    vi.mocked(settingsStore.getChannelVolumes).mockResolvedValueOnce({
+      master: 70,
+      participants: {},
+      streams: { u2: 0 },
+    });
+
+    await driveToActive();
+
+    expect(getPersistedStreamMuted('peer-2')).toBe(true);
     leaveRoom();
   });
 });

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2123,7 +2123,12 @@ function saveVolumesDebounced(): void {
         participantVols[p.userId] = p.volume;
       }
     }
-    const prefs: ChannelVolumePrefs = { master: state.masterVolume, participants: participantVols, streams: { ...(channelVolumePrefs?.streams ?? {}) } };
+    const prefs: ChannelVolumePrefs = {
+      master: state.masterVolume,
+      participants: participantVols,
+      streams: { ...(channelVolumePrefs?.streams ?? {}) },
+      streamMutes: { ...(channelVolumePrefs?.streamMutes ?? {}) },
+    };
     channelVolumePrefs = prefs;
     setChannelVolumes(state.channelId, prefs).catch((err) => {
       console.warn(LOG, 'failed to persist channel volumes:', err);
@@ -3929,6 +3934,7 @@ export function leaveRoom(): void {
       master: state.masterVolume,
       participants: flushParticipantVols,
       streams: { ...(channelVolumePrefs.streams ?? {}) },
+      streamMutes: { ...(channelVolumePrefs.streamMutes ?? {}) },
     }).catch(() => {});
   }
 
@@ -4746,6 +4752,29 @@ export function getPersistedStreamVolume(participantId: string): number | null {
   const p = state.participants.find((pp) => pp.id === participantId);
   if (!p?.userId) return null;
   return channelVolumePrefs.streams[p.userId] ?? null;
+}
+
+export function persistStreamMuted(participantId: string, muted: boolean): void {
+  const p = state.participants.find((pp) => pp.id === participantId);
+  if (p?.userId) {
+    if (!channelVolumePrefs) {
+      channelVolumePrefs = { master: state.masterVolume, participants: {} };
+    }
+    channelVolumePrefs = {
+      ...channelVolumePrefs,
+      streamMutes: { ...(channelVolumePrefs.streamMutes ?? {}), [p.userId]: muted },
+    };
+  }
+  saveVolumesDebounced();
+}
+
+export function getPersistedStreamMuted(participantId: string): boolean | null {
+  const p = state.participants.find((pp) => pp.id === participantId);
+  if (!p?.userId) return null;
+  const savedMute = channelVolumePrefs?.streamMutes?.[p.userId];
+  if (savedMute !== undefined) return savedMute;
+  // Backward compatibility: older preferences represented mute as volume 0.
+  return channelVolumePrefs?.streams?.[p.userId] === 0 ? true : null;
 }
 
 export function kickParticipant(participantId: string): void {

--- a/wavis-backend/tests/ws_dispatch_newer_variants.rs
+++ b/wavis-backend/tests/ws_dispatch_newer_variants.rs
@@ -417,9 +417,8 @@ async fn deafened_state_visible_in_room_state_for_late_joiner() {
     let participants = joined["participants"].as_array().unwrap();
     let p1 = participants.iter().find(|p| p["participantId"].as_str() == Some(&peer1));
     assert!(p1.is_some(), "peer1 should be in participants list");
-    assert_eq!(
+    assert!(
         p1.unwrap()["isDeafened"].as_bool().unwrap_or(false),
-        true,
         "peer1 should be marked as deafened for late joiner"
     );
 }


### PR DESCRIPTION
## Summary
- persist remote stream mute separately from its slider volume per channel and remote user
- keep direct viewers, Watch All, audio-only tiles, and main-room stream controls synchronized across pop-out, pop-back, close/reopen, share restart, and app restart
- preserve legacy saved volume 0 as muted and fix two existing Rust clippy failures found during validation

## Testing
- Not run per request
- git diff --check origin/pre-dev...HEAD passed