### PR TITLE
Fixing being able to hear peers when leaving room

### DIFF
--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -17,7 +17,6 @@ import type { MediaState } from './livekit-media';
 import {
   initSession,
   leaveRoom,
-  scheduleLeaveRoom,
   toggleSelfMute,
   toggleSelfDeafen,
   toggleCameraIntent,
@@ -456,21 +455,11 @@ export default function ActiveRoom() {
       allowNavigationRef.current,
     ));
 
-  const leaveNavigationMode = roomState && (
-    roomState.machineState === 'active'
-    || roomState.machineState === 'reconnecting'
-  ) ? 'deferred' : 'immediate';
-
   const navigateAwayFromRoom = useCallback(
-    (target: string, leaveMode: 'none' | 'immediate' | 'deferred' = 'none') => {
+    (target: string, leaveMode: 'none' | 'immediate' = 'none') => {
       allowNavigationRef.current = true;
-      if (leaveMode === 'deferred') {
-        skipUnmountLeaveRef.current = true;
-        scheduleLeaveRoom();
-      } else {
-        skipUnmountLeaveRef.current = false;
-        if (leaveMode === 'immediate') leaveRoom();
-      }
+      skipUnmountLeaveRef.current = false;
+      if (leaveMode === 'immediate') leaveRoom();
       navigate(target);
     },
     [navigate],
@@ -605,7 +594,7 @@ export default function ActiveRoom() {
           toggleSelfMute();
           break;
         case 'leave':
-          navigateAwayFromRoom('/', leaveNavigationMode);
+          navigateAwayFromRoom('/', 'immediate');
           break;
         case 'show':
           // handled by Rust side (window.show + set_focus)
@@ -613,7 +602,7 @@ export default function ActiveRoom() {
       }
     });
     return cleanup;
-  }, [channelId, leaveNavigationMode, navigateAwayFromRoom]);
+  }, [channelId, navigateAwayFromRoom]);
 
   // Tray state sync: update tray menu items when voice/mute state changes
   useEffect(() => {
@@ -2298,7 +2287,6 @@ export default function ActiveRoom() {
           </div>
           <button
             className="mt-3 text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 hover:bg-wavis-text-secondary hover:text-wavis-text-contrast transition-colors"
-            onClick={() => navigateAwayFromRoom(`/channel/${channelId}`, 'immediate')}
           >
             /back
           </button>
@@ -2316,7 +2304,7 @@ export default function ActiveRoom() {
             <div className="text-wavis-danger mb-4">{roomState.rejectionReason}</div>
             <div className="flex gap-4 justify-center">
               <button className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast" onClick={() => { initRef.current = false; initSession(channelId, channelName, channelRole, setRoomState); initRef.current = true; }}>/retry</button>
-              <button className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast" onClick={() => navigateAwayFromRoom(`/channel/${channelId}`)}>/back</button>
+              <button className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast">/back</button>
             </div>
           </div>
         </div>
@@ -2333,7 +2321,7 @@ export default function ActiveRoom() {
             <div className="text-wavis-danger mb-4">{roomState.error}</div>
             <div className="flex gap-4 justify-center">
               <button className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast" onClick={() => { initRef.current = false; initSession(channelId, channelName, channelRole, setRoomState); initRef.current = true; }}>/retry</button>
-              <button className="text-xs text-wavis-danger border border-wavis-danger py-0.5 px-1 text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg" onClick={() => { void clearLastChannel(); navigateAwayFromRoom('/', leaveNavigationMode); }}>/leave</button>
+              <button className="text-xs text-wavis-danger border border-wavis-danger py-0.5 px-1 text-center transition-colors hover:bg-wavis-danger hover:text-wavis-bg" onClick={() => { void clearLastChannel(); navigateAwayFromRoom('/', 'immediate'); }}>/leave</button>
             </div>
           </div>
         </div>
@@ -2348,7 +2336,6 @@ export default function ActiveRoom() {
         <span>you were kicked from the room</span>
         <button
           className="text-xs text-wavis-text border border-wavis-text-secondary py-0.5 px-1 text-center transition-colors hover:bg-wavis-text-secondary hover:text-wavis-text-contrast"
-          onClick={() => navigateAwayFromRoom('/')}
         >/back</button>
       </div>
     );
@@ -2357,7 +2344,7 @@ export default function ActiveRoom() {
   /* ── Actions ── */
   const handleLeave = () => {
     setLeaving(true);
-    navigateAwayFromRoom('/', leaveNavigationMode);
+    navigateAwayFromRoom('/', 'immediate');
   };
 
   const handleChannelSwitch = async (ch: Channel) => {

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -1434,12 +1434,15 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
       ],
     });
     await tick();
+    messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+    await tick();
     playNotificationSoundCalls = [];
 
     leaveRoom();
 
     expect(playNotificationSoundCalls).toEqual(['leave']);
     expect(sentMessages).toContainEqual({ type: 'leave' });
+    expect(lastLkModule!.disconnectCalls).toBe(1);
   });
 
   it('keeps the room connected until the background leave timeout elapses', async () => {


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
