### PR TITLE
[codex] Fix native capture room mocks

### DIFF
--- a/clients/wavis-gui/src/features/voice/__tests__/native-capture-preservation.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/native-capture-preservation.property.test.ts
@@ -65,6 +65,7 @@ vi.mock('livekit-client', () => ({
     this.disconnect = vi.fn();
     this.on = vi.fn(() => this);
     this.off = vi.fn(() => this);
+    this.remoteParticipants = new Map();
     this.localParticipant = {
       setMicrophoneEnabled: vi.fn(async () => {}),
       publishTrack: mockPublishTrack,

--- a/clients/wavis-gui/src/features/voice/__tests__/native-capture-race.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/native-capture-race.property.test.ts
@@ -67,6 +67,7 @@ vi.mock('livekit-client', () => ({
     this.disconnect = vi.fn();
     this.on = vi.fn(() => this);
     this.off = vi.fn(() => this);
+    this.remoteParticipants = new Map();
     this.localParticipant = {
       setMicrophoneEnabled: vi.fn(async () => {}),
       publishTrack: vi.fn(async () => {


### PR DESCRIPTION
## Summary

- Adds the missing remoteParticipants map to the LiveKit Room mocks used by the native capture property tests.
- Keeps the change scoped to the test harness so the production Connected handler can iterate the same LiveKit SDK surface used elsewhere.

## Root Cause

The native capture property-test mocks did not include remoteParticipants, while livekit-media.ts now reads room.remoteParticipants.values() when driving the module to the connected state. That caused the property tests to fail before reaching the native capture behavior under test.

## Verification

User confirmed the tests were run manually and passed, per repository verification rules.

Required manual checks reported as passed by the user:

```powershell
cargo test --workspace
cargo clippy --workspace -- -D warnings
```n
Targeted frontend check reported as passed by the user:

```powershell
cd clients/wavis-gui
npm.cmd test -- src/features/voice/__tests__/native-capture-preservation.property.test.ts src/features/voice/__tests__/native-capture-race.property.test.ts
```