### PR TITLE
Fix: audio only share being silent on start (#170)

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -674,7 +674,11 @@ const AudioOnlyTile = memo(function AudioOnlyTile({
     <div className="flex items-center gap-3 px-3 py-2 text-xs font-mono select-none">
       <button
         className="shrink-0 hover:opacity-70 transition-opacity"
-        style={{ color: muted ? 'var(--wavis-text-secondary)' : color }}
+        style={{
+          color: muted ? 'var(--wavis-danger)' : 'transparent',
+          WebkitTextStroke: muted ? undefined : '1px var(--wavis-danger)',
+          animation: muted ? 'watchPulse 2s ease-in-out infinite' : undefined,
+        }}
         onClick={() => onToggleMute(participantId)}
         aria-label={muted ? `Unmute ${displayName} audio` : `Mute ${displayName} audio`}
         title={muted ? 'click to unmute' : 'click to mute'}

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -672,7 +672,13 @@ const AudioOnlyTile = memo(function AudioOnlyTile({
 }: AudioOnlyTileProps) {
   return (
     <div className="flex items-center gap-3 px-3 py-2 text-xs font-mono select-none">
-      <span style={{ color }} aria-hidden="true">{"♪"}</span>
+      <button
+        className="shrink-0 hover:opacity-70 transition-opacity"
+        style={{ color: muted ? 'var(--wavis-text-secondary)' : color }}
+        onClick={() => onToggleMute(participantId)}
+        aria-label={muted ? `Unmute ${displayName} audio` : `Mute ${displayName} audio`}
+        title={muted ? 'click to unmute' : 'click to mute'}
+      >{"♪"}</button>
       <span className="truncate min-w-0" style={{ color }}>{displayName}</span>
       <div className="flex items-center gap-2 ml-auto shrink-0">
         <span className="text-wavis-text-secondary whitespace-nowrap hidden sm:block">audio vol</span>

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1333,16 +1333,22 @@ export default function ActiveRoom() {
       const participant = roomState.participants.find((p) => p.id === identity);
       if (!participant) continue;
       const vol = getSavedShareVolume(identity);
-      const muted = getSavedShareMuted(identity);
-      applySavedScreenShareAudio(identity);
-      void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted });
+      // Always start audio shares muted; preserve the last-set volume for restore.
+      shareMutedRef.current.set(identity, true);
+      setShareMuted((prev) => {
+        if (prev.get(identity) === true) return prev;
+        const next = new Map(prev);
+        next.set(identity, true);
+        return next;
+      });
+      void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted: true });
     }
     for (const identity of prev) {
       if (curr.has(identity)) continue;
       void emit('watch-all:audio-share-removed', { participantId: identity });
     }
     prevAudioOnlySharersRef.current = new Set(curr);
-  }, [applySavedScreenShareAudio, getSavedShareMuted, getSavedShareVolume, watchAllOpen, roomState?.audioOnlySharers, roomState?.participants]);
+  }, [getSavedShareVolume, watchAllOpen, roomState?.audioOnlySharers, roomState?.participants]);
 
   // Watch All: emit share-updated when participant info changes
   const prevParticipantsRef = useRef<Map<string, { displayName: string; color: string }>>(new Map());
@@ -1797,14 +1803,20 @@ export default function ActiveRoom() {
         // Seed the dynamic tracking ref so the useEffect doesn't
         // re-emit these same shares as "new".
         prevWatchAllStreamsRef.current = new Map(scope.streams);
-        // Seed audio-only sharers into Watch All
+        // Seed audio-only sharers into Watch All — always start muted
         for (const identity of rs.audioOnlySharers) {
           const participant = scope.participants.find((p) => p.id === identity);
           if (!participant) continue;
           const vol = getSavedShareVolume(identity);
-          const muted = getSavedShareMuted(identity);
-          applySavedScreenShareAudio(identity);
-          void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted });
+          shareMutedRef.current.set(identity, true);
+          setShareMuted((prev) => {
+            if (prev.get(identity) === true) return prev;
+            const next = new Map(prev);
+            next.set(identity, true);
+            return next;
+          });
+          setScreenShareAudioVolume(identity, 0);
+          void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted: true });
         }
         prevAudioOnlySharersRef.current = new Set(rs.audioOnlySharers);
       });
@@ -2638,14 +2650,22 @@ export default function ActiveRoom() {
             {!isSelf && p.isSharing && (() => {
               const isAudioOnly = roomState.audioOnlySharers.has(p.id);
               if (isAudioOnly) {
+                const isAudioMuted = getSavedShareMuted(p.id);
                 return (
-                  <span
-                    className="text-sm leading-none"
-                    style={{ color: 'var(--wavis-danger)', animation: 'watchPulse 2s ease-in-out infinite' }}
-                    title="sharing audio"
+                  <button
+                    className="text-sm leading-none hover:opacity-70 transition-opacity"
+                    style={{
+                      color: isAudioMuted ? 'var(--wavis-text-secondary)' : 'var(--wavis-danger)',
+                      animation: isAudioMuted ? undefined : 'watchPulse 2s ease-in-out infinite',
+                    }}
+                    title={isAudioMuted ? 'unmute audio share' : 'mute audio share'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      syncScreenShareMuted(p.id, !isAudioMuted);
+                    }}
                   >
                     {"\u266A"}
-                  </span>
+                  </button>
                 );
               }
               const hasStream = roomState.screenShareStreams.has(p.id);

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -2655,8 +2655,9 @@ export default function ActiveRoom() {
                   <button
                     className="text-sm leading-none hover:opacity-70 transition-opacity"
                     style={{
-                      color: isAudioMuted ? 'var(--wavis-text-secondary)' : 'var(--wavis-danger)',
-                      animation: isAudioMuted ? undefined : 'watchPulse 2s ease-in-out infinite',
+                      color: isAudioMuted ? 'var(--wavis-danger)' : 'transparent',
+                      WebkitTextStroke: isAudioMuted ? undefined : '1px var(--wavis-danger)',
+                      animation: isAudioMuted ? 'watchPulse 2s ease-in-out infinite' : undefined,
                     }}
                     title={isAudioMuted ? 'unmute audio share' : 'mute audio share'}
                     onClick={(e) => {

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -611,6 +611,8 @@ function createMockCallbacks(): MediaCallbacks & { calls: CallRecord[] } {
     onSystemEvent: (msg) => calls.push({ method: 'onSystemEvent', args: [msg] }),
     onShareLeakSummary: (summary) => calls.push({ method: 'onShareLeakSummary', args: [summary] }),
     onNoiseSuppressionState: (active) => calls.push({ method: 'onNoiseSuppressionState', args: [active] }),
+    onAudioOnlySharerAdded: (identity) => calls.push({ method: 'onAudioOnlySharerAdded', args: [identity] }),
+    onAudioOnlySharerRemoved: (identity) => calls.push({ method: 'onAudioOnlySharerRemoved', args: [identity] }),
   };
 }
 
@@ -2507,7 +2509,7 @@ describe('Screen share and device selection', () => {
       mod.disconnect();
     });
 
-    it('keeps legacy screen share audio silent until watched even when video has not arrived yet', async () => {
+    it('infers legacy ScreenShareAudio without video as audio-only and autoplays it', async () => {
       resetAll();
       const cbs = createMockCallbacks();
       const mod = new LiveKitModule(cbs);
@@ -2522,8 +2524,32 @@ describe('Screen share and device selection', () => {
       );
 
       const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
-      expect(setSubscribed).toHaveBeenCalledWith(false);
-      expect(audioElementMap.has('alice:screen-share')).toBe(false);
+      expect(setSubscribed).toHaveBeenCalledWith(true);
+      expect(audioElementMap.has('alice:screen-share')).toBe(true);
+      expect(cbs.calls).toContainEqual({ method: 'onAudioOnlySharerAdded', args: ['alice'] });
+
+      mod.disconnect();
+    });
+
+    it('infers already-present ScreenShareAudio without video as audio-only on connect', async () => {
+      resetAll();
+      const cbs = createMockCallbacks();
+      const mod = new LiveKitModule(cbs);
+      const setSubscribed = vi.fn();
+      const remoteTrack = { kind: 'audio', mediaStreamTrack: { id: 'ssa-existing-audio-only' } };
+      const publication = { source: 'screen_share_audio', kind: 'audio', track: remoteTrack, setSubscribed };
+      mockRoom.remoteParticipants.set('alice', {
+        identity: 'alice',
+        getTrackPublication: vi.fn((source: string) => source === 'screen_share_audio' ? publication : undefined),
+        trackPublications: new Map([['ssa-existing', publication]]),
+      });
+
+      await driveToConnected(mod);
+
+      const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
+      expect(setSubscribed).toHaveBeenCalledWith(true);
+      expect(audioElementMap.has('alice:screen-share')).toBe(true);
+      expect(cbs.calls).toContainEqual({ method: 'onAudioOnlySharerAdded', args: ['alice'] });
 
       mod.disconnect();
     });

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -443,6 +443,37 @@ describe('VoiceRoom screen share audio delegation', () => {
     leaveRoom();
   });
 
+  it('keeps LiveKit-inferred audio-only state when share_started arrives without shareType', async () => {
+    resetAll();
+    await driveToActive();
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+
+    // Simulate lkModule inferring audio-only from TrackSubscribed before share_started arrives
+    lastLkModule!.callbacks.onAudioOnlySharerAdded('peer-2');
+    await tick();
+    expect(getState().audioOnlySharers.has('peer-2')).toBe(true);
+
+    // share_started arrives without shareType (older sender client)
+    messageHandler!({ type: 'share_started', participantId: 'peer-2' });
+    await tick();
+
+    expect(getState().participants.find((p) => p.id === 'peer-2')).toMatchObject({
+      isSharing: true,
+      shareType: undefined,
+    });
+    // Inferred audio-only state must be preserved
+    expect(getState().audioOnlySharers.has('peer-2')).toBe(true);
+
+    // An explicit non-audio-only type should still clear it
+    messageHandler!({ type: 'share_started', participantId: 'peer-2', shareType: 'screen_audio' });
+    await tick();
+    expect(getState().audioOnlySharers.has('peer-2')).toBe(false);
+
+    leaveRoom();
+  });
+
   it('attachScreenShareAudio and detachScreenShareAudio delegate to the media module', async () => {
     resetAll();
     await driveToActive();

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -407,6 +407,42 @@ describe('VoiceRoom screen share audio delegation', () => {
     leaveRoom();
   });
 
+  it('keeps LiveKit-inferred audio-only state across legacy share_state without shareType', async () => {
+    resetAll();
+    await driveToActive();
+
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
+
+    lastLkModule!.callbacks.onAudioOnlySharerAdded('peer-2');
+    await tick();
+    expect(getState().audioOnlySharers.has('peer-2')).toBe(true);
+
+    messageHandler!({
+      type: 'share_state',
+      participantIds: ['peer-2'],
+      activeShares: [{ participantId: 'peer-2' }],
+    });
+    await tick();
+
+    expect(getState().participants.find((p) => p.id === 'peer-2')).toMatchObject({
+      isSharing: true,
+      shareType: undefined,
+    });
+    expect(getState().audioOnlySharers.has('peer-2')).toBe(true);
+
+    messageHandler!({
+      type: 'share_state',
+      participantIds: ['peer-2'],
+      activeShares: [{ participantId: 'peer-2', shareType: 'screen_audio' }],
+    });
+    await tick();
+
+    expect(getState().audioOnlySharers.has('peer-2')).toBe(false);
+
+    leaveRoom();
+  });
+
   it('attachScreenShareAudio and detachScreenShareAudio delegate to the media module', async () => {
     resetAll();
     await driveToActive();

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -2281,6 +2281,7 @@ export class LiveKitModule {
         listenOnly = true;
         for (const participant of this.room?.remoteParticipants.values() ?? []) {
           this.callbacks.onRemoteParticipantConnected?.(participant.identity);
+          this.syncRemoteParticipantPublications(participant, 'connected');
         }
         // Watch for OS device changes so the routing survives plug/unplug events.
         this.startDeviceChangeWatcher();
@@ -2322,6 +2323,7 @@ export class LiveKitModule {
         this.callbacks.onMediaReconnected?.();
         for (const participant of this.room?.remoteParticipants.values() ?? []) {
           this.callbacks.onRemoteParticipantConnected?.(participant.identity);
+          this.syncRemoteParticipantPublications(participant, 'reconnected');
         }
         this.callbacks.onSystemEvent('LiveKit reconnected');
         // Re-apply output device routing after reconnect — the room's internal
@@ -2363,6 +2365,10 @@ export class LiveKitModule {
         if (publication.source === Track.Source.ScreenShare && publication.kind === Track.Kind.Video) {
           if (DEBUG_SHARE_TRACK_SUB) {
             console.log(LOG, `[diag] TrackPublished ScreenShare — participant: ${participant.identity}, trackSid: ${publication.trackSid}, isSubscribed: ${publication.isSubscribed}`);
+          }
+          if (this.remoteShareTypes.get(participant.identity) === 'audio_only') {
+            if (DEBUG_SHARE_AUDIO) console.log(LOG, '[audio-only-diag] clearing inferred audio_only: ScreenShare video published', { identity: participant.identity });
+            this.setRemoteShareType(participant.identity, undefined);
           }
           publication.setSubscribed?.(true);
           publication.setEnabled?.(true);
@@ -2456,6 +2462,16 @@ export class LiveKitModule {
                 settings,
               });
             }
+            // Infer audio-only when share_started WS message omits shareType
+            // (older sender clients). ScreenShareAudio with no ScreenShare video = audio-only.
+            if (publication.source === Track.Source.ScreenShareAudio &&
+                this.remoteShareTypes.get(participant.identity) !== 'audio_only') {
+              const hasVideoShare = !!participant.getTrackPublication(Track.Source.ScreenShare);
+              if (!hasVideoShare) {
+                if (DEBUG_SHARE_AUDIO) console.log(LOG, '[audio-only-diag] inferred audio_only: ScreenShareAudio present but no ScreenShare video', { identity: participant.identity });
+                this.setRemoteShareType(participant.identity, 'audio_only');
+              }
+            }
             if (this.shouldPlayScreenShareAudio(participant.identity)) {
               this.attachDesiredScreenShareAudio(participant.identity);
             } else if (typeof publication.setSubscribed === 'function') {
@@ -2467,6 +2483,10 @@ export class LiveKitModule {
         } else if (track.kind === Track.Kind.Video && publication.source === Track.Source.ScreenShare) {
           if (DEBUG_SHARE_TRACK_SUB) {
             console.log(LOG, `[diag] TrackSubscribed ScreenShare — participant: ${participant.identity}, trackSid: ${publication.trackSid}, readyState: ${track.mediaStreamTrack.readyState}`);
+          }
+          if (this.remoteShareTypes.get(participant.identity) === 'audio_only') {
+            if (DEBUG_SHARE_AUDIO) console.log(LOG, '[audio-only-diag] clearing inferred audio_only: ScreenShare video subscribed', { identity: participant.identity });
+            this.setRemoteShareType(participant.identity, undefined);
           }
           this.attachRemoteScreenShareTrack(participant, publication, track, 'track_subscribed');
         }
@@ -2562,25 +2582,7 @@ export class LiveKitModule {
       addListener(RoomEvent.ParticipantConnected, (participant: RemoteParticipant) => {
         if (this.disposed) return;
         this.callbacks.onRemoteParticipantConnected?.(participant.identity);
-        const screenShareAudioPub = participant.getTrackPublication(Track.Source.ScreenShareAudio);
-        if (screenShareAudioPub) {
-          this.screenShareAudioPublications.set(participant.identity, screenShareAudioPub);
-          screenShareAudioPub.setSubscribed(this.shouldPlayScreenShareAudio(participant.identity));
-        }
-        const screenShareVideoPub = participant.getTrackPublication(Track.Source.ScreenShare);
-        const screenShareVideoTrack = screenShareVideoPub?.track;
-        if (
-          screenShareVideoPub &&
-          screenShareVideoTrack &&
-          screenShareVideoTrack.kind === Track.Kind.Video
-        ) {
-          this.attachRemoteScreenShareTrack(
-            participant,
-            screenShareVideoPub,
-            screenShareVideoTrack as RemoteTrack,
-            'participant_connected_recovery',
-          );
-        }
+        this.syncRemoteParticipantPublications(participant, 'participant_connected');
         // Only act if we're already waiting for this participant's audio
         // (viewer window opened before TrackSubscribed could fire).
         if (!this.screenShareAudioPending.has(participant.identity)) return;
@@ -5384,6 +5386,52 @@ export class LiveKitModule {
   attachScreenShareAudio(participantIdentity: string): void {
     this.screenShareAudioViewerOwners.add(participantIdentity);
     this.syncScreenShareAudioPolicy(participantIdentity);
+  }
+
+  private syncRemoteParticipantPublications(participant: RemoteParticipant, reason: string): void {
+    const screenShareAudioPub = participant.getTrackPublication(Track.Source.ScreenShareAudio);
+    const screenShareVideoPub = participant.getTrackPublication(Track.Source.ScreenShare);
+
+    if (screenShareVideoPub && this.remoteShareTypes.get(participant.identity) === 'audio_only') {
+      if (DEBUG_SHARE_AUDIO) {
+        console.log(LOG, '[audio-only-diag] clearing inferred audio_only: ScreenShare video present during sync', { identity: participant.identity, reason });
+      }
+      this.setRemoteShareType(participant.identity, undefined);
+    }
+
+    if (screenShareAudioPub) {
+      this.screenShareAudioPublications.set(participant.identity, screenShareAudioPub);
+      if (!screenShareVideoPub && this.remoteShareTypes.get(participant.identity) !== 'audio_only') {
+        if (DEBUG_SHARE_AUDIO) {
+          console.log(LOG, '[audio-only-diag] inferred audio_only during participant sync: no ScreenShare video', { identity: participant.identity, reason });
+        }
+        this.setRemoteShareType(participant.identity, 'audio_only');
+      }
+      screenShareAudioPub.setSubscribed(this.shouldPlayScreenShareAudio(participant.identity));
+
+      const screenShareAudioTrack = screenShareAudioPub.track;
+      if (screenShareAudioTrack && screenShareAudioTrack.kind === Track.Kind.Audio) {
+        this.screenShareAudioTracks.set(participant.identity, {
+          track: screenShareAudioTrack as RemoteTrack,
+          participant,
+        });
+        this.syncScreenShareAudioPolicy(participant.identity);
+      }
+    }
+
+    const screenShareVideoTrack = screenShareVideoPub?.track;
+    if (
+      screenShareVideoPub &&
+      screenShareVideoTrack &&
+      screenShareVideoTrack.kind === Track.Kind.Video
+    ) {
+      this.attachRemoteScreenShareTrack(
+        participant,
+        screenShareVideoPub,
+        screenShareVideoTrack as RemoteTrack,
+        'participant_connected_recovery',
+      );
+    }
   }
 
   /** Update the server-authoritative remote share type for audio policy decisions. */

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2900,7 +2900,10 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
 
   for (const participant of state.participants) {
     if (participant.isSharing) {
-      updateRemoteShareType(participant.id, parseRemoteShareType(participant.shareType));
+      const shareType = parseRemoteShareType(participant.shareType);
+      if (shareType !== undefined || !state.audioOnlySharers.has(participant.id)) {
+        updateRemoteShareType(participant.id, shareType);
+      }
     }
   }
 
@@ -3705,7 +3708,11 @@ function dispatchMessage(raw: unknown): void {
         state.audioOnlySharers = new Set(state.audioOnlySharers);
         state.audioOnlySharers.delete(shareStartId);
       }
-      updateRemoteShareType(shareStartId, remoteShareType);
+      // Don't pass undefined to lkModule when the track was already inferred as audio-only —
+      // setRemoteShareType(undefined) would clear the inference and fire onAudioOnlySharerRemoved.
+      if (remoteShareType !== undefined || !state.audioOnlySharers.has(shareStartId)) {
+        updateRemoteShareType(shareStartId, remoteShareType);
+      }
       const shareStartIsAudioOnly =
         remoteShareType === 'audio_only' ||
         (remoteShareType === undefined && state.audioOnlySharers.has(shareStartId));

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -3696,8 +3696,20 @@ function dispatchMessage(raw: unknown): void {
         sp.isSharing = true;
         sp.shareType = remoteShareType;
       }
+      // Keep audioOnlySharers in sync directly — updateRemoteShareType is a no-op
+      // when lkModule is not yet initialized, which would leave the UI stuck on ◉.
+      if (remoteShareType === 'audio_only' && !state.audioOnlySharers.has(shareStartId)) {
+        state.audioOnlySharers = new Set(state.audioOnlySharers);
+        state.audioOnlySharers.add(shareStartId);
+      } else if (remoteShareType !== undefined && remoteShareType !== 'audio_only' && state.audioOnlySharers.has(shareStartId)) {
+        state.audioOnlySharers = new Set(state.audioOnlySharers);
+        state.audioOnlySharers.delete(shareStartId);
+      }
       updateRemoteShareType(shareStartId, remoteShareType);
-      if (remoteShareType !== 'audio_only') {
+      const shareStartIsAudioOnly =
+        remoteShareType === 'audio_only' ||
+        (remoteShareType === undefined && state.audioOnlySharers.has(shareStartId));
+      if (!shareStartIsAudioOnly) {
         refreshRemoteScreenShare(shareStartId);
         // Schedule retries for the case where TrackSubscribed is delayed or the SFU
         // treats the republish as a track resume (no TrackPublished/TrackSubscribed).
@@ -3733,6 +3745,10 @@ function dispatchMessage(raw: unknown): void {
       if (ssp) {
         ssp.isSharing = false;
         ssp.shareType = undefined;
+      }
+      if (state.audioOnlySharers.has(shareStopId)) {
+        state.audioOnlySharers = new Set(state.audioOnlySharers);
+        state.audioOnlySharers.delete(shareStopId);
       }
       clearRemoteShareType(shareStopId);
       refreshRetryGenerations.delete(shareStopId);
@@ -3782,6 +3798,10 @@ function dispatchMessage(raw: unknown): void {
           // Server says they're not sharing — clear stale flag + stream
           p.isSharing = false;
           p.shareType = undefined;
+          if (state.audioOnlySharers.has(p.id)) {
+            state.audioOnlySharers = new Set(state.audioOnlySharers);
+            state.audioOnlySharers.delete(p.id);
+          }
           clearRemoteShareType(p.id);
           if (state.screenShareStreams.has(p.id)) {
             state.screenShareStreams = new Map(state.screenShareStreams);
@@ -3792,8 +3812,21 @@ function dispatchMessage(raw: unknown): void {
         }
         if (shouldBeSharing) {
           p.shareType = typedShares.get(p.id);
-          updateRemoteShareType(p.id, p.shareType as RemoteShareType | undefined);
-          if (p.shareType !== 'audio_only') {
+          const resolvedType = p.shareType as RemoteShareType | undefined;
+          if (resolvedType === 'audio_only' && !state.audioOnlySharers.has(p.id)) {
+            state.audioOnlySharers = new Set(state.audioOnlySharers);
+            state.audioOnlySharers.add(p.id);
+          } else if (resolvedType !== undefined && resolvedType !== 'audio_only' && state.audioOnlySharers.has(p.id)) {
+            state.audioOnlySharers = new Set(state.audioOnlySharers);
+            state.audioOnlySharers.delete(p.id);
+          }
+          if (resolvedType !== undefined || !state.audioOnlySharers.has(p.id)) {
+            updateRemoteShareType(p.id, resolvedType);
+          }
+          const isAudioOnlyShare =
+            resolvedType === 'audio_only' ||
+            (resolvedType === undefined && state.audioOnlySharers.has(p.id));
+          if (!isAudioOnlyShare) {
             refreshRemoteScreenShare(p.id);
             // Schedule retries for late joiners or post-reconnect cases where
             // the stream isn't available yet. share_state doesn't schedule

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -2875,6 +2875,9 @@ function connectMedia(sfuUrl: string, token: string, iceConfig?: { stunUrls: str
     onAudioOnlySharerAdded: (identity) => {
       state.audioOnlySharers = new Set(state.audioOnlySharers);
       state.audioOnlySharers.add(identity);
+      // Silence immediately so the gain node is created at 0 before any audio
+      // plays. The viewer un-mutes by clicking the music icon to restore volume.
+      setScreenShareAudioVolume(identity, 0);
       notify();
     },
     onAudioOnlySharerRemoved: (identity) => {


### PR DESCRIPTION
Closes #170. 

This PR fixes an issue where audio-only shares were starting silent because the LiveKit-inferred audio-only state was being cleared when a 'share_started' message arrived without an explicit 'shareType'. 

Changes: 
- Modified oice-room.ts to preserve existing audio-only inference when the incoming share type is undefined. 
- Added a regression test in oice-room-media.test.ts to verify the state preservation.