### PR TITLE
fix: restore active state and share availability on reconnection (#157)

### DIFF
--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -309,6 +309,7 @@ import {
   detachScreenShareAudio,
   startCustomShare,
   getState,
+  isShareEnabled,
   persistStreamVolume,
   getPersistedStreamVolume,
   persistStreamMuted,
@@ -2650,6 +2651,36 @@ describe('Edge case unit tests', () => {
 
       expect(latestState!.mediaState).toBe('connected');
       expect(lkConstructorCalls.length).toBe(moduleCount);
+
+      leaveRoom();
+    });
+
+    it('LiveKit reconnect success restores active voice state and share availability', async () => {
+      resetAll();
+      await driveToActive();
+      await assignSelfToSubRoom();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      lastLkModule!.callbacks.onMediaConnected();
+      await tick();
+
+      statusChangeHandler!('disconnected');
+      await tick();
+      expect(latestState!.machineState).toBe('reconnecting');
+
+      lastLkModule!.callbacks.onMediaReconnected?.();
+      await tick();
+
+      expect(latestState!.machineState).toBe('active');
+      expect(latestState!.mediaState).toBe('connected');
+      expect(isShareEnabled(
+        latestState!.sharePermission,
+        latestState!.selfIsHost,
+        latestState!.machineState,
+        latestState!.mediaState,
+        latestState!.joinedSubRoomId,
+      )).toBe(true);
 
       leaveRoom();
     });

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1980,6 +1980,24 @@ function flushBufferedMediaTokenIfReady(): void {
   }
 }
 
+function promoteReconnectedSessionIfReady(): void {
+  if (
+    state.machineState !== 'reconnecting'
+    || state.mediaState !== 'connected'
+    || state.selfParticipantId === null
+    || state.roomId === null
+    || state.joinedSubRoomId === null
+  ) {
+    return;
+  }
+
+  state.machineState = 'active';
+  if (wasReconnecting) {
+    wasReconnecting = false;
+    appendEvent({ id: makeEventId(), timestamp: timestamp(), type: 'system', message: 'reconnected - back online' });
+  }
+}
+
 function ensureInSubRoomForShare(): void {
   if (state.joinedSubRoomId !== null) return;
   throw new Error('Join a room before sharing.');
@@ -2472,6 +2490,7 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
         });
     }).catch(() => { });
     void resumePendingWasapiCapture();
+    promoteReconnectedSessionIfReady();
     notify();
   };
 
@@ -3058,6 +3077,7 @@ function dispatchMessage(raw: unknown): void {
       // Legacy-client fallback: sub_room_joined fires before sub_room_state (room doesn't exist
       // yet in state when sub_room_joined arrives), so flush here once state catches up.
       flushBufferedMediaTokenIfReady();
+      promoteReconnectedSessionIfReady();
       void applyCameraQualityForShareState();
       notify();
       break;
@@ -3130,6 +3150,7 @@ function dispatchMessage(raw: unknown): void {
       }
       if (participantId === state.selfParticipantId) {
         flushBufferedMediaTokenIfReady();
+        promoteReconnectedSessionIfReady();
       }
       void applyCameraQualityForShareState();
       notify();


### PR DESCRIPTION
This PR fixes a state mismatch where the voice room remained in a 'reconnecting' state after a successful SFU reconnection, which prevented screen sharing.

Closes #157