### PR TITLE
fix: restore window from tray using keyboard shortcut (#155)

### DIFF
--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -536,6 +536,7 @@ fn main() {
             media::media_close_native_screen_share_viewer,
             media::media_set_screen_share_quality,
             is_window_visible,
+            tray::show_main_window,
             share_sources::list_share_sources,
             share_sources::fetch_source_thumbnail,
             share_sources::share_picker_select,

--- a/clients/wavis-gui/src-tauri/src/tray.rs
+++ b/clients/wavis-gui/src-tauri/src/tray.rs
@@ -90,6 +90,24 @@ pub fn setup_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Show and focus the main window from any state (tray-hidden, minimized, or normal).
+/// Clears the hidden flag and emits `window-visibility-changed` so the frontend
+/// tracks tray state correctly regardless of how the window was restored.
+#[tauri::command]
+pub fn show_main_window(
+    app: tauri::AppHandle,
+    visibility: tauri::State<'_, WindowVisibility>,
+) -> Result<(), String> {
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+    visibility.hidden.store(false, Ordering::SeqCst);
+    let _ = app.emit("window-visibility-changed", WindowVisibilityPayload { visible: true });
+    Ok(())
+}
+
 /// Handle the window close event. If minimize-to-tray is enabled, hide the
 /// window instead of closing it. Returns `true` if the close was intercepted.
 pub fn handle_close_requested(

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1476,13 +1476,10 @@ export default function ActiveRoom() {
   useEffect(() => {
     console.log('[wavis:focus-main] registering focus-main-window listener');
     const unlisten = listen('focus-main-window', async () => {
-      console.log('[wavis:focus-main] event received — calling unminimize + setFocus');
+      console.log('[wavis:focus-main] event received — calling show_main_window');
       try {
-        const win = getCurrentWindow();
-        await win.unminimize();
-        console.log('[wavis:focus-main] unminimize done');
-        await win.setFocus();
-        console.log('[wavis:focus-main] setFocus done');
+        await invoke('show_main_window');
+        console.log('[wavis:focus-main] show_main_window done');
       } catch (e) {
         console.error('[wavis:focus-main] error:', e);
       }
@@ -1965,7 +1962,7 @@ export default function ActiveRoom() {
     getFocusMainHotkey().then((hotkey) => {
       if (cancelled) return;
       focusMainHotkeyRef.current = hotkey;
-      registerFocusMainHotkey(hotkey, () => { console.log('[wavis:focus-main] hotkey fired'); void getCurrentWindow().unminimize().then(() => getCurrentWindow().setFocus()).catch((e) => console.error('[wavis:focus-main] hotkey error:', e)); });
+      registerFocusMainHotkey(hotkey, () => { console.log('[wavis:focus-main] hotkey fired'); void invoke('show_main_window').catch((e) => console.error('[wavis:focus-main] hotkey error:', e)); });
     });
 
     return () => {


### PR DESCRIPTION
This PR fixes issue #155 by introducing a new Tauri command show_main_window that handles showing, unminimizing, and focusing the window, while also correctly updating the app's internal visibility state. This ensures that the global keyboard shortcut can restore the window even when it's hidden in the tray.

Closes #155