### PR TITLE
Fix: Stream interrupted message for static content

### DIFF
--- a/.github/workflows/workspace-ci.yml
+++ b/.github/workflows/workspace-ci.yml
@@ -36,6 +36,9 @@ env:
   CARGO_PROFILE_DEV_DEBUG: 0
   # Limit to 1 parallel link job as a secondary guard against OOM.
   CARGO_BUILD_JOBS: 1
+  # Retry transient crates.io network failures (SSL EOF, timeout, etc).
+  CARGO_NET_RETRY: 10
+  CARGO_HTTP_TIMEOUT: 120
   # All workspace packages EXCEPT wavis-gui (Tauri crate needs GTK/WebKit
   # system libs that aren't available on the CI runner).
   CI_PACKAGES: >-

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -6,7 +6,7 @@ import { emit, emitTo, listen } from '@tauri-apps/api/event';
 import { StreamReceiver } from './screen-share-viewer';
 import { computeWatchAllLayout } from './watch-all-grid';
 import { shouldShowShareLoadingOverlay, useShareTransitionOverlay } from './share-transition';
-import { isPlaybackHealthyWithoutFreshFrames } from './useVideoStallDetector';
+import { isPlaybackHealthyWithoutFreshFrames, STATIC_CONTENT_HEALTH_PING_MS } from './useVideoStallDetector';
 import {
   WATCH_ALL_TEST_READY_EVENT,
   WATCH_ALL_TEST_STATE_EVENT,
@@ -428,7 +428,7 @@ const ShareTile = memo(function ShareTile({
       if (isPlaybackHealthyWithoutFreshFrames(video, stream)) {
         markFrameRendered();
       }
-    }, 1000);
+    }, STATIC_CONTENT_HEALTH_PING_MS);
 
     if (hasRvfc) {
       const scheduleRvfc = () => {

--- a/clients/wavis-gui/src/features/screen-share/__tests__/share-viewer-hooks.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/share-viewer-hooks.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fc from 'fast-check';
-import { isPlaybackHealthyWithoutFreshFrames } from '../useVideoStallDetector';
+import { isPlaybackHealthyWithoutFreshFrames, STATIC_CONTENT_HEALTH_PING_MS } from '../useVideoStallDetector';
 
 const HAVE_METADATA = 1;
 const HAVE_CURRENT_DATA = 2;
@@ -449,6 +449,93 @@ describe('useVideoStallDetector stall-check logic', () => {
         checkStall({ elapsed, stallThresholdMs: 3000, trackAlive: true, onReattach: () => { calls += 1; } });
         expect(calls).toBe(1);
       }),
+    );
+  });
+});
+
+/* ═══ Static-content health ping ══════════════════════════════════
+ *
+ * The health ping fires onFrameDetected when rvfc stops for static content.
+ * It must keep lastFrameAt fresh enough that the share-transition overlay
+ * (threshold 1200ms) never triggers falsely due to timer jitter.
+ *
+ * Core contract:
+ *   - fires when elapsed >= STATIC_CONTENT_HEALTH_PING_MS AND stream is healthy
+ *   - does not fire when elapsed is too small (rvfc still delivering frames)
+ *   - does not fire when the stream is unhealthy (genuine interruption)
+ * ================================================================= */
+
+function checkHealthPing({
+  elapsed,
+  isHealthy,
+  pingMs = STATIC_CONTENT_HEALTH_PING_MS,
+}: {
+  elapsed: number;
+  isHealthy: boolean;
+  pingMs?: number;
+}): boolean {
+  return elapsed >= pingMs && isHealthy;
+}
+
+describe('static content health ping', () => {
+  it('fires when elapsed >= pingMs and stream is healthy', () => {
+    expect(checkHealthPing({ elapsed: STATIC_CONTENT_HEALTH_PING_MS, isHealthy: true })).toBe(true);
+  });
+
+  it('fires for any elapsed well above pingMs with a healthy stream', () => {
+    expect(checkHealthPing({ elapsed: 2000, isHealthy: true })).toBe(true);
+  });
+
+  it('does not fire when elapsed is below pingMs (rvfc recently delivered a frame)', () => {
+    expect(checkHealthPing({ elapsed: STATIC_CONTENT_HEALTH_PING_MS - 1, isHealthy: true })).toBe(false);
+  });
+
+  it('does not fire when stream is unhealthy even if elapsed is large (genuine interruption)', () => {
+    expect(checkHealthPing({ elapsed: 5000, isHealthy: false })).toBe(false);
+  });
+
+  it('health ping interval leaves 800ms margin below the 1200ms overlay threshold', () => {
+    // The overlay triggers at SHARE_TRANSITION_THRESHOLD_MS = 1200ms.
+    // The health ping fires at most STATIC_CONTENT_HEALTH_PING_MS after the
+    // previous markFrameRendered call. The remaining margin must be > 0.
+    const SHARE_TRANSITION_THRESHOLD_MS = 1200;
+    const margin = SHARE_TRANSITION_THRESHOLD_MS - STATIC_CONTENT_HEALTH_PING_MS;
+    expect(margin).toBeGreaterThan(0);
+    // Require at least 500ms margin to absorb timer jitter.
+    expect(margin).toBeGreaterThanOrEqual(500);
+  });
+
+  it('property: always fires when elapsed >= pingMs and stream is healthy', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: STATIC_CONTENT_HEALTH_PING_MS, max: 10_000 }),
+        (elapsed) => {
+          expect(checkHealthPing({ elapsed, isHealthy: true })).toBe(true);
+        },
+      ),
+    );
+  });
+
+  it('property: never fires when elapsed < pingMs', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: STATIC_CONTENT_HEALTH_PING_MS - 1 }),
+        fc.boolean(),
+        (elapsed, isHealthy) => {
+          expect(checkHealthPing({ elapsed, isHealthy })).toBe(false);
+        },
+      ),
+    );
+  });
+
+  it('property: never fires when stream is unhealthy', () => {
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: 10_000 }),
+        (elapsed) => {
+          expect(checkHealthPing({ elapsed, isHealthy: false })).toBe(false);
+        },
+      ),
     );
   });
 });

--- a/clients/wavis-gui/src/features/screen-share/useVideoStallDetector.ts
+++ b/clients/wavis-gui/src/features/screen-share/useVideoStallDetector.ts
@@ -4,6 +4,14 @@ import { isVideoTrackAlive } from './screen-share-viewer';
 
 const HAVE_CURRENT_DATA = 2;
 
+/**
+ * How often to ping markFrameRendered when rvfc stops for static content.
+ * Must be small enough that lastFrameAt never goes stale past
+ * SHARE_TRANSITION_THRESHOLD_MS (1200ms) due to timer jitter.
+ * 400ms gives 800ms of margin.
+ */
+export const STATIC_CONTENT_HEALTH_PING_MS = 400;
+
 interface UseVideoStallDetectorOptions {
   videoRef: RefObject<HTMLVideoElement | null>;
   stream: MediaStream | null;
@@ -69,17 +77,24 @@ export function useVideoStallDetector({
       video.addEventListener('timeupdate', timeupdateHandler);
     }
 
+    // Health ping: keeps onFrameDetected alive when rvfc stops for static content.
+    // Runs at STATIC_CONTENT_HEALTH_PING_MS (400ms) to stay well below the
+    // 1200ms overlay threshold even with timer jitter.
+    const healthPing = setInterval(() => {
+      if (disposed) return;
+      const elapsed = Date.now() - lastFrameTime;
+      if (elapsed >= STATIC_CONTENT_HEALTH_PING_MS && isPlaybackHealthyWithoutFreshFrames(video, stream)) {
+        lastFrameTime = Date.now();
+        onFrameDetected?.();
+      }
+    }, STATIC_CONTENT_HEALTH_PING_MS);
+
+    // Stall detection: fires when no frame (real or healthy-ping) has arrived
+    // for stallThresholdMs. Separate from the health ping so detection timing
+    // is not coupled to the ping frequency.
     const interval = setInterval(() => {
       if (disposed) return;
       const elapsed = Date.now() - lastFrameTime;
-      if (
-        elapsed >= checkIntervalMs &&
-        isPlaybackHealthyWithoutFreshFrames(video, stream)
-      ) {
-        lastFrameTime = Date.now();
-        onFrameDetected?.();
-        return;
-      }
       if (elapsed <= stallThresholdMs) return;
 
       if (!isVideoTrackAlive(stream)) {
@@ -103,6 +118,7 @@ export function useVideoStallDetector({
 
     return () => {
       disposed = true;
+      clearInterval(healthPing);
       clearInterval(interval);
       if (timeupdateHandler) {
         video.removeEventListener('timeupdate', timeupdateHandler);


### PR DESCRIPTION
This PR introduces a health ping mechanism to prevent false 'Stream interrupted' messages when the screen content is static. 

- Added STATIC_CONTENT_HEALTH_PING_MS (400ms) to periodically mark the stream as healthy if playback state is good.
- Decoupled stall detection from health ping to maintain detection responsiveness.
- Added comprehensive tests for the health ping logic.

Closes #179