### PR TITLE
[codex] add screen share loading state and share type metadata

### DIFF
--- a/clients/shared/src/call_session.rs
+++ b/clients/shared/src/call_session.rs
@@ -210,7 +210,7 @@ impl<
                 | SignalingMessage::ParticipantKicked(_)
                 | SignalingMessage::ParticipantMuted(_)
                 | SignalingMessage::ParticipantUnmuted(_)
-                | SignalingMessage::StartShare
+                | SignalingMessage::StartShare(_)
                 | SignalingMessage::ShareStarted(_)
                 | SignalingMessage::StopShare(_)
                 | SignalingMessage::ShareStopped(_)

--- a/clients/shared/src/room_session/screen_share.rs
+++ b/clients/shared/src/room_session/screen_share.rs
@@ -49,7 +49,7 @@ where
             return Err(RoomError::NotInRoom);
         }
         self.signaling
-            .send(&SignalingMessage::StartShare)
+            .send(&SignalingMessage::StartShare(Default::default()))
             .map_err(|e| RoomError::Signaling(e.to_string()))
     }
 

--- a/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ScreenSharePage.tsx
@@ -4,7 +4,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { startReceiving, stopReceiving } from './screen-share-viewer';
 import type { ShareQuality } from '@features/voice/voice-room';
-import { useShareTransitionOverlay } from './share-transition';
+import { shouldShowShareLoadingOverlay, useShareTransitionOverlay } from './share-transition';
 import { useVideoStallDetector } from './useVideoStallDetector';
 import { useShareReconnect } from './useShareReconnect';
 import { useAutoHide } from '@shared/hooks/useAutoHide';
@@ -12,6 +12,7 @@ import { useFullscreen } from '@shared/hooks/useFullscreen';
 import StreamHoverBar from '@shared/StreamHoverBar';
 import type { MixerParticipant } from '@shared/ParticipantMixer';
 import ShareSwitchingOverlay from './ShareSwitchingOverlay';
+import ShareLoadingOverlay from './ShareLoadingOverlay';
 
 /* ─── Constants ─────────────────────────────────────────────────── */
 
@@ -79,7 +80,7 @@ export default function ScreenSharePage() {
   const [voiceParticipants, setVoiceParticipants] = useState<MixerParticipant[]>([]);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [debugInfo, setDebugInfo] = useState('init');
-  const { isSwitching, markFrameRendered } = useShareTransitionOverlay({
+  const { isSwitching, hasRenderedFrame, markFrameRendered } = useShareTransitionOverlay({
     hasSurface: Boolean(stream) || Boolean(shareParams?.canvasFallback),
     hasError: Boolean(error),
   });
@@ -684,6 +685,7 @@ export default function ScreenSharePage() {
           </div>
         )}
         {isSwitching && <ShareSwitchingOverlay displayName={p.username} />}
+        {shouldShowShareLoadingOverlay(hasRenderedFrame, Boolean(error)) && <ShareLoadingOverlay />}
 
         {/* Zoom overlay */}
         {zoom > 1 && (

--- a/clients/wavis-gui/src/features/screen-share/ShareLoadingOverlay.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ShareLoadingOverlay.tsx
@@ -1,0 +1,23 @@
+interface ShareLoadingOverlayProps {
+  compact?: boolean;
+}
+
+export default function ShareLoadingOverlay({ compact = false }: ShareLoadingOverlayProps) {
+  return (
+    <div className="absolute inset-0 pointer-events-none flex items-center justify-center bg-wavis-overlay-base/80">
+      <div className="flex items-center gap-1.5" aria-label="Loading screen share">
+        {[0, 1, 2].map((bar) => (
+          <span
+            key={bar}
+            className="inline-block w-1 bg-wavis-purple"
+            style={{
+              height: compact ? '0.7rem' : '0.9rem',
+              animation: 'pulse 1.2s ease-in-out infinite',
+              animationDelay: `${bar * 0.16}s`,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -5,7 +5,7 @@ import { getCurrentWindow } from '@tauri-apps/api/window';
 import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { StreamReceiver } from './screen-share-viewer';
 import { computeWatchAllLayout } from './watch-all-grid';
-import { useShareTransitionOverlay } from './share-transition';
+import { shouldShowShareLoadingOverlay, useShareTransitionOverlay } from './share-transition';
 import { isPlaybackHealthyWithoutFreshFrames } from './useVideoStallDetector';
 import {
   WATCH_ALL_TEST_READY_EVENT,
@@ -21,6 +21,7 @@ import QuickActionButtons from '@shared/QuickActionButtons';
 import FocusMainButton from '@shared/FocusMainButton';
 import FullscreenButton from '@shared/FullscreenButton';
 import ShareSwitchingOverlay from './ShareSwitchingOverlay';
+import ShareLoadingOverlay from './ShareLoadingOverlay';
 
 /* ─── Constants ─────────────────────────────────────────────────── */
 
@@ -137,7 +138,7 @@ const ShareTile = memo(function ShareTile({
   const [hovered, setHovered] = useState(false);
   const [diagnosticViewport, setDiagnosticViewport] = useState({ width: 0, height: 0 });
   const { isVisible: labelVisible, resetTimer: revealLabel } = useAutoHide({ delayMs: LABEL_FADE_DELAY_MS });
-  const { isSwitching, markFrameRendered } = useShareTransitionOverlay({
+  const { isSwitching, hasRenderedFrame, markFrameRendered } = useShareTransitionOverlay({
     hasSurface: isDiagnosticTest || canvasFallback || Boolean(stream),
     hasError: Boolean(error),
   });
@@ -588,6 +589,7 @@ const ShareTile = memo(function ShareTile({
         </div>
       )}
       {isSwitching && <ShareSwitchingOverlay compact displayName={displayName} />}
+      {!isDiagnosticTest && shouldShowShareLoadingOverlay(hasRenderedFrame, Boolean(error)) && <ShareLoadingOverlay compact />}
 
       {/* Pop-out icon (top-right on hover) */}
       {hovered && !isDiagnosticTest && (

--- a/clients/wavis-gui/src/features/screen-share/__tests__/share-transition.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/share-transition.test.ts
@@ -4,7 +4,22 @@ import {
   SHARE_TRANSITION_THRESHOLD_MS,
   SHARE_STREAM_STABILIZATION_MS,
   shouldShowShareTransitionOverlay,
+  shouldShowShareLoadingOverlay,
 } from '../share-transition';
+
+describe('shouldShowShareLoadingOverlay', () => {
+  it('shows before the first painted frame', () => {
+    expect(shouldShowShareLoadingOverlay(false, false)).toBe(true);
+  });
+
+  it('dismisses after the first painted frame', () => {
+    expect(shouldShowShareLoadingOverlay(true, false)).toBe(false);
+  });
+
+  it('stays hidden while an explicit error is rendered', () => {
+    expect(shouldShowShareLoadingOverlay(false, true)).toBe(false);
+  });
+});
 
 describe('shouldShowShareTransitionOverlay', () => {
   it('returns false when no render surface is active', () => {

--- a/clients/wavis-gui/src/features/screen-share/share-transition.ts
+++ b/clients/wavis-gui/src/features/screen-share/share-transition.ts
@@ -4,6 +4,10 @@ export const SHARE_TRANSITION_THRESHOLD_MS = 1200;
 export const SHARE_STREAM_STABILIZATION_MS = 2000;
 const SHARE_TRANSITION_POLL_MS = 250;
 
+export function shouldShowShareLoadingOverlay(hasRenderedFrame: boolean, hasError: boolean): boolean {
+  return !hasRenderedFrame && !hasError;
+}
+
 interface ShareTransitionVisibilityInput {
   hasSurface: boolean;
   hasRenderedFrame: boolean;
@@ -53,12 +57,14 @@ export function useShareTransitionOverlay({
   thresholdMs = SHARE_TRANSITION_THRESHOLD_MS,
 }: UseShareTransitionOverlayOptions) {
   const [isSwitching, setIsSwitching] = useState(false);
+  const [hasRenderedFrame, setHasRenderedFrame] = useState(false);
   const hasRenderedFrameRef = useRef(false);
   const firstFrameAtRef = useRef<number | null>(null);
   const lastFrameAtRef = useRef<number | null>(null);
 
   const markFrameRendered = useCallback(() => {
     hasRenderedFrameRef.current = true;
+    setHasRenderedFrame(true);
     if (firstFrameAtRef.current === null) {
       firstFrameAtRef.current = Date.now();
     }
@@ -68,6 +74,7 @@ export function useShareTransitionOverlay({
 
   const reset = useCallback(() => {
     hasRenderedFrameRef.current = false;
+    setHasRenderedFrame(false);
     firstFrameAtRef.current = null;
     lastFrameAtRef.current = null;
     setIsSwitching(false);
@@ -112,5 +119,5 @@ export function useShareTransitionOverlay({
     return () => clearInterval(interval);
   }, [hasError, hasSurface, thresholdMs]);
 
-  return { isSwitching, markFrameRendered, reset };
+  return { isSwitching, hasRenderedFrame, markFrameRendered, reset };
 }

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -2507,6 +2507,75 @@ describe('Screen share and device selection', () => {
       mod.disconnect();
     });
 
+    it('keeps legacy screen share audio silent until watched even when video has not arrived yet', async () => {
+      resetAll();
+      const cbs = createMockCallbacks();
+      const mod = new LiveKitModule(cbs);
+      await driveToConnected(mod);
+
+      const setSubscribed = vi.fn();
+      emitRoomEvent(
+        'trackSubscribed',
+        { kind: 'audio', mediaStreamTrack: { id: 'ssa-legacy-race' } },
+        { source: 'screen_share_audio', setSubscribed },
+        { identity: 'alice', getTrackPublication: vi.fn(() => undefined) },
+      );
+
+      const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
+      expect(setSubscribed).toHaveBeenCalledWith(false);
+      expect(audioElementMap.has('alice:screen-share')).toBe(false);
+
+      mod.disconnect();
+    });
+
+    it('autoplays confirmed audio-only shares and detaches autoplay when promoted to video', async () => {
+      resetAll();
+      const cbs = createMockCallbacks();
+      const mod = new LiveKitModule(cbs);
+      await driveToConnected(mod);
+
+      const setSubscribed = vi.fn();
+      mod.setRemoteShareType('alice', 'audio_only');
+      emitRoomEvent(
+        'trackSubscribed',
+        { kind: 'audio', mediaStreamTrack: { id: 'ssa-audio-only' } },
+        { source: 'screen_share_audio', setSubscribed },
+        { identity: 'alice', getTrackPublication: vi.fn(() => undefined) },
+      );
+
+      const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
+      expect(audioElementMap.has('alice:screen-share')).toBe(true);
+
+      mod.setRemoteShareType('alice', 'screen_audio');
+
+      expect(setSubscribed).toHaveBeenLastCalledWith(false);
+      expect(audioElementMap.has('alice:screen-share')).toBe(false);
+
+      mod.disconnect();
+    });
+
+    it('keeps promoted video-share audio attached while a viewer owns the stream', async () => {
+      resetAll();
+      const cbs = createMockCallbacks();
+      const mod = new LiveKitModule(cbs);
+      await driveToConnected(mod);
+
+      mod.setRemoteShareType('alice', 'audio_only');
+      emitRoomEvent(
+        'trackSubscribed',
+        { kind: 'audio', mediaStreamTrack: { id: 'ssa-watched-promotion' } },
+        { source: 'screen_share_audio', setSubscribed: vi.fn() },
+        { identity: 'alice', getTrackPublication: vi.fn(() => undefined) },
+      );
+      mod.attachScreenShareAudio('alice');
+      mod.setRemoteShareType('alice', 'window');
+
+      const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
+      expect(audioElementMap.has('alice:screen-share')).toBe(true);
+
+      mod.disconnect();
+    });
+
     it('late join keeps cached screen share audio detached until viewer-ready calls attachScreenShareAudio', async () => {
       resetAll();
       const cbs = createMockCallbacks();

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
@@ -193,6 +193,8 @@ type IntegrationMockLiveKitModule = {
   setScreenShareAudioVolume: (id: string, vol: number) => void;
   attachScreenShareAudio: (id: string) => void;
   detachScreenShareAudio: (id: string) => void;
+  setRemoteShareType: (id: string, shareType?: 'screen_audio' | 'window' | 'audio_only' | 'browser') => void;
+  clearRemoteShareType: (id: string) => void;
   startWasapiAudioBridge: (loopbackExclusionAvailable: boolean) => Promise<void>;
   stopWasapiAudioBridge: () => Promise<void>;
   startScreenShare: () => Promise<boolean>;
@@ -281,6 +283,8 @@ function createIntegrationMockLiveKitModule(
     setScreenShareAudioVolume: vi.fn(() => {}),
     attachScreenShareAudio: vi.fn(() => {}),
     detachScreenShareAudio: vi.fn(() => {}),
+    setRemoteShareType: vi.fn(() => {}),
+    clearRemoteShareType: vi.fn(() => {}),
     startWasapiAudioBridge: vi.fn(async () => {}),
     stopWasapiAudioBridge: vi.fn(async () => {}),
     startScreenShare: vi.fn(async () => true),

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -30,7 +30,7 @@ import {
   getScreenShareCodec,
   type ScreenShareCodecOverride,
 } from '@features/settings/settings-store';
-import type { AudioShareStartResult } from '@features/screen-share/share-types';
+import type { AudioShareStartResult, ShareMode } from '@features/screen-share/share-types';
 import type {
   NativeShareLeakStage,
   ShareLeakBrowserWebRtcSnapshot,
@@ -99,6 +99,7 @@ const DEBUG_NOISE_SUPPRESSION = import.meta.env.VITE_DEBUG_NOISE_SUPPRESSION ===
 const CAMERA_CAPTURE_TIMEOUT_MS = 10_000;
 const CAMERA_PUBLISH_TIMEOUT_MS = 5_000;
 const REMOTE_CAMERA_READY_TIMEOUT_MS = 10_000;
+export type RemoteShareType = ShareMode | 'browser';
 
 /**
  * Open a camera device via getUserMedia with a hard timeout. Standard
@@ -1118,7 +1119,11 @@ export class LiveKitModule {
   private screenShareAudioPublications: Map<string, RemoteTrackPublication> = new Map();
   /** Participants whose viewer window is open but whose audio track hadn't arrived yet when attachScreenShareAudio was called. */
   private screenShareAudioPending = new Set<string>();
-  /** Participants whose share is audio-only (no video track ever published). */
+  /** Participants whose direct viewer or Watch All tile currently owns playback. */
+  private screenShareAudioViewerOwners = new Set<string>();
+  /** Server-authoritative share type metadata. Missing legacy metadata stays video-gated. */
+  private remoteShareTypes = new Map<string, RemoteShareType | undefined>();
+  /** Participants whose authoritative share type is audio-only. */
   private audioOnlySharers = new Set<string>();
   private pendingLevels: Map<string, { isSpeaking: boolean; rmsLevel: number }> = new Map();
   private rafId: number | null = null;
@@ -2326,9 +2331,7 @@ export class LiveKitModule {
         }
         if (publication.source !== Track.Source.ScreenShareAudio) return;
         this.screenShareAudioPublications.set(participant.identity, publication);
-        if (!this.screenShareAudioPending.has(participant.identity)) {
-          publication.setSubscribed(false);
-        }
+        publication.setSubscribed(this.shouldPlayScreenShareAudio(participant.identity));
       });
 
       // e. TrackSubscribed
@@ -2413,20 +2416,10 @@ export class LiveKitModule {
                 settings,
               });
             }
-            if (isPending) {
-              // Viewer window already open — attach now
-              this.attachScreenShareAudio(participant.identity);
-            } else {
-              // Audio-only share: no video track means there will never be a viewer window.
-              // Attach immediately so the audio plays without requiring the user to click Watch.
-              const hasVideoShare = !!participant.getTrackPublication(Track.Source.ScreenShare);
-              if (!hasVideoShare) {
-                this.attachScreenShareAudio(participant.identity);
-                this.audioOnlySharers.add(participant.identity);
-                this.callbacks.onAudioOnlySharerAdded?.(participant.identity);
-              } else if (typeof publication.setSubscribed === 'function') {
-                publication.setSubscribed(false);
-              }
+            if (this.shouldPlayScreenShareAudio(participant.identity)) {
+              this.attachDesiredScreenShareAudio(participant.identity);
+            } else if (typeof publication.setSubscribed === 'function') {
+              publication.setSubscribed(false);
             }
           } else {
             this.attachAudioTrack(participant, track);
@@ -2454,9 +2447,6 @@ export class LiveKitModule {
             this.screenShareAudioTracks.delete(participant.identity);
             // Also clean up if it was attached
             this.cleanupParticipantAudio(`${participant.identity}:screen-share`);
-            if (this.audioOnlySharers.delete(participant.identity)) {
-              this.callbacks.onAudioOnlySharerRemoved?.(participant.identity);
-            }
           } else {
             this.cleanupParticipantAudio(participant.identity);
           }
@@ -2470,12 +2460,7 @@ export class LiveKitModule {
             }
             this.screenShareElements.delete(participant.identity);
             this.callbacks.onScreenShareUnsubscribed(participant.identity);
-            // If audio is still attached (participant stopped video but kept audio),
-            // re-enter audio-only mode so the UI reflects the ongoing audio share.
-            if (this.screenShareAudioTracks.has(participant.identity)) {
-              this.audioOnlySharers.add(participant.identity);
-              this.callbacks.onAudioOnlySharerAdded?.(participant.identity);
-            }
+            this.syncScreenShareAudioPolicy(participant.identity);
           }
         }
       });
@@ -2508,6 +2493,9 @@ export class LiveKitModule {
         // Clean up deferred screen share audio
         this.screenShareAudioTracks.delete(participant.identity);
         this.screenShareAudioPublications.delete(participant.identity);
+        this.screenShareAudioPending.delete(participant.identity);
+        this.screenShareAudioViewerOwners.delete(participant.identity);
+        this.remoteShareTypes.delete(participant.identity);
         this.cleanupParticipantAudio(`${participant.identity}:screen-share`);
         if (this.audioOnlySharers.delete(participant.identity)) {
           this.callbacks.onAudioOnlySharerRemoved?.(participant.identity);
@@ -2532,9 +2520,7 @@ export class LiveKitModule {
         const screenShareAudioPub = participant.getTrackPublication(Track.Source.ScreenShareAudio);
         if (screenShareAudioPub) {
           this.screenShareAudioPublications.set(participant.identity, screenShareAudioPub);
-          if (!this.screenShareAudioPending.has(participant.identity)) {
-            screenShareAudioPub.setSubscribed(false);
-          }
+          screenShareAudioPub.setSubscribed(this.shouldPlayScreenShareAudio(participant.identity));
         }
         const screenShareVideoPub = participant.getTrackPublication(Track.Source.ScreenShare);
         const screenShareVideoTrack = screenShareVideoPub?.track;
@@ -2558,7 +2544,7 @@ export class LiveKitModule {
             const track = pub.track as RemoteTrack;
             this.screenShareAudioTracks.set(participant.identity, { track, participant });
             if (DEBUG_SHARE_AUDIO) console.log(LOG, `[screen-share-audio] ParticipantConnected recovery for ${participant.identity}`);
-            this.attachScreenShareAudio(participant.identity);
+            this.attachDesiredScreenShareAudio(participant.identity);
             break;
           }
         }
@@ -2949,6 +2935,9 @@ export class LiveKitModule {
     this.screenShareAudioTracks.clear();
     this.screenShareAudioPublications.clear();
     this.screenShareAudioPending.clear();
+    this.screenShareAudioViewerOwners.clear();
+    this.remoteShareTypes.clear();
+    this.audioOnlySharers.clear();
 
     // 8c. Clean up any attached screen share audio elements
     for (const key of this.audioElementMap.keys()) {
@@ -5162,12 +5151,7 @@ export class LiveKitModule {
       mst.addEventListener('unmute', onUnmute);
     }
 
-    // If this participant was previously audio-only, they've now added video.
-    // Remove them from audioOnlySharers — their audio keeps playing but is no
-    // longer treated as an isolated audio-only stream.
-    if (this.audioOnlySharers.delete(participant.identity)) {
-      this.callbacks.onAudioOnlySharerRemoved?.(participant.identity);
-    }
+    this.syncScreenShareAudioPolicy(participant.identity);
   }
 
   /**
@@ -5324,6 +5308,46 @@ export class LiveKitModule {
    * Called when the user opens the screen share viewer window.
    */
   attachScreenShareAudio(participantIdentity: string): void {
+    this.screenShareAudioViewerOwners.add(participantIdentity);
+    this.syncScreenShareAudioPolicy(participantIdentity);
+  }
+
+  /** Update the server-authoritative remote share type for audio policy decisions. */
+  setRemoteShareType(participantIdentity: string, shareType?: RemoteShareType): void {
+    this.remoteShareTypes.set(participantIdentity, shareType);
+    const isAudioOnly = shareType === 'audio_only';
+    if (isAudioOnly && !this.audioOnlySharers.has(participantIdentity)) {
+      this.audioOnlySharers.add(participantIdentity);
+      this.callbacks.onAudioOnlySharerAdded?.(participantIdentity);
+    } else if (!isAudioOnly && this.audioOnlySharers.delete(participantIdentity)) {
+      this.callbacks.onAudioOnlySharerRemoved?.(participantIdentity);
+    }
+    this.syncScreenShareAudioPolicy(participantIdentity);
+  }
+
+  /** Remove stale authoritative metadata when a remote share stops. */
+  clearRemoteShareType(participantIdentity: string): void {
+    this.remoteShareTypes.delete(participantIdentity);
+    if (this.audioOnlySharers.delete(participantIdentity)) {
+      this.callbacks.onAudioOnlySharerRemoved?.(participantIdentity);
+    }
+    this.syncScreenShareAudioPolicy(participantIdentity);
+  }
+
+  private shouldPlayScreenShareAudio(participantIdentity: string): boolean {
+    return this.screenShareAudioViewerOwners.has(participantIdentity)
+      || this.remoteShareTypes.get(participantIdentity) === 'audio_only';
+  }
+
+  private syncScreenShareAudioPolicy(participantIdentity: string): void {
+    if (this.shouldPlayScreenShareAudio(participantIdentity)) {
+      this.attachDesiredScreenShareAudio(participantIdentity);
+    } else {
+      this.detachDesiredScreenShareAudio(participantIdentity);
+    }
+  }
+
+  private attachDesiredScreenShareAudio(participantIdentity: string): void {
     // Mark as pending immediately so any TrackSubscribed that fires after the
     // in-flight setSubscribed(false) (from initial deferral) sees isPending=true
     // and does not call setSubscribed(false) again, which would permanently
@@ -5410,6 +5434,11 @@ export class LiveKitModule {
    * Called when the user closes the screen share viewer window.
    */
   detachScreenShareAudio(participantIdentity: string): void {
+    this.screenShareAudioViewerOwners.delete(participantIdentity);
+    this.syncScreenShareAudioPolicy(participantIdentity);
+  }
+
+  private detachDesiredScreenShareAudio(participantIdentity: string): void {
     this.screenShareAudioPending.delete(participantIdentity);
     const publication = this.screenShareAudioPublications.get(participantIdentity);
     if (publication && typeof publication.setSubscribed === 'function') {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -86,6 +86,26 @@ export interface RoomParticipant {
   volume: number;
 }
 
+type RemoteShareType = 'screen_audio' | 'window' | 'audio_only' | 'browser';
+
+function parseRemoteShareType(value: unknown): RemoteShareType | undefined {
+  return value === 'screen_audio' || value === 'window' || value === 'audio_only' || value === 'browser'
+    ? value
+    : undefined;
+}
+
+function updateRemoteShareType(participantId: string, shareType?: RemoteShareType): void {
+  if (lkModule && 'setRemoteShareType' in lkModule) {
+    (lkModule as LiveKitModule).setRemoteShareType(participantId, shareType);
+  }
+}
+
+function clearRemoteShareType(participantId: string): void {
+  if (lkModule && 'clearRemoteShareType' in lkModule) {
+    (lkModule as LiveKitModule).clearRemoteShareType(participantId);
+  }
+}
+
 export type SubRoomMembershipSource = 'explicit' | 'legacy_room_one';
 
 export interface VoiceSubRoom {
@@ -2687,6 +2707,12 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
     lkModule = new LiveKitModule(callbacks);
   }
 
+  for (const participant of state.participants) {
+    if (participant.isSharing) {
+      updateRemoteShareType(participant.id, parseRemoteShareType(participant.shareType));
+    }
+  }
+
   applyPassthroughFilterSettings();
   applyEffectiveParticipantVolumes();
   lkModule.connect(sfuUrl, token, iceConfig).catch((err) => {
@@ -3459,11 +3485,13 @@ function dispatchMessage(raw: unknown): void {
     case 'share_started': {
       const shareStartId = msg.participantId as string;
       const shareStartName = msg.displayName as string | undefined;
+      const remoteShareType = parseRemoteShareType(msg.shareType);
       const sp = state.participants.find((pp) => pp.id === shareStartId);
       if (sp) {
         sp.isSharing = true;
-        sp.shareType = (msg.shareType as string) || undefined;
+        sp.shareType = remoteShareType;
       }
+      updateRemoteShareType(shareStartId, remoteShareType);
       // Cache the display name from the server payload
       if (shareStartName) {
         displayNameCache.set(shareStartId, shareStartName);
@@ -3493,6 +3521,7 @@ function dispatchMessage(raw: unknown): void {
         ssp.isSharing = false;
         ssp.shareType = undefined;
       }
+      clearRemoteShareType(shareStopId);
       // Clear the stream reference immediately on signaling. The LiveKit
       // TrackUnsubscribed event may lag by the SFU's disconnect timeout when
       // the sharer closes the app abruptly; without this the viewer's UI shows
@@ -3526,18 +3555,30 @@ function dispatchMessage(raw: unknown): void {
     case 'share_state': {
       // share_state is an authoritative snapshot — reconcile all participants
       const shareIds = new Set((msg.participantIds as string[]) || []);
+      const typedShares = new Map<string, RemoteShareType | undefined>(
+        ((msg.activeShares as Array<{ participantId: string; shareType?: unknown }>) || [])
+          .map((share) => [
+            share.participantId,
+            parseRemoteShareType(share.shareType),
+          ] as [string, RemoteShareType | undefined]),
+      );
       for (const p of state.participants) {
         const shouldBeSharing = shareIds.has(p.id);
         if (p.isSharing && !shouldBeSharing) {
           // Server says they're not sharing — clear stale flag + stream
           p.isSharing = false;
           p.shareType = undefined;
+          clearRemoteShareType(p.id);
           if (state.screenShareStreams.has(p.id)) {
             state.screenShareStreams = new Map(state.screenShareStreams);
             state.screenShareStreams.delete(p.id);
           }
         } else if (!p.isSharing && shouldBeSharing) {
           p.isSharing = true;
+        }
+        if (shouldBeSharing) {
+          p.shareType = typedShares.get(p.id);
+          updateRemoteShareType(p.id, p.shareType as RemoteShareType | undefined);
         }
       }
       void applyCameraQualityForShareState();
@@ -4262,12 +4303,6 @@ export async function startCustomShare(selection: ShareSelection): Promise<void>
     isWindowsPlatform() ? 'native_custom_picker' : isMacPlatform() ? 'mac_custom_share' : 'linux_custom_share',
   );
 
-  // Capture whether any share was already active before this call.
-  // When the user layers a video share on top of an audio-only share (or vice
-  // versa), the backend already knows the participant is sharing — sending
-  // start_share again would be redundant and confuse the signaling state.
-  const wasAlreadySharing = state.activeVideoShare !== null || state.activeAudioShare !== null;
-
   // 2. Set state fields optimistically
   const isVideoShare = selection.mode === 'screen_audio' || selection.mode === 'window';
   if (isVideoShare) {
@@ -4415,9 +4450,9 @@ export async function startCustomShare(selection: ShareSelection): Promise<void>
       }
     }
 
-    // 5. Send signaling on success — skip if we were already in a share session
-    // (layering a second stream on top of an existing one; backend state is unchanged).
-    if (client && !wasAlreadySharing) {
+    // 5. Send signaling on success. Re-sending for a layered share updates the
+    // authoritative type used by remote audio gating.
+    if (client) {
       client.send({ type: 'start_share', shareType: selection.mode });
     }
 
@@ -4534,8 +4569,14 @@ export async function stopCustomShare(target: 'video' | 'audio' | 'all' = 'all')
   const willStillBeSharing =
     (target === 'video' && state.activeAudioShare !== null) ||
     (target === 'audio' && state.activeVideoShare !== null);
-  if (client && !willStillBeSharing) {
-    client.send({ type: 'stop-share' });
+  if (client) {
+    if (!willStillBeSharing) {
+      client.send({ type: 'stop-share' });
+    } else if (target === 'video' && state.activeAudioShare !== null) {
+      client.send({ type: 'start_share', shareType: 'audio_only' });
+    } else if (target === 'audio' && state.activeVideoShare !== null) {
+      client.send({ type: 'start_share', shareType: state.activeVideoShare.mode });
+    }
   }
 
   // 5. Clear affected slot(s)

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -74,6 +74,16 @@ pub enum WireSharePermission {
     HostOnly,
 }
 
+/// Wire-format screen share type.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WireShareType {
+    ScreenAudio,
+    Window,
+    AudioOnly,
+    Browser,
+}
+
 impl WireSharePermission {
     /// Parse from a raw string (e.g. from legacy code paths).
     /// Returns `None` for unrecognized values.
@@ -170,7 +180,7 @@ pub enum SignalingMessage {
     ParticipantUndeafened(ParticipantUndeafenedPayload),
     // Phase 3: Screen share lifecycle
     /// Client -> server request to begin screen sharing.
-    StartShare,
+    StartShare(StartSharePayload),
     /// Server -> all participants broadcast that a share started.
     ShareStarted(ShareStartedPayload),
     /// Client -> server request to stop a share.
@@ -628,6 +638,14 @@ pub struct ParticipantUndeafenedPayload {
 
 // --- Phase 3: Screen share payload structs ---
 
+/// Client requests to begin a screen share.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct StartSharePayload {
+    /// Optional for compatibility with legacy clients.
+    #[serde(rename = "shareType", default, skip_serializing_if = "Option::is_none")]
+    pub share_type: Option<WireShareType>,
+}
+
 /// Broadcast to all participants when a screen share starts.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ShareStartedPayload {
@@ -637,6 +655,9 @@ pub struct ShareStartedPayload {
     /// Display name for the sharer who started presenting.
     #[serde(rename = "displayName")]
     pub display_name: String,
+    /// Optional for compatibility with legacy clients.
+    #[serde(rename = "shareType", default, skip_serializing_if = "Option::is_none")]
+    pub share_type: Option<WireShareType>,
 }
 
 /// Client requests to stop a screen share (optionally targeting another participant's share).
@@ -667,6 +688,20 @@ pub struct ShareStatePayload {
     /// Participant identifiers for every currently active sharer.
     #[serde(rename = "participantIds")]
     pub participant_ids: Vec<String>,
+    /// Typed metadata for clients that support share-type-aware behavior.
+    #[serde(rename = "activeShares", default, skip_serializing_if = "Vec::is_empty")]
+    pub active_shares: Vec<ActiveSharePayload>,
+}
+
+/// Typed metadata for one active share in a late-join snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ActiveSharePayload {
+    /// Participant identifier for the active sharer.
+    #[serde(rename = "participantId")]
+    pub participant_id: String,
+    /// Optional when the share was started by a legacy client.
+    #[serde(rename = "shareType", default, skip_serializing_if = "Option::is_none")]
+    pub share_type: Option<WireShareType>,
 }
 
 /// Client (host) requests a share permission change.

--- a/shared/src/signaling/proptest_support.rs
+++ b/shared/src/signaling/proptest_support.rs
@@ -339,6 +339,21 @@ impl Arbitrary for WireSharePermission {
     }
 }
 
+impl Arbitrary for WireShareType {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            Just(WireShareType::ScreenAudio),
+            Just(WireShareType::Window),
+            Just(WireShareType::AudioOnly),
+            Just(WireShareType::Browser),
+        ]
+        .boxed()
+    }
+}
+
 impl Arbitrary for JoinRejectionReason {
     type Parameters = ();
     type Strategy = BoxedStrategy<Self>;
@@ -460,11 +475,23 @@ impl Arbitrary for ShareStartedPayload {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<String>(), any::<String>())
-            .prop_map(|(participant_id, display_name)| ShareStartedPayload {
+        (any::<String>(), any::<String>(), prop::option::of(any::<WireShareType>()))
+            .prop_map(|(participant_id, display_name, share_type)| ShareStartedPayload {
                 participant_id,
                 display_name,
+                share_type,
             })
+            .boxed()
+    }
+}
+
+impl Arbitrary for StartSharePayload {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        prop::option::of(any::<WireShareType>())
+            .prop_map(|share_type| StartSharePayload { share_type })
             .boxed()
     }
 }
@@ -500,8 +527,28 @@ impl Arbitrary for ShareStatePayload {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        prop::collection::vec(any::<String>(), 0..=6)
-            .prop_map(|participant_ids| ShareStatePayload { participant_ids })
+        (
+            prop::collection::vec(any::<String>(), 0..=6),
+            prop::collection::vec(any::<ActiveSharePayload>(), 0..=6),
+        )
+            .prop_map(|(participant_ids, active_shares)| ShareStatePayload {
+                participant_ids,
+                active_shares,
+            })
+            .boxed()
+    }
+}
+
+impl Arbitrary for ActiveSharePayload {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (any::<String>(), prop::option::of(any::<WireShareType>()))
+            .prop_map(|(participant_id, share_type)| ActiveSharePayload {
+                participant_id,
+                share_type,
+            })
             .boxed()
     }
 }
@@ -1054,7 +1101,7 @@ impl Arbitrary for SignalingMessage {
             any::<ParticipantDeafenedPayload>().prop_map(SignalingMessage::ParticipantDeafened),
             any::<ParticipantUndeafenedPayload>().prop_map(SignalingMessage::ParticipantUndeafened),
             // Phase 3: Screen share lifecycle
-            Just(SignalingMessage::StartShare),
+            any::<StartSharePayload>().prop_map(SignalingMessage::StartShare),
             any::<ShareStartedPayload>().prop_map(SignalingMessage::ShareStarted),
             any::<StopSharePayload>().prop_map(SignalingMessage::StopShare),
             any::<ShareStoppedPayload>().prop_map(SignalingMessage::ShareStopped),

--- a/shared/src/signaling/tests.rs
+++ b/shared/src/signaling/tests.rs
@@ -2,6 +2,35 @@ use super::*;
 use proptest::prelude::*;
 
 #[test]
+fn start_share_accepts_legacy_and_typed_payloads() {
+    assert_eq!(
+        parse(r#"{"type":"start_share"}"#).unwrap(),
+        SignalingMessage::StartShare(StartSharePayload::default()),
+    );
+    assert_eq!(
+        parse(r#"{"type":"start_share","shareType":"audio_only"}"#).unwrap(),
+        SignalingMessage::StartShare(StartSharePayload {
+            share_type: Some(WireShareType::AudioOnly),
+        }),
+    );
+    assert!(parse(r#"{"type":"start_share","shareType":"unexpected"}"#).is_err());
+}
+
+#[test]
+fn share_state_serializes_typed_metadata_and_legacy_ids() {
+    let json = to_json(&SignalingMessage::ShareState(ShareStatePayload {
+        participant_ids: vec!["peer-1".to_string()],
+        active_shares: vec![ActiveSharePayload {
+            participant_id: "peer-1".to_string(),
+            share_type: Some(WireShareType::Window),
+        }],
+    }))
+    .unwrap();
+    assert!(json.contains(r#""participantIds":["peer-1"]"#));
+    assert!(json.contains(r#""activeShares":[{"participantId":"peer-1","shareType":"window"}]"#));
+}
+
+#[test]
 fn chat_payloads_serialize_optional_user_id_as_user_id() {
     let chat = SignalingMessage::ChatMessage(ChatMessagePayload {
         participant_id: "peer-1".to_string(),

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -188,7 +188,7 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
         SignalingMessage::ParticipantUndeafened(p) => {
             check("participant_id", &p.participant_id, MAX_PEER_ID_LEN)?;
         }
-        SignalingMessage::StartShare => {}
+        SignalingMessage::StartShare(_) => {}
         SignalingMessage::ShareStarted(p) => {
             check("participant_id", &p.participant_id, MAX_PEER_ID_LEN)?;
             check("display_name", &p.display_name, MAX_DISPLAY_NAME_LEN)?;
@@ -213,6 +213,16 @@ pub fn validate_field_lengths(msg: &SignalingMessage) -> Result<(), ValidationEr
                     });
                 }
                 check("participant_id", id, MAX_PEER_ID_LEN)?;
+            }
+            for share in &p.active_shares {
+                if share.participant_id.is_empty() {
+                    return Err(ValidationError {
+                        field: "participant_id".to_string(),
+                        actual_len: 0,
+                        max_len: MAX_PEER_ID_LEN,
+                    });
+                }
+                check("participant_id", &share.participant_id, MAX_PEER_ID_LEN)?;
             }
         }
         SignalingMessage::SetSharePermission(_) => {
@@ -504,6 +514,7 @@ mod tests {
         let msg = SignalingMessage::ShareStarted(ShareStartedPayload {
             participant_id: long_str(MAX_PEER_ID_LEN + 1),
             display_name: "test".to_string(),
+            share_type: None,
         });
         let err = validate_field_lengths(&msg).unwrap_err();
         assert_eq!(err.field, "participant_id");
@@ -519,6 +530,7 @@ mod tests {
     fn share_state_empty_participant_id_rejected() {
         let msg = SignalingMessage::ShareState(ShareStatePayload {
             participant_ids: vec!["peer-1".to_string(), "".to_string()],
+            active_shares: vec![],
         });
         let err = validate_field_lengths(&msg).unwrap_err();
         assert_eq!(err.field, "participant_id");
@@ -529,6 +541,7 @@ mod tests {
     fn share_state_oversized_participant_id_rejected() {
         let msg = SignalingMessage::ShareState(ShareStatePayload {
             participant_ids: vec![long_str(MAX_PEER_ID_LEN + 1)],
+            active_shares: vec![],
         });
         let err = validate_field_lengths(&msg).unwrap_err();
         assert_eq!(err.field, "participant_id");
@@ -538,6 +551,7 @@ mod tests {
     fn share_state_valid_passes() {
         let msg = SignalingMessage::ShareState(ShareStatePayload {
             participant_ids: vec!["peer-1".to_string(), "peer-2".to_string()],
+            active_shares: vec![],
         });
         assert!(validate_field_lengths(&msg).is_ok());
     }
@@ -546,6 +560,7 @@ mod tests {
     fn share_state_empty_list_passes() {
         let msg = SignalingMessage::ShareState(ShareStatePayload {
             participant_ids: vec![],
+            active_shares: vec![],
         });
         assert!(validate_field_lengths(&msg).is_ok());
     }

--- a/wavis-backend/src/state.rs
+++ b/wavis-backend/src/state.rs
@@ -138,6 +138,8 @@ pub struct RoomInfo {
     pub revoked_participants: HashMap<String, Instant>,
     /// Participant IDs currently sharing their screen. SFU rooms only.
     pub active_shares: HashSet<String>,
+    /// Authoritative share types for active shares that supplied metadata.
+    pub active_share_types: HashMap<String, shared::signaling::WireShareType>,
     /// Screen share permission policy (default: AllParticipants).
     pub share_permission: SharePermission,
     /// Optional synchronized sub-room state for channel-based voice sessions.
@@ -157,6 +159,7 @@ impl RoomInfo {
             media_connected: HashSet::new(),
             revoked_participants: HashMap::new(),
             active_shares: HashSet::new(),
+            active_share_types: HashMap::new(),
             share_permission: SharePermission::default(),
             sub_room_state: None,
         }
@@ -173,6 +176,7 @@ impl RoomInfo {
             media_connected: HashSet::new(),
             revoked_participants: HashMap::new(),
             active_shares: HashSet::new(),
+            active_share_types: HashMap::new(),
             share_permission: SharePermission::default(),
             sub_room_state: None,
         }

--- a/wavis-backend/src/voice/screen_share.rs
+++ b/wavis-backend/src/voice/screen_share.rs
@@ -31,8 +31,8 @@
 use crate::state::{InMemoryRoomState, RoomType, SharePermission};
 use crate::voice::sfu_relay::{OutboundSignal, ParticipantRole};
 use shared::signaling::{
-    ErrorPayload, SharePermissionChangedPayload, ShareStartedPayload, ShareStatePayload,
-    ShareStoppedPayload, SignalingMessage,
+    ActiveSharePayload, ErrorPayload, SharePermissionChangedPayload, ShareStartedPayload,
+    ShareStatePayload, ShareStoppedPayload, SignalingMessage, WireShareType,
 };
 
 /// Look up a participant's display name from the room's participant list.
@@ -67,11 +67,23 @@ pub enum ShareResult {
 /// - Sender is not already sharing
 ///
 /// On success, inserts sender into `active_shares` and returns a `BroadcastAll` `ShareStarted` signal.
+#[allow(dead_code)] // Retained for legacy callers and domain tests without share-type metadata.
 pub fn handle_start_share(
     state: &InMemoryRoomState,
     room_id: &str,
     sender_id: &str,
     role: ParticipantRole,
+) -> ShareResult {
+    handle_start_share_with_type(state, room_id, sender_id, role, None)
+}
+
+/// Start a share while preserving optional validated wire metadata.
+pub fn handle_start_share_with_type(
+    state: &InMemoryRoomState,
+    room_id: &str,
+    sender_id: &str,
+    role: ParticipantRole,
+    share_type: Option<WireShareType>,
 ) -> ShareResult {
     let result = state.with_room_write(room_id, |members| {
         // Check room type
@@ -107,17 +119,42 @@ pub fn handle_start_share(
 
         // Check sender not already sharing
         if members.info.active_shares.contains(sender_id) {
-            return ShareResult::Noop;
+            if members.info.active_share_types.get(sender_id).copied() == share_type {
+                return ShareResult::Noop;
+            }
+            if let Some(share_type) = share_type {
+                members
+                    .info
+                    .active_share_types
+                    .insert(sender_id.to_string(), share_type);
+            } else {
+                members.info.active_share_types.remove(sender_id);
+            }
+            let display_name = lookup_display_name(&members.info.participants, sender_id);
+            return ShareResult::Ok(vec![OutboundSignal::broadcast_all(
+                SignalingMessage::ShareStarted(ShareStartedPayload {
+                    participant_id: sender_id.to_string(),
+                    display_name,
+                    share_type,
+                }),
+            )]);
         }
 
         // All preconditions pass — atomically insert into active_shares
         members.info.active_shares.insert(sender_id.to_string());
+        if let Some(share_type) = share_type {
+            members
+                .info
+                .active_share_types
+                .insert(sender_id.to_string(), share_type);
+        }
 
         let display_name = lookup_display_name(&members.info.participants, sender_id);
         let signal =
             OutboundSignal::broadcast_all(SignalingMessage::ShareStarted(ShareStartedPayload {
                 participant_id: sender_id.to_string(),
                 display_name,
+                share_type,
             }));
         ShareResult::Ok(vec![signal])
     });
@@ -186,6 +223,7 @@ pub fn handle_stop_share(
 
         // All preconditions pass — atomically remove from active_shares
         members.info.active_shares.remove(effective_target);
+        members.info.active_share_types.remove(effective_target);
 
         let display_name = lookup_display_name(&members.info.participants, effective_target);
         let signal =
@@ -237,6 +275,7 @@ pub fn handle_stop_all_shares(
 
         // Collect all current sharers, then clear
         let sharers: Vec<String> = members.info.active_shares.drain().collect();
+        members.info.active_share_types.clear();
 
         let signals = sharers
             .into_iter()
@@ -268,14 +307,27 @@ pub fn share_state_snapshot(
     room_id: &str,
     target_peer_id: &str,
 ) -> OutboundSignal {
-    let participant_ids: Vec<String> = state
+    let (participant_ids, active_shares) = state
         .get_room_info(room_id)
-        .map(|info| info.active_shares.iter().cloned().collect())
+        .map(|info| {
+            let participant_ids: Vec<String> = info.active_shares.iter().cloned().collect();
+            let active_shares = participant_ids
+                .iter()
+                .map(|participant_id| ActiveSharePayload {
+                    participant_id: participant_id.clone(),
+                    share_type: info.active_share_types.get(participant_id).copied(),
+                })
+                .collect();
+            (participant_ids, active_shares)
+        })
         .unwrap_or_default();
 
     OutboundSignal::to_peer(
         target_peer_id,
-        SignalingMessage::ShareState(ShareStatePayload { participant_ids }),
+        SignalingMessage::ShareState(ShareStatePayload {
+            participant_ids,
+            active_shares,
+        }),
     )
 }
 
@@ -292,6 +344,7 @@ pub fn cleanup_share_on_disconnect(
         if !members.info.active_shares.remove(peer_id) {
             return None;
         }
+        members.info.active_share_types.remove(peer_id);
 
         let display_name = lookup_display_name(&members.info.participants, peer_id);
         let signal =
@@ -718,6 +771,49 @@ mod tests {
             }
             _ => panic!("expected ShareState message"),
         }
+    }
+
+    #[test]
+    fn share_state_snapshot_includes_authoritative_share_type() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["peer-a", "peer-b"]);
+        let result = handle_start_share_with_type(
+            &state,
+            "room-1",
+            "peer-a",
+            ParticipantRole::Guest,
+            Some(WireShareType::AudioOnly),
+        );
+        assert!(matches!(result, ShareResult::Ok(_)));
+
+        let signal = share_state_snapshot(&state, "room-1", "peer-b");
+        match signal.msg {
+            SignalingMessage::ShareState(payload) => {
+                assert_eq!(payload.active_shares.len(), 1);
+                assert_eq!(payload.active_shares[0].participant_id, "peer-a");
+                assert_eq!(payload.active_shares[0].share_type, Some(WireShareType::AudioOnly));
+            }
+            _ => panic!("expected ShareState message"),
+        }
+    }
+
+    #[test]
+    fn disconnect_cleanup_removes_authoritative_share_type() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["peer-a"]);
+        let result = handle_start_share_with_type(
+            &state,
+            "room-1",
+            "peer-a",
+            ParticipantRole::Guest,
+            Some(WireShareType::Browser),
+        );
+        assert!(matches!(result, ShareResult::Ok(_)));
+
+        cleanup_share_on_disconnect(&state, "room-1", "peer-a");
+
+        let info = state.get_room_info("room-1").unwrap();
+        assert!(!info.active_share_types.contains_key("peer-a"));
     }
 
     #[test]

--- a/wavis-backend/src/voice/voice_orchestrator.rs
+++ b/wavis-backend/src/voice/voice_orchestrator.rs
@@ -688,6 +688,7 @@ pub fn leave_sub_room(
             expiry = schedule_empty_room_if_needed(sub_rooms, &current_room_id);
             left_sub_room_id = Some(current_room_id);
             if members.info.active_shares.remove(participant_id) {
+                members.info.active_share_types.remove(participant_id);
                 share_stopped = Some(SignalingMessage::ShareStopped(ShareStoppedPayload {
                     participant_id: participant_id.to_string(),
                     display_name: participant_display_name(

--- a/wavis-backend/src/ws/ws.rs
+++ b/wavis-backend/src/ws/ws.rs
@@ -415,7 +415,7 @@ mod tests {
                         SignalingMessage::SelfUndeafen |
                         SignalingMessage::ParticipantDeafened(_) |
                         SignalingMessage::ParticipantUndeafened(_) |
-                        SignalingMessage::StartShare |
+                        SignalingMessage::StartShare(_) |
                         SignalingMessage::ShareStarted(_) |
                         SignalingMessage::StopShare(_) |
                         SignalingMessage::ShareStopped(_) |

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -23,7 +23,7 @@ use crate::ec2_control::Ec2InstanceState;
 use crate::state::{InMemoryRoomState, RoomType};
 use crate::voice::relay::{self, P2PJoinResult, RelayResult, RoomState, handle_p2p_join};
 use crate::voice::screen_share::{
-    ShareResult, handle_set_share_permission, handle_start_share, handle_stop_all_shares,
+    ShareResult, handle_set_share_permission, handle_start_share_with_type, handle_stop_all_shares,
     handle_stop_share,
 };
 use crate::voice::sfu_bridge::SfuHealth;
@@ -1986,7 +1986,7 @@ pub(crate) async fn dispatch_message(
             );
             DispatchOutcome::Continue
         }
-        SignalingMessage::StartShare => {
+        SignalingMessage::StartShare(payload) => {
             // Session is guaranteed Some here (pre-join gate already handled above)
             let session_ref = ctx.session.as_ref().unwrap();
             let sender_id = session_ref.participant_id.as_str();
@@ -2024,11 +2024,12 @@ pub(crate) async fn dispatch_message(
                 }
             };
 
-            match handle_start_share(
+            match handle_start_share_with_type(
                 ctx.app_state.room_state.as_ref(),
                 &room_id,
                 sender_id,
                 sender_role,
+                payload.share_type,
             ) {
                 ShareResult::Ok(signals) => {
                     dispatch_signals(
@@ -3302,7 +3303,7 @@ pub(crate) fn handle_signaling_event(
         | SignalingMessage::SelfUndeafen
         | SignalingMessage::ParticipantDeafened(_)
         | SignalingMessage::ParticipantUndeafened(_)
-        | SignalingMessage::StartShare
+        | SignalingMessage::StartShare(_)
         | SignalingMessage::ShareStarted(_)
         | SignalingMessage::StopShare(_)
         | SignalingMessage::ShareStopped(_)

--- a/wavis-backend/tests/screen_share_integration.rs
+++ b/wavis-backend/tests/screen_share_integration.rs
@@ -460,7 +460,7 @@ proptest! {
             prop_assert_eq!(share_state_signals.len(), 1, "should have exactly one ShareState signal for joiner");
 
             // Verify content matches active shares
-            if let SignalingMessage::ShareState(ShareStatePayload { participant_ids }) = &share_state_signals[0].msg {
+            if let SignalingMessage::ShareState(ShareStatePayload { participant_ids, .. }) = &share_state_signals[0].msg {
                 let received_set: HashSet<String> = participant_ids.iter().cloned().collect();
                 prop_assert_eq!(received_set, expected_sharer_set, "ShareState should match active shares");
             } else {
@@ -742,7 +742,7 @@ async fn integration_late_joiner_receives_share_state() {
         "should have exactly one ShareState for late joiner"
     );
 
-    if let SignalingMessage::ShareState(ShareStatePayload { participant_ids }) =
+    if let SignalingMessage::ShareState(ShareStatePayload { participant_ids, .. }) =
         &share_state_signals[0].msg
     {
         let received_set: HashSet<String> = participant_ids.iter().cloned().collect();


### PR DESCRIPTION
## Summary
- add loading overlays while screen-share viewers wait for their first rendered frame
- propagate optional screen-share type metadata through signaling and late-join snapshots
- gate remote screen-share audio playback using authoritative audio-only metadata or active viewer ownership

## Why
Remote screen-share audio could begin playing before a viewer intentionally opened the stream when video had not arrived yet. The UI also lacked feedback while waiting for the first painted frame.

## Impact
- audio-only shares autoplay as intended
- video-backed share audio remains silent until watched
- layered share transitions update the authoritative remote share type
- screen-share viewers and Watch All tiles display a loading indicator before first render

## Validation
Not run per explicit request: automated tests and clippy were skipped.