### PR TITLE
fix: prevent audio leak by gating track attachment with viewer-ready

### DIFF
--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1282,9 +1282,15 @@ export default function ActiveRoom() {
         if (stream && stream !== prevStream) {
           console.log(LOG_SS, `resendStream(${pid}, 'watch-all') — stream: ${stream?.id}, prevStream: ${prevStream?.id ?? 'none'}, active: ${stream?.active}, ts: ${Date.now()}`);
           resendStream(pid, 'watch-all', stream);
-          attachScreenShareAudio(pid);
-          applySavedScreenShareAudio(pid);
-          watchAllAttachedAudioRef.current.add(pid);
+          // Only re-attach audio if the viewer already owns this stream's audio.
+          // A stream reference change can fire before viewer-ready resolves (e.g.
+          // the SFU delivers the track muted then unmutes it within the same
+          // subscription window). Attaching audio here in that case would bypass
+          // the viewer-ready gate and leak audio before the tile visually connects.
+          if (watchAllAttachedAudioRef.current.has(pid)) {
+            attachScreenShareAudio(pid);
+            applySavedScreenShareAudio(pid);
+          }
         }
       }
     }

--- a/clients/wavis-gui/src/features/voice/__tests__/ActiveRoom-watchall-audio.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/ActiveRoom-watchall-audio.test.ts
@@ -129,9 +129,15 @@ function onWatchAllViewerStreamChanged(
   if (!state.watchAllOpen || !state.watchAllReady) return;
   if (state.shareWindows.has(participantId) || !stream || stream === prevStream) return;
   deps.resendStream(participantId, 'watch-all', stream);
-  deps.attachScreenShareAudio(participantId);
-  deps.setScreenShareAudioVolume(participantId, state.savedVolumes.get(participantId) ?? 70);
-  state.watchAllAttachedAudio.add(participantId);
+  // Only re-attach audio if the viewer already owns this stream's audio.
+  // A stream reference change can fire before viewer-ready resolves (e.g. the
+  // SFU delivers the track muted then unmutes it within the same subscription
+  // window). Attaching here in that case bypasses the viewer-ready gate and
+  // leaks audio before the tile visually connects.
+  if (state.watchAllAttachedAudio.has(participantId)) {
+    deps.attachScreenShareAudio(participantId);
+    deps.setScreenShareAudioVolume(participantId, state.savedVolumes.get(participantId) ?? 70);
+  }
 }
 
 describe('ActiveRoom viewer audio orchestration', () => {
@@ -287,11 +293,37 @@ describe('ActiveRoom viewer audio orchestration', () => {
     expect(setScreenShareAudioVolume).toHaveBeenCalledWith('user-1', 61);
   });
 
-  it('re-attaches watch-all audio when an existing tile gets a fresh stream', () => {
+  it('does not attach watch-all audio when a fresh stream arrives before viewer-ready', () => {
+    // Stream reference changed (e.g. SFU unmuted) before the tile's viewer-ready fired.
+    // Audio must stay silent until viewer-ready explicitly attaches it.
     const state = createState({
       watchAllOpen: true,
       watchAllReady: true,
       savedVolumes: new Map([['user-1', 44]]),
+      watchAllAttachedAudio: new Set(), // viewer-ready has not fired yet
+    });
+    const prevStream = new MediaStream();
+    const nextStream = new MediaStream();
+
+    onWatchAllViewerStreamChanged(state, 'user-1', nextStream, prevStream, {
+      resendStream,
+      attachScreenShareAudio,
+      setScreenShareAudioVolume,
+    });
+
+    expect(resendStream).toHaveBeenCalledWith('user-1', 'watch-all', nextStream);
+    expect(attachScreenShareAudio).not.toHaveBeenCalled();
+    expect(setScreenShareAudioVolume).not.toHaveBeenCalled();
+  });
+
+  it('re-attaches watch-all audio when an already-playing tile gets a fresh stream', () => {
+    // viewer-ready already fired (audio is attached); stream reference changed mid-share.
+    // Audio must follow the new stream without interruption.
+    const state = createState({
+      watchAllOpen: true,
+      watchAllReady: true,
+      savedVolumes: new Map([['user-1', 44]]),
+      watchAllAttachedAudio: new Set(['user-1']), // viewer-ready already fired
     });
     const prevStream = new MediaStream();
     const nextStream = new MediaStream();
@@ -305,6 +337,5 @@ describe('ActiveRoom viewer audio orchestration', () => {
     expect(resendStream).toHaveBeenCalledWith('user-1', 'watch-all', nextStream);
     expect(attachScreenShareAudio).toHaveBeenCalledWith('user-1');
     expect(setScreenShareAudioVolume).toHaveBeenCalledWith('user-1', 44);
-    expect(state.watchAllAttachedAudio.has('user-1')).toBe(true);
   });
 });


### PR DESCRIPTION
Ensures that audio tracks are only attached if the viewer-ready gate has already passed. This prevents audio leaks that occur when the SFU delivers a track update (e.g. unmuting) before the tile has visually connected. Closes #174