### PR TITLE
161 show name in ban

### DIFF
--- a/clients/wavis-gui/src/App.tsx
+++ b/clients/wavis-gui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { RouterProvider } from 'react-router';
 import { router } from './routes';
 import TitleBar from '@shared/TitleBar';
@@ -7,8 +7,10 @@ import { DebugProvider } from '@shared/debug-context';
 import { initNotificationBridge } from '@shared/notification-bridge';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit } from '@tauri-apps/api/event';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { getState } from '@features/voice/voice-room';
 import AppUpdatePrompt from '@shared/AppUpdatePrompt';
+import type { AppDimensions } from '@features/diagnostics/diagnostics';
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
@@ -25,9 +27,38 @@ function isChromelessWindow(): boolean {
   );
 }
 
+async function readAppDimensions(): Promise<AppDimensions> {
+  const nativeWindow = await getCurrentWindow().outerSize();
+  return {
+    nativeWindow: {
+      width: Math.round(nativeWindow.width),
+      height: Math.round(nativeWindow.height),
+    },
+    viewport: {
+      width: Math.round(window.innerWidth),
+      height: Math.round(window.innerHeight),
+    },
+    devicePixelRatio: window.devicePixelRatio,
+    capturedAt: Date.now(),
+  };
+}
+
+async function emitAppDimensions(): Promise<AppDimensions | null> {
+  try {
+    const appDimensions = await readAppDimensions();
+    await emit('diagnostics:app-dimensions', appDimensions);
+    return appDimensions;
+  } catch (err) {
+    console.warn('[wavis:diagnostics] app dimensions unavailable:', err);
+    return null;
+  }
+}
+
 /* ═══ Component ═════════════════════════════════════════════════════ */
 
 export default function App() {
+  const latestAppDimensionsRef = useRef<AppDimensions | null>(null);
+
   // Initialize notification bridge (seeds visibility cache, starts event listener)
   useEffect(() => {
     const cleanup = initNotificationBridge();
@@ -75,10 +106,63 @@ export default function App() {
           isSpeaking: p.isSpeaking,
         })),
         selfParticipantId,
+        appDimensions: latestAppDimensionsRef.current,
       });
     }, 1000);
 
     return () => clearInterval(intervalId);
+  }, []);
+
+  // Diagnostics app-size bridge. Sends the main Wavis native window and webview
+  // viewport dimensions on startup and resize without a polling loop.
+  useEffect(() => {
+    if (import.meta.env.VITE_DIAGNOSTICS !== 'true') return;
+    if (isChromelessWindow()) return;
+
+    let mounted = true;
+    let frameId: number | null = null;
+    let unlistenResize: (() => void) | null = null;
+
+    const publishDimensions = async () => {
+      const appDimensions = await emitAppDimensions();
+      if (mounted && appDimensions) {
+        latestAppDimensionsRef.current = appDimensions;
+      }
+    };
+
+    const scheduleEmit = () => {
+      if (frameId !== null) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        if (mounted) {
+          void publishDimensions();
+        }
+      });
+    };
+
+    void publishDimensions();
+    window.addEventListener('resize', scheduleEmit);
+    getCurrentWindow()
+      .onResized(scheduleEmit)
+      .then((unlisten) => {
+        if (!mounted) {
+          unlisten();
+          return;
+        }
+        unlistenResize = unlisten;
+      })
+      .catch((err) => {
+        console.warn('[wavis:diagnostics] resize listener unavailable:', err);
+      });
+
+    return () => {
+      mounted = false;
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      window.removeEventListener('resize', scheduleEmit);
+      unlistenResize?.();
+    };
   }, []);
 
   if (isChromelessWindow()) {

--- a/clients/wavis-gui/src/features/channels/ChannelDetail.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelDetail.tsx
@@ -44,7 +44,7 @@ const DETAIL_POLL_MS = 15_000;
 const VOICE_POLL_MS = 5_000;
 const SUCCESS_DISPLAY_MS = 2_000;
 const MEMBER_ROW_GRID_CLASS =
-  'grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-3 gap-y-1 @[480px]:grid-cols-[minmax(0,1fr)_5rem_4.5rem_6.5rem] @[480px]:gap-2';
+  'grid grid-cols-[minmax(0,1fr)_4rem_4rem_5.75rem] items-center gap-1';
 const MEMBER_JOINED_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
@@ -54,13 +54,18 @@ const MEMBER_JOINED_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
 function formatMemberJoinedDate(joinedAt: string): string {
   return MEMBER_JOINED_DATE_FORMATTER.format(new Date(joinedAt));
 }
+
+function formatUserTargetLabel(userId: string, displayName?: string): string {
+  const trimmedDisplayName = displayName?.trim() ?? '';
+  return trimmedDisplayName ? `${trimmedDisplayName} (${userId})` : userId;
+}
 const DIVIDER = '─'.repeat(48);
 
 /* ─── Sub-components ────────────────────────────────────────────── */
 
 function MembersHeader() {
   return (
-    <div className={`${MEMBER_ROW_GRID_CLASS} hidden px-3 py-1 text-xs text-wavis-text-secondary @[480px]:grid`}>
+    <div className={`${MEMBER_ROW_GRID_CLASS} px-3 py-1 text-xs text-wavis-text-secondary`}>
       <span />
       <span />
       <span />
@@ -95,13 +100,39 @@ function MemberRow({
 
   return (
     <div className={`${MEMBER_ROW_GRID_CLASS} px-3 py-2 ${isMe ? 'text-wavis-accent' : ''}`}>
-      <span className="min-w-0 truncate flex-1 text-sm">
+      <span className="min-w-0 truncate text-sm">
         {member.displayName || member.userId}
         {isMe && <span className="text-xs ml-1">(you)</span>}
       </span>
-      <ChannelRoleBadge role={member.role} className="justify-self-end @[480px]:justify-self-end" />
-      <div className="col-span-2 row-start-2 min-w-0 flex flex-wrap items-center justify-start gap-1 @[480px]:col-auto @[480px]:row-auto @[480px]:justify-end @[480px]:flex-nowrap">
-        {showRoleBtn && !isRoleTarget && (
+      {!isRoleTarget && (
+        <ChannelRoleBadge role={member.role} className="min-w-0 justify-self-end" />
+      )}
+      {isRoleTarget ? (
+        <div className="col-start-2 col-span-2 min-w-0 flex items-center justify-end gap-1.5">
+          <button
+            onClick={() => { onRoleChange(member.userId, 'admin'); setRoleTarget(null); }}
+            disabled={submitting || member.role === 'admin'}
+            className="text-xs border border-wavis-warn text-wavis-warn hover:bg-wavis-warn hover:text-wavis-bg transition-colors px-1 py-0.5 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            ADMIN
+          </button>
+          <button
+            onClick={() => { onRoleChange(member.userId, 'member'); setRoleTarget(null); }}
+            disabled={submitting || member.role === 'member'}
+            className="text-xs border border-wavis-text-secondary text-wavis-text-secondary hover:bg-wavis-text-secondary hover:text-wavis-bg transition-colors px-1 py-0.5 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            MEMBER
+          </button>
+          <button
+            onClick={() => setRoleTarget(null)}
+            className="text-xs text-wavis-text-secondary hover:text-wavis-text"
+          >
+            [x]
+          </button>
+        </div>
+      ) : (
+        <div className="min-w-0 flex items-center justify-end gap-1">
+        {showRoleBtn && (
           <button
             onClick={() => onRole?.(member.userId)}
             disabled={submitting}
@@ -143,8 +174,9 @@ function MemberRow({
             /ban
           </button>
         )}
-      </div>
-      <span className="col-span-2 row-start-3 justify-self-start text-right text-xs text-wavis-text-secondary font-mono tabular-nums @[480px]:col-auto @[480px]:row-auto @[480px]:justify-self-auto">
+        </div>
+      )}
+      <span className="justify-self-end text-right text-xs text-wavis-text-secondary font-mono tabular-nums">
         {formatMemberJoinedDate(member.joinedAt)}
       </span>
     </div>
@@ -398,7 +430,9 @@ function BanPanel({
       {bannable.map((m) => {
         return (
           <div key={m.userId} className="flex items-center gap-3 py-1">
-            <span className="text-sm text-wavis-text truncate flex-1">{m.userId}</span>
+            <span className="min-w-0 text-sm text-wavis-text truncate flex-1">
+              {formatUserTargetLabel(m.userId, m.displayName)}
+            </span>
             <ChannelRoleBadge role={m.role} className="shrink-0" />
             <button
               onClick={() => {
@@ -419,10 +453,12 @@ function BanPanel({
 
 function UnbanPanel({
   channelId,
+  knownDisplayNames,
   submitting,
   onMutation,
 }: {
   channelId: string;
+  knownDisplayNames: Map<string, string>;
   submitting: boolean;
   onMutation: (fn: () => Promise<void>, msg: string) => Promise<void>;
 }) {
@@ -434,7 +470,14 @@ function UnbanPanel({
     (async () => {
       try {
         const list = await fetchBannedMembers(channelId);
-        if (!cancelled) setBanned(list);
+        if (!cancelled) {
+          setBanned(
+            list.map((member) => ({
+              ...member,
+              displayName: member.displayName || knownDisplayNames.get(member.userId) || '',
+            })),
+          );
+        }
       } catch (err) {
         if (!cancelled) {
           setLoadError(err instanceof ApiError ? apiErrorMessage(err) : 'failed to load bans');
@@ -442,7 +485,7 @@ function UnbanPanel({
       }
     })();
     return () => { cancelled = true; };
-  }, [channelId]);
+  }, [channelId, knownDisplayNames]);
 
   if (loadError) {
     return (
@@ -470,9 +513,11 @@ function UnbanPanel({
       <p className="text-sm text-wavis-text-secondary mb-2">banned members</p>
       {banned.map((b) => (
         <div key={b.userId} className="flex items-center gap-3 py-1">
-          <span className="text-sm text-wavis-text truncate flex-1">{b.userId}</span>
+          <span className="min-w-0 text-sm text-wavis-text truncate flex-1">
+            {formatUserTargetLabel(b.userId, b.displayName)}
+          </span>
           <span className="text-xs text-wavis-text-secondary shrink-0">
-            {new Date(b.bannedAt).toLocaleDateString()}
+            {MEMBER_JOINED_DATE_FORMATTER.format(new Date(b.bannedAt))}
           </span>
           <button
             onClick={() =>
@@ -558,6 +603,16 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
   const skipNextRefresh = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const hasLoaded = useRef(false);
+  const memberDisplayNamesRef = useRef(new Map<string, string>());
+
+  const rememberMemberDisplayNames = useCallback((data: ChannelDetailData) => {
+    for (const member of data.members) {
+      const displayName = member.displayName.trim();
+      if (displayName) {
+        memberDisplayNamesRef.current.set(member.userId, displayName);
+      }
+    }
+  }, []);
 
   /* ── Resolve device ID once ── */
   useEffect(() => {
@@ -587,6 +642,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
 
       try {
         const data = await fetchChannelDetail(channelId, controller.signal);
+        rememberMemberDisplayNames(data);
         setDetail(data);
         hasLoaded.current = true;
       } catch (err) {
@@ -608,7 +664,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
         if (!silent) setLoading(false);
       }
     },
-    [channelId, navigateAway],
+    [channelId, navigateAway, rememberMemberDisplayNames],
   );
 
   /* ── loadVoice ── */
@@ -654,6 +710,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
         if (abortRef.current) abortRef.current.abort();
         try {
           const data = await fetchChannelDetail(channelId);
+          rememberMemberDisplayNames(data);
           setDetail(data);
         } catch {
           // re-fetch failed, will catch up on next poll
@@ -667,6 +724,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
             if (abortRef.current) abortRef.current.abort();
             try {
               const data = await fetchChannelDetail(channelId);
+              rememberMemberDisplayNames(data);
               setDetail(data);
             } catch {
               // re-fetch failed
@@ -682,7 +740,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
         setSubmitting(false);
       }
     },
-    [channelId],
+    [channelId, rememberMemberDisplayNames],
   );
 
   /* ── Panel toggle ── */
@@ -946,6 +1004,7 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
               {activePanel === 'unban' && (
                 <UnbanPanel
                   channelId={channelId!}
+                  knownDisplayNames={memberDisplayNamesRef.current}
                   submitting={submitting}
                   onMutation={handleMutation}
                 />
@@ -1016,7 +1075,12 @@ export default function ChannelDetail({ channelIdProp, hideJoinVoice, hideBackBu
           />
         )}
         {activePanel === 'unban' && (
-          <UnbanPanel channelId={channelId!} submitting={submitting} onMutation={handleMutation} />
+          <UnbanPanel
+            channelId={channelId!}
+            knownDisplayNames={memberDisplayNamesRef.current}
+            submitting={submitting}
+            onMutation={handleMutation}
+          />
         )}
       </>
     );

--- a/clients/wavis-gui/src/features/channels/channel-detail.ts
+++ b/clients/wavis-gui/src/features/channels/channel-detail.ts
@@ -48,6 +48,7 @@ export interface ChannelInvite {
 export interface BannedMember {
   userId: string;
   bannedAt: string;
+  displayName: string;
 }
 
 
@@ -90,7 +91,7 @@ interface BackendInviteListItem {
 }
 
 interface BackendBanListResponse {
-  banned: Array<{ user_id: string; banned_at: string }>;
+  banned: Array<{ user_id: string; banned_at: string; display_name?: string }>;
 }
 
 interface BackendBanResponse {
@@ -208,6 +209,7 @@ export async function fetchBannedMembers(
   return res.banned.map((b) => ({
     userId: b.user_id,
     bannedAt: b.banned_at,
+    displayName: b.display_name ?? '',
   }));
 }
 

--- a/clients/wavis-gui/src/features/diagnostics/DiagnosticsPage.tsx
+++ b/clients/wavis-gui/src/features/diagnostics/DiagnosticsPage.tsx
@@ -103,6 +103,10 @@ function fmtAspectRatio(value: number): string {
   return `${value.toFixed(2)}:1`;
 }
 
+function fmtDimensions(width: number, height: number): string {
+  return `${width}x${height}`;
+}
+
 const WATCH_ALL_TEST_PRESETS = [
   { label: '1080', width: 1920, height: 1080, color: '#60a5fa' },
   { label: 'wide', width: 1728, height: 1080, color: '#34d399' },
@@ -553,6 +557,36 @@ export default function DiagnosticsPage() {
           </button>
         </div>
       </div>
+
+      {/* App dimensions */}
+      <Section>
+        <SectionHeader>App Dimensions</SectionHeader>
+        {snap.appDimensions ? (
+          <>
+            <MetricRow
+              label="Window"
+              value={`${fmtDimensions(snap.appDimensions.nativeWindow.width, snap.appDimensions.nativeWindow.height)} physical px`}
+            />
+            <div className="text-[0.6rem] text-wavis-text-secondary/60">
+              Native Tauri window size, including OS window frame/decorations.
+            </div>
+            <MetricRow
+              label="Viewport"
+              value={`${fmtDimensions(snap.appDimensions.viewport.width, snap.appDimensions.viewport.height)} CSS px`}
+            />
+            <div className="text-[0.6rem] text-wavis-text-secondary/60">
+              Webview content area used by the React layout.
+            </div>
+            <MetricRow
+              label="DPR"
+              value={snap.appDimensions.devicePixelRatio.toFixed(2)}
+              dim
+            />
+          </>
+        ) : (
+          <MetricRow label="Status" value="Waiting for main app" dim />
+        )}
+      </Section>
 
       {/* Network */}
       <Section>

--- a/clients/wavis-gui/src/features/diagnostics/diagnostics.ts
+++ b/clients/wavis-gui/src/features/diagnostics/diagnostics.ts
@@ -37,8 +37,23 @@ export interface DiagnosticsConfig {
   renderWarnMs: number;
 }
 
+export interface AppDimensions {
+  nativeWindow: {
+    width: number;
+    height: number;
+  };
+  viewport: {
+    width: number;
+    height: number;
+  };
+  devicePixelRatio: number;
+  capturedAt: number;
+}
+
 export interface DiagnosticsSnapshot {
   timestamp: number;
+  /** Main Wavis app window dimensions, pushed from the main webview. */
+  appDimensions: AppDimensions | null;
   rss: { mb: number; childCount: number } | null;
   /** JS heap size. Null on macOS (WKWebView does not expose performance.memory). */
   jsHeap: { usedMb: number; totalMb: number } | null;
@@ -142,6 +157,7 @@ interface DiagnosticsVoiceStatsPayload {
   videoReceiveStats: VideoReceiveStats | null;
   participants: Array<{ id: string; rmsLevel: number; isSpeaking: boolean }>;
   selfParticipantId: string | null;
+  appDimensions?: AppDimensions;
 }
 
 /* ─── Module state ──────────────────────────────────────────────── */
@@ -169,8 +185,14 @@ let prevWasSharing = false;
 /** Latest voice-room stats received from the main window via 'diagnostics:voice-stats' event. */
 let cachedVoiceStats: DiagnosticsVoiceStatsPayload | null = null;
 
+/** Latest main app dimensions received from the main window via 'diagnostics:app-dimensions'. */
+let cachedAppDimensions: AppDimensions | null = null;
+
 /** Unlisten function for the 'diagnostics:voice-stats' event listener. */
 let unlistenVoiceStats: UnlistenFn | null = null;
+
+/** Unlisten function for the 'diagnostics:app-dimensions' event listener. */
+let unlistenAppDimensions: UnlistenFn | null = null;
 
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
@@ -254,6 +276,10 @@ export async function initDiagnostics(
     'diagnostics:voice-stats',
     (event) => { cachedVoiceStats = event.payload; },
   );
+  unlistenAppDimensions = await listen<AppDimensions>(
+    'diagnostics:app-dimensions',
+    (event) => { cachedAppDimensions = event.payload; },
+  );
 
   // VITE_DIAGNOSTICS=true is the build-time gate; the Rust `enabled` flag is
   // unreliable in release builds (dotenvy only loads .env in debug mode).
@@ -280,7 +306,10 @@ export function destroyDiagnostics(): void {
   shareStoppedAt = null;
   unlistenVoiceStats?.();
   unlistenVoiceStats = null;
+  unlistenAppDimensions?.();
+  unlistenAppDimensions = null;
   cachedVoiceStats = null;
+  cachedAppDimensions = null;
 }
 
 /** Store a baseline snapshot for delta display. */
@@ -319,6 +348,17 @@ export function exportSnapshot(snap: DiagnosticsSnapshot): string {
 
   lines.push('=== WAVIS DIAGNOSTICS SNAPSHOT ===');
   lines.push(`Captured: ${now.toISOString()}`);
+  lines.push('');
+
+  // App dimensions
+  lines.push('[APP DIMENSIONS]');
+  if (snap.appDimensions) {
+    lines.push(pad('Window:', `${snap.appDimensions.nativeWindow.width}x${snap.appDimensions.nativeWindow.height} physical px`));
+    lines.push(pad('Viewport:', `${snap.appDimensions.viewport.width}x${snap.appDimensions.viewport.height} CSS px`));
+    lines.push(pad('DPR:', snap.appDimensions.devicePixelRatio.toFixed(2)));
+  } else {
+    lines.push(pad('Status:', 'Waiting for main app dimensions'));
+  }
   lines.push('');
 
   // Memory
@@ -484,6 +524,7 @@ async function poll(): Promise<void> {
   const videoReceiveStats = voiceStats?.videoReceiveStats ?? null;
   const participants = voiceStats?.participants ?? [];
   const selfParticipantId = voiceStats?.selfParticipantId ?? null;
+  const appDimensions = cachedAppDimensions ?? voiceStats?.appDimensions ?? null;
 
   // Show network block whenever we're in a session (selfParticipantId is non-null).
   // Avoid gating on rttMs > 0: the subscriber PC often returns RTT=0 on cycles where
@@ -559,6 +600,7 @@ async function poll(): Promise<void> {
 
   const snap: DiagnosticsSnapshot = {
     timestamp: Date.now(),
+    appDimensions,
     rss,
     jsHeap,
     domNodes,

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -445,6 +445,8 @@ export default function ActiveRoom() {
   // Mobile tab state
   type MobileTab = 'participants' | 'chat' | 'log' | 'video';
   const [mobileTab, setMobileTab] = useState<MobileTab>('participants');
+  type GroupedPanelTab = 'chat' | 'log' | 'video';
+  const [groupedPanelTab, setGroupedPanelTab] = useState<GroupedPanelTab>('chat');
 
   const blocker = useBlocker(({ currentLocation, nextLocation }) =>
     shouldBlockRoomNavigation(
@@ -726,6 +728,29 @@ export default function ActiveRoom() {
   const watchAllHotkeyRef = useRef<string | null>(null);
   const focusMainHotkeyRef = useRef<string | null>(null);
   const toggleWatchAllRef = useRef<() => void>(() => { });
+  const groupedPanelVideoActivityKey = roomState
+    ? Object.entries(roomState.videoTilesById)
+      .filter(([, tile]) => !tile.isMuted)
+      .map(([participantId]) => participantId)
+      .sort()
+      .join('|')
+    : '';
+  const groupedPanelVideoActivityRef = useRef(groupedPanelVideoActivityKey);
+
+  useEffect(() => {
+    const previous = groupedPanelVideoActivityRef.current;
+    if (previous === groupedPanelVideoActivityKey) return;
+    groupedPanelVideoActivityRef.current = groupedPanelVideoActivityKey;
+    setGroupedPanelTab((current) => {
+      if (groupedPanelVideoActivityKey !== '') return 'video';
+      return current === 'video' ? 'chat' : current;
+    });
+  }, [groupedPanelVideoActivityKey]);
+
+  useEffect(() => {
+    if (!videoPopoutOpen) return;
+    setGroupedPanelTab((current) => (current === 'video' ? 'chat' : current));
+  }, [videoPopoutOpen]);
 
   // Screen share window state (multi-window: one per sharer)
   const [watchingShareIds, setWatchingShareIds] = useState<Set<string>>(new Set());
@@ -3274,6 +3299,20 @@ export default function ActiveRoom() {
     </>
   );
 
+  const videoPanel = (
+    <div className="flex flex-col flex-1 min-h-0">
+      <VideoTab videoTilesById={videoTilesById} />
+      <div className="shrink-0 p-4 border-t border-wavis-text-secondary -translate-y-px">
+        <button
+          onClick={() => { void openVideoPopoutWindow(); }}
+          className={`w-full py-[7px] px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
+        >
+          /pop-out
+        </button>
+      </div>
+    </div>
+  );
+
   // Desktop right-panel: LOGS / VIDEOS tab switcher
   const logPanel = (
     <div className="flex-1 flex flex-col min-h-0">
@@ -3312,19 +3351,65 @@ export default function ActiveRoom() {
       </div>
       {/* ── Tab body ── */}
       {currentPanelTab === 'video' && !videoPopoutOpen ? (
-        <>
-          <VideoTab videoTilesById={videoTilesById} />
-          <div className="shrink-0 p-4 border-t border-wavis-text-secondary -translate-y-px">
-            <button
-              onClick={() => { void openVideoPopoutWindow(); }}
-              className={`w-full py-[7px] px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
-            >
-              /pop-out
-            </button>
-          </div>
-        </>
+        videoPanel
       ) : (
         logsContent
+      )}
+    </div>
+  );
+
+  const groupedPanel = (
+    <div className="flex-1 flex flex-col min-h-0">
+      {showSettings ? (
+        <Settings onClose={() => setShowSettings(false)} onNavigateAway={navigateAwayFromRoom} channelId={channelId} />
+      ) : channelSwitcherOpen ? (
+        <ChannelSwitcherPanel
+          onChannelSelect={handleChannelSwitch}
+          onClose={() => setChannelSwitcherOpen(false)}
+          currentChannelId={channelId}
+        />
+      ) : (
+        <>
+          <div className="flex h-[4.5rem] border-b border-wavis-text-secondary bg-wavis-panel">
+            {(['chat', 'log', 'video'] as const).filter((tab) => !(tab === 'video' && videoPopoutOpen)).map((tab) => {
+              const active = groupedPanelTab === tab;
+              const label = tab === 'chat'
+                ? `CHAT (${roomState.chatMessages.length})`
+                : tab === 'log'
+                  ? `LOG (${roomState.events.length})`
+                  : 'VIDEO';
+              return (
+                <button
+                  key={tab}
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => setGroupedPanelTab(tab)}
+                  onDoubleClick={() => {
+                    if (tab !== 'video') return;
+                    setGroupedPanelTab('video');
+                    void openVideoPopoutWindow();
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setGroupedPanelTab(tab);
+                    }
+                  }}
+                  className="flex-1 flex items-center justify-center font-bold text-xs border-r border-wavis-text-secondary last:border-r-0 transition-colors"
+                  style={{
+                    color: active ? 'var(--wavis-accent)' : 'var(--wavis-text-secondary)',
+                    backgroundColor: active ? 'rgba(46,160,67,0.08)' : 'transparent',
+                  }}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          {groupedPanelTab === 'chat' && chatPanel}
+          {groupedPanelTab === 'log' && logsContent}
+          {groupedPanelTab === 'video' && !videoPopoutOpen && videoPanel}
+        </>
       )}
     </div>
   );
@@ -3405,25 +3490,28 @@ export default function ActiveRoom() {
               {mobileTab === 'participants' && <div className="flex flex-col flex-1 min-h-0">{participantsSections}{youBar}</div>}
               {mobileTab === 'chat' && chatPanel}
               {mobileTab === 'log' && logsContent}
-              {mobileTab === 'video' && !videoPopoutOpen && (
-                <div className="flex flex-col flex-1 min-h-0">
-                  <VideoTab videoTilesById={videoTilesById} />
-                  <div className="shrink-0 p-4 border-t border-wavis-text-secondary -translate-y-px">
-                    <button
-                      onClick={() => { void openVideoPopoutWindow(); }}
-                      className={`w-full py-[7px] px-2 text-xs text-center transition-colors border ${videoPopoutOpen ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}
-                    >
-                      /pop-out
-                    </button>
-                  </div>
-                </div>
-              )}
+              {mobileTab === 'video' && !videoPopoutOpen && videoPanel}
             </>
           )}
         </div>
       </div>
 
-      {/* ═══ DESKTOP LAYOUT (md+) ═══ */}
+      {/* Intermediate layout (md to 1038px) */}
+      <div className="wavis-room-intermediate-layout flex-1 overflow-hidden">
+        <div className="w-80 shrink-0 border-r border-wavis-text-secondary flex flex-col">
+          {roomHeader}
+          {mediaReconnectingBanner}
+          {mediaRetryBanner}
+          {reconnectBanner}
+          {participantsSections}
+          {youBar}
+        </div>
+        <div className="flex-1 flex flex-col min-h-0 min-w-0 overflow-hidden">
+          {groupedPanel}
+        </div>
+      </div>
+
+      {/* Desktop layout (1039px+) */}
       <div className="hidden md:flex flex-1 overflow-hidden">
         <div className="w-80 border-r border-wavis-text-secondary flex flex-col">
           {roomHeader}

--- a/clients/wavis-gui/src/features/voice/__tests__/ActiveRoom.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/ActiveRoom.test.ts
@@ -25,6 +25,33 @@ import type { RoomParticipant } from '../voice-room';
 
 const ROOM_REMOVAL_COUNTDOWN_INTERVAL_MS = 10_000;
 
+type VoiceRoomLayoutBand = 'mobile' | 'intermediate' | 'desktop';
+type GroupedPanelTab = 'chat' | 'log' | 'video';
+
+function voiceRoomLayoutBand(widthPx: number): VoiceRoomLayoutBand {
+  if (widthPx < 768) return 'mobile';
+  if (widthPx < 1039) return 'intermediate';
+  return 'desktop';
+}
+
+function groupedPanelTabs(videoPopoutOpen: boolean): GroupedPanelTab[] {
+  return videoPopoutOpen ? ['chat', 'log'] : ['chat', 'log', 'video'];
+}
+
+function nextGroupedPanelTab(
+  current: GroupedPanelTab,
+  previousVideoActivityKey: string,
+  nextVideoActivityKey: string,
+): GroupedPanelTab {
+  if (previousVideoActivityKey === nextVideoActivityKey) return current;
+  if (nextVideoActivityKey !== '') return 'video';
+  return current === 'video' ? 'chat' : current;
+}
+
+function groupedPanelTabAfterPopout(current: GroupedPanelTab, videoPopoutOpen: boolean): GroupedPanelTab {
+  return videoPopoutOpen && current === 'video' ? 'chat' : current;
+}
+
 /* ─── Mock voice-room module ────────────────────────────────────── */
 
 const mockToggleShareAudio = vi.fn();
@@ -52,6 +79,62 @@ vi.mock('../voice-room', () => ({
   toggleShareAudio: mockToggleShareAudio,
   changeShareSource: vi.fn(),
 }));
+
+describe('voice room responsive layout bands', () => {
+  it('keeps the current mobile layout below 768px', () => {
+    expect(voiceRoomLayoutBand(320)).toBe('mobile');
+    expect(voiceRoomLayoutBand(767)).toBe('mobile');
+  });
+
+  it('uses the grouped-panel intermediate layout from 768px through 1038px', () => {
+    expect(voiceRoomLayoutBand(768)).toBe('intermediate');
+    expect(voiceRoomLayoutBand(900)).toBe('intermediate');
+    expect(voiceRoomLayoutBand(1038)).toBe('intermediate');
+  });
+
+  it('keeps the existing desktop three-column layout at 1039px and wider', () => {
+    expect(voiceRoomLayoutBand(1039)).toBe('desktop');
+    expect(voiceRoomLayoutBand(1440)).toBe('desktop');
+  });
+});
+
+describe('intermediate grouped panel tabs', () => {
+  it('defaults the grouped panel to chat', () => {
+    const initialTab: GroupedPanelTab = 'chat';
+    expect(initialTab).toBe('chat');
+  });
+
+  it('shows chat, log, and video unless the video popout is open', () => {
+    expect(groupedPanelTabs(false)).toEqual(['chat', 'log', 'video']);
+    expect(groupedPanelTabs(true)).toEqual(['chat', 'log']);
+  });
+
+  it('auto-switches to video when video activity starts', () => {
+    expect(nextGroupedPanelTab('chat', '', 'alice')).toBe('video');
+    expect(nextGroupedPanelTab('log', '', 'alice')).toBe('video');
+  });
+
+  it('respects a manual chat or log choice while video activity stays unchanged', () => {
+    expect(nextGroupedPanelTab('chat', 'alice', 'alice')).toBe('chat');
+    expect(nextGroupedPanelTab('log', 'alice', 'alice')).toBe('log');
+  });
+
+  it('auto-switches again when the active video set changes', () => {
+    expect(nextGroupedPanelTab('chat', 'alice', 'alice|bob')).toBe('video');
+    expect(nextGroupedPanelTab('log', 'alice|bob', 'bob')).toBe('video');
+  });
+
+  it('returns to chat when video activity ends while the video tab is active', () => {
+    expect(nextGroupedPanelTab('video', 'alice', '')).toBe('chat');
+    expect(nextGroupedPanelTab('log', 'alice', '')).toBe('log');
+  });
+
+  it('moves away from the hidden video tab when the popout opens', () => {
+    expect(groupedPanelTabAfterPopout('video', true)).toBe('chat');
+    expect(groupedPanelTabAfterPopout('log', true)).toBe('log');
+    expect(groupedPanelTabAfterPopout('video', false)).toBe('video');
+  });
+});
 
 /* ─── Quality Indicator Rendering Logic ─────────────────────────── */
 

--- a/clients/wavis-gui/src/styles/theme.css
+++ b/clients/wavis-gui/src/styles/theme.css
@@ -301,6 +301,20 @@
   color: var(--wavis-text);
 }
 
+.wavis-room-intermediate-layout {
+  display: none;
+}
+
+@media (min-width: 768px) and (max-width: 1038px) {
+  .wavis-room-intermediate-layout {
+    display: flex;
+  }
+
+  .wavis-room-intermediate-layout + .hidden.md\:flex {
+    display: none;
+  }
+}
+
 @media (max-width: 600px) {
   .wavis-room-toaster[data-sonner-toaster] {
     width: var(--wavis-room-toast-max-width);

--- a/wavis-backend/src/channel/channel.rs
+++ b/wavis-backend/src/channel/channel.rs
@@ -661,9 +661,12 @@ pub async fn list_bans(
 
     // 2. Query banned members, ordered by banned_at DESC
     let rows = sqlx::query(
-        "SELECT user_id, banned_at FROM channel_memberships \
-         WHERE channel_id = $1 AND banned_at IS NOT NULL \
-         ORDER BY banned_at DESC",
+        "SELECT cm.user_id, cm.banned_at, \
+                COALESCE(u.username, '') AS display_name \
+         FROM channel_memberships cm \
+         LEFT JOIN users u ON u.user_id = cm.user_id \
+         WHERE cm.channel_id = $1 AND cm.banned_at IS NOT NULL \
+         ORDER BY cm.banned_at DESC",
     )
     .bind(channel_id)
     .fetch_all(pool)
@@ -675,6 +678,7 @@ pub async fn list_bans(
         .map(|row| BannedMemberInfo {
             user_id: row.get("user_id"),
             banned_at: row.get("banned_at"),
+            display_name: row.get("display_name"),
         })
         .collect())
 }

--- a/wavis-backend/src/channel/channel_models.rs
+++ b/wavis-backend/src/channel/channel_models.rs
@@ -113,6 +113,7 @@ pub struct RoleChangeResult {
 pub struct BannedMemberInfo {
     pub user_id: Uuid,
     pub banned_at: DateTime<Utc>,
+    pub display_name: String,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/wavis-backend/src/channel/routes.rs
+++ b/wavis-backend/src/channel/routes.rs
@@ -167,6 +167,7 @@ pub struct BanListResponse {
 pub struct BanListItem {
     pub user_id: String,
     pub banned_at: String,
+    pub display_name: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -801,6 +802,7 @@ pub async fn list_bans(
             .map(|b| BanListItem {
                 user_id: b.user_id.to_string(),
                 banned_at: b.banned_at.to_rfc3339(),
+                display_name: b.display_name,
             })
             .collect(),
     }))

--- a/wavis-backend/tests/channel_integration.rs
+++ b/wavis-backend/tests/channel_integration.rs
@@ -1041,6 +1041,42 @@ async fn example_banned_member_cannot_leave() {
     ));
 }
 
+#[tokio::test]
+#[ignore] // requires Postgres
+async fn example_list_bans_includes_display_name() {
+    let pool = test_pool().await;
+    truncate_channel_tables(&pool).await;
+
+    let owner = register_test_user(&pool).await;
+    let member = register_test_user(&pool).await;
+    sqlx::query("UPDATE users SET username = $1 WHERE user_id = $2")
+        .bind("Display Target")
+        .bind(member)
+        .execute(&pool)
+        .await
+        .expect("set username");
+
+    let ch = channel::create_channel(&pool, owner, "banned-display")
+        .await
+        .unwrap();
+    let inv = channel::create_invite(&pool, ch.channel_id, owner, Some(3600), Some(1))
+        .await
+        .unwrap();
+    channel::join_channel_by_invite(&pool, member, &inv.code)
+        .await
+        .unwrap();
+    channel::ban_member(&pool, ch.channel_id, owner, member)
+        .await
+        .unwrap();
+
+    let banned = channel::list_bans(&pool, ch.channel_id, owner)
+        .await
+        .unwrap();
+    assert_eq!(banned.len(), 1);
+    assert_eq!(banned[0].user_id, member);
+    assert_eq!(banned[0].display_name, "Display Target");
+}
+
 // ---------------------------------------------------------------------------
 // Example: expired invite rejected on join
 // ---------------------------------------------------------------------------

--- a/wavis-backend/tests/channel_rest_integration.rs
+++ b/wavis-backend/tests/channel_rest_integration.rs
@@ -2017,6 +2017,12 @@ async fn test_list_bans_owner_gets_200_with_banned_list() {
 
     let owner = register_test_user(&pool).await;
     let member = register_test_user(&pool).await;
+    sqlx::query("UPDATE users SET username = $1 WHERE user_id = $2")
+        .bind("Banned User")
+        .bind(member)
+        .execute(&pool)
+        .await
+        .expect("set username");
     let owner_token = sign_test_token(&owner);
     let member_token = sign_test_token(&member);
     let app = build_channel_router(build_test_app_state(pool));
@@ -2073,6 +2079,7 @@ async fn test_list_bans_owner_gets_200_with_banned_list() {
     let banned = body["banned"].as_array().unwrap();
     assert_eq!(banned.len(), 1);
     assert_eq!(banned[0]["user_id"], member.to_string());
+    assert_eq!(banned[0]["display_name"], "Banned User");
     assert!(banned[0]["banned_at"].as_str().is_some());
 }
 


### PR DESCRIPTION
 ## Summary

  - Show user display names in channel ban lists across backend responses and the GUI.
  - Add an intermediate voice-room layout for 768px-1038px widths, keeping mobile and full desktop layouts
  unchanged.
  - Add diagnostics reporting for main app window size, viewport size, and device pixel ratio.

  ## Details

  - Extends channel ban data with display names and updates channel detail UI rendering.
  - Adds focused backend/channel tests for ban-list display-name behavior.
  - Adds a two-column intermediate voice-room layout with participants on the left and Chat/Log/Video
  grouped into tabs on the right.
  - Keeps the existing desktop layout active at 1039px+ and prevents duplicate layout rendering.
  - Adds ActiveRoom tests for responsive layout bands and grouped tab behavior.
  - Emits app dimensions from the main webview and displays/exports them in diagnostics.