### PR TITLE
fix: first join to the room comes with no sound

### DIFF
--- a/clients/wavis-gui/src/features/settings/__tests__/settings-store.property.test.ts
+++ b/clients/wavis-gui/src/features/settings/__tests__/settings-store.property.test.ts
@@ -174,6 +174,9 @@ vi.mock('../../voice/audio-devices', () => ({
 
 vi.mock('../../voice/notification-sounds', () => ({
   playNotificationSound: vi.fn(async () => {}),
+  updateCachedNotificationVolume: vi.fn(),
+  updateCachedSoundVolumes: vi.fn(),
+  prewarmAudioContext: vi.fn(),
 }));
 
 vi.mock('@shared/hotkey-bridge', () => ({

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
@@ -392,6 +392,9 @@ async function loadVoiceRoomIntegrationHarness() {
 
   vi.doMock('../notification-sounds', () => ({
     playNotificationSound: vi.fn(async () => {}),
+    updateCachedNotificationVolume: vi.fn(),
+    updateCachedSoundVolumes: vi.fn(),
+    prewarmAudioContext: vi.fn(),
   }));
 
   vi.doMock('@tauri-apps/api/core', () => ({

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.test-helpers.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.test-helpers.ts
@@ -275,6 +275,9 @@ export async function setupVoiceRoomCameraHarness(): Promise<VoiceRoomCameraHarn
 
   vi.doMock('../notification-sounds', () => ({
     playNotificationSound: vi.fn(async () => {}),
+    updateCachedNotificationVolume: vi.fn(),
+    updateCachedSoundVolumes: vi.fn(),
+    prewarmAudioContext: vi.fn(),
   }));
 
   vi.doMock('@tauri-apps/api/core', () => ({

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
@@ -45,6 +45,9 @@ vi.mock('@shared/hotkey-bridge', () => ({
 }));
 vi.mock('../notification-sounds', () => ({
   playNotificationSound: vi.fn().mockResolvedValue(undefined),
+  updateCachedNotificationVolume: vi.fn(),
+  updateCachedSoundVolumes: vi.fn(),
+  prewarmAudioContext: vi.fn(),
 }));
 vi.mock('../livekit-media', () => ({
   LiveKitModule: vi.fn().mockImplementation(() => ({
@@ -107,6 +110,8 @@ vi.mock('@features/settings/settings-store', () => ({
   setChannelVolumes: vi.fn().mockResolvedValue(undefined),
   getVideoInputDevice: vi.fn().mockResolvedValue(null),
   setVideoInputDevice: vi.fn().mockResolvedValue(undefined),
+  getNotificationVolume: vi.fn().mockResolvedValue(100),
+  getSoundVolumes: vi.fn().mockResolvedValue({}),
   DEFAULT_PASSTHROUGH_VOLUME: 20,
 }));
 // ─── Message injection state ──────────────────────────────────────

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -251,6 +251,9 @@ vi.mock('../notification-sounds', () => ({
   playNotificationSound: vi.fn(async (name: string) => {
     playNotificationSoundCalls.push(name);
   }),
+  updateCachedNotificationVolume: vi.fn(),
+  updateCachedSoundVolumes: vi.fn(),
+  prewarmAudioContext: vi.fn(),
 }));
 
 // ─── Mock Tauri APIs ───────────────────────────────────────────────

--- a/clients/wavis-gui/src/features/voice/notification-sounds.ts
+++ b/clients/wavis-gui/src/features/voice/notification-sounds.ts
@@ -15,6 +15,7 @@ let cachedSoundVolumes: Record<string, number> | null = null;
 // AudioBufferSourceNode. fetch() works with tauri:// in both dev and
 // production. This is the same API the voice chat system uses.
 let audioCtx: AudioContext | null = null;
+let gestureListenerActive = false;
 
 // Cache decoded audio buffers so we only fetch + decode each sound once.
 const bufferCache: Map<string, AudioBuffer> = new Map();
@@ -32,6 +33,40 @@ function getAudioContext(): AudioContext {
     audioCtx = new AudioContext();
   }
   return audioCtx;
+}
+
+// Register a one-shot click/keydown listener so the AudioContext is resumed
+// on the next user gesture if the immediate resume() call fails or is pending.
+function registerGestureListenerIfNeeded(ctx: AudioContext): void {
+  if (gestureListenerActive || ctx.state !== 'suspended') return;
+  gestureListenerActive = true;
+  const resume = () => {
+    ctx.resume().catch(() => {});
+    document.removeEventListener('click', resume);
+    document.removeEventListener('keydown', resume);
+    gestureListenerActive = false;
+  };
+  document.addEventListener('click', resume);
+  document.addEventListener('keydown', resume);
+}
+
+/**
+ * Pre-warm the AudioContext so it is ready before the first notification
+ * sound is triggered. Call this when media starts connecting to avoid the
+ * AudioContext being created lazily inside an async callback where the
+ * browser may refuse to resume it without a prior user gesture.
+ *
+ * Mirrors the pattern in livekit-media.ts ensureAudioContext().
+ */
+export function prewarmAudioContext(): void {
+  if (typeof AudioContext === 'undefined') return;
+  const ctx = getAudioContext();
+  if (ctx.state !== 'suspended') return;
+  // In Tauri (WebView2/WebKit) the autoplay policy is often more relaxed
+  // than in a browser tab, so resume() may succeed without a user gesture.
+  ctx.resume().catch(() => {});
+  // Register a gesture listener as fallback in case resume() is blocked.
+  registerGestureListenerIfNeeded(ctx);
 }
 
 async function getAudioBuffer(name: string): Promise<AudioBuffer> {
@@ -68,6 +103,7 @@ export async function playNotificationSound(name: string): Promise<void> {
 
     // Resume AudioContext if suspended (browser autoplay policy).
     if (ctx.state === 'suspended') {
+      registerGestureListenerIfNeeded(ctx);
       await ctx.resume();
     }
 

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -28,6 +28,8 @@ import { NativeMediaModule } from './native-media';
 import { setActiveLiveKitModule } from './audio-devices';
 import {
   getDefaultVolume,
+  getNotificationVolume,
+  getSoundVolumes,
   getReconnectConfig,
   getMuteHotkey,
   getProfileColor,
@@ -47,7 +49,7 @@ import {
   type LinuxCapabilityRow,
 } from './linux-capability-matrix';
 import { registerMuteHotkey, unregisterMuteHotkey } from '@shared/hotkey-bridge';
-import { playNotificationSound } from './notification-sounds';
+import { playNotificationSound, prewarmAudioContext, updateCachedNotificationVolume, updateCachedSoundVolumes } from './notification-sounds';
 import { toast } from 'sonner';
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -2586,6 +2588,10 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
   state.noiseSuppressionActive = false;
   markAllParticipantsMediaConnecting();
   suppressReconnectJoinForParticipantIds.clear();
+  // Pre-warm the notification-sounds AudioContext before the join sound fires.
+  // Without this, the AudioContext is created lazily inside an async callback
+  // where the browser may refuse to resume it (no active user gesture).
+  prewarmAudioContext();
   notify();
 
   const restoreConnectedMediaState = (
@@ -4095,14 +4101,18 @@ export function initSession(
     if (!serverUrl || client !== thisClient) return;
     const wsUrl = toWsUrl(serverUrl);
     // Load display name, default volume, profile color, persisted channel volumes,
-    // and the Windows share-path preference before connecting.
+    // notification volumes, and the Windows share-path preference before connecting.
+    // Notification volumes are pre-cached here so playNotificationSound() on the
+    // first join does not make IPC calls that break the user-activation chain.
     Promise.all([
       getUsername(),
       getDefaultVolume(),
       getProfileColor(),
       getChannelVolumes(channelId),
       getWindowsSharePath(),
-    ]).then(([name, vol, profileColor, savedVols, windowsSharePath]) => {
+      getNotificationVolume(),
+      getSoundVolumes(),
+    ]).then(([name, vol, profileColor, savedVols, windowsSharePath, notifVol, soundVols]) => {
       if (client !== thisClient) return;
       sessionUsername = name;
       sessionProfileColor = profileColor;
@@ -4110,6 +4120,8 @@ export function initSession(
       state.defaultVolume = vol;
       state.masterVolume = savedVols?.master ?? vol;
       state.windowsSharePath = resolveWindowsSharePathPreference(windowsSharePath);
+      updateCachedNotificationVolume(notifVol);
+      updateCachedSoundVolumes(soundVols);
       client.connectWithAuth(wsUrl).catch((err) => {
         console.error(LOG, 'connect failed:', err);
         if (client !== thisClient) return;


### PR DESCRIPTION
This PR fixes the issue where the notification sound does not play on the first join to a room. 

### Changes:
- Pre-warms the AudioContext when media starts connecting.
- Caches notification and sound volumes during session initialization to avoid async IPC calls during sound playback.
- Registers a one-shot gesture listener as a fallback for AudioContext resumption.

Closes #148