### PR TITLE
fix: schedule stream refresh retries to prevent grayed out icon (#175)

### DIFF
--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2625,6 +2625,14 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
       if (state.screenShareStreams.size === 0) {
         state.videoReceiveStats = null;
       }
+      // If the participant is still marked as sharing, schedule retries so that
+      // a temporary track unsubscription (e.g. LiveKit media reconnect) doesn't
+      // leave the icon stuck in "waiting for stream" forever when TrackSubscribed
+      // doesn't re-fire (SFU treat-as-resume edge case).
+      const unsub = state.participants.find((pp) => pp.id === identity);
+      if (unsub?.isSharing && identity !== state.selfParticipantId) {
+        scheduleRefreshRetries(identity);
+      }
       notify();
     },
     onLocalScreenShareEnded: () => {
@@ -3656,6 +3664,13 @@ function dispatchMessage(raw: unknown): void {
           updateRemoteShareType(p.id, p.shareType as RemoteShareType | undefined);
           if (p.shareType !== 'audio_only') {
             refreshRemoteScreenShare(p.id);
+            // Schedule retries for late joiners or post-reconnect cases where
+            // the stream isn't available yet. share_state doesn't schedule
+            // retries (only share_started does), so viewers who join mid-share
+            // and whose TrackSubscribed is delayed get stuck without this.
+            if (!state.screenShareStreams.has(p.id) && p.id !== state.selfParticipantId) {
+              scheduleRefreshRetries(p.id);
+            }
           }
         }
       }


### PR DESCRIPTION
This PR fixes the issue where the video stream icon would sometimes remain grayed out (in a 'waiting' state) due to missed TrackSubscribed events or mid-share joins.

Key changes:
- Added scheduleRefreshRetries on track unsubscription if the participant is still marked as sharing. This handles SFU resume edge cases where tracks might temporarily drop.
- Added scheduleRefreshRetries in dispatchMessage (share_state) for viewers joining mid-share, ensuring the stream is eventually picked up even if the initial track event was missed.

Closes #175