### PR TITLE
possible fix

### DIFF
--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -3519,6 +3519,10 @@ describe('Screen share quality optimization', () => {
      */
     it('falls back to defaults when first call throws OverconstrainedError, returns true', async () => {
       resetAll();
+      vi.stubGlobal('navigator', {
+        userAgent: 'Mozilla/5.0',
+        mediaDevices: createMockMediaDevices(),
+      });
       const cbs = createMockCallbacks();
       const mod = new LiveKitModule(cbs);
       await driveToConnected(mod);
@@ -3543,9 +3547,12 @@ describe('Screen share quality optimization', () => {
       expect(calls[0][1]).toBeDefined(); // captureOpts
       expect(calls[0][2]).toBeDefined(); // publishOpts
 
-      // Second call: fallback with just `true` (no constraints)
+      // Second call: fallback without video constraints. Native/Rust audio
+      // platforms may still pass audio:false so browser audio stays disabled.
       expect(calls[1][0]).toBe(true);
-      expect(calls[1].length).toBe(1);
+      if (calls[1][1] !== undefined) {
+        expect(calls[1][1]).toEqual({ audio: false });
+      }
 
       // onSystemEvent called with constraint rejection message
       const sysEvents = cbs.calls.filter(c => c.method === 'onSystemEvent');
@@ -3554,6 +3561,7 @@ describe('Screen share quality optimization', () => {
       )).toBe(true);
 
       mod.disconnect();
+      vi.stubGlobal('navigator', { userAgent: '', mediaDevices: createMockMediaDevices() });
     });
 
     it('returns false when both constrained and fallback calls fail', async () => {
@@ -4926,6 +4934,9 @@ let audioShareStartResult: {
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async (cmd: string, args?: unknown) => {
     tauriInvokeCalls.push({ cmd, args });
+    if (cmd === 'get_default_audio_monitor_fast') {
+      return 'alsa_output.test.monitor';
+    }
     if (cmd === 'audio_share_start') {
       return audioShareStartResult;
     }
@@ -5561,11 +5572,10 @@ describe('Preservation: Native Share-Audio Path and Non-Audio Paths', () => {
   /**
    * Validates: Requirements 3.3
    *
-   * Preservation Property 1: For all non-Windows platforms with audio: true,
-   * captureOpts.audio === true is passed to setScreenShareEnabled.
-   * macOS getDisplayMedia audio path unchanged.
+   * Linux share audio must use the Rust PulseAudio path. Browser-managed
+   * getDisplayMedia audio can capture the room output and feed it back.
    */
-  it('non-Windows platforms with audio:true → captureOpts.audio === true (PBT)', async () => {
+  it('Linux startScreenShare with audio:true → browser video-only plus PulseAudio IPC (PBT)', async () => {
     await fc.assert(
       fc.asyncProperty(
         fc.constant('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36'),
@@ -5581,6 +5591,12 @@ describe('Preservation: Native Share-Audio Path and Non-Audio Paths', () => {
 
           const cbs = createMockCallbacks();
           const mod = new LiveKitModule(cbs);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (mod as any).currentCaptureProfile = {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...(mod as any).currentCaptureProfile,
+            audio: true,
+          };
           await driveToConnected(mod);
 
           await mod.startScreenShare();
@@ -5594,9 +5610,12 @@ describe('Preservation: Native Share-Audio Path and Non-Audio Paths', () => {
           const captureOpts = startCalls[0].args[1] as Record<string, unknown>;
           expect(captureOpts.audio).toBe(false);
 
-          // No audio_share_start should be called on non-Windows
+          const monitorCalls = tauriInvokeCalls.filter(c => c.cmd === 'get_default_audio_monitor_fast');
+          expect(monitorCalls).toHaveLength(1);
+
           const audioStartCalls = tauriInvokeCalls.filter(c => c.cmd === 'audio_share_start');
-          expect(audioStartCalls).toHaveLength(0);
+          expect(audioStartCalls).toHaveLength(1);
+          expect(audioStartCalls[0].args).toEqual({ sourceId: 'alsa_output.test.monitor' });
 
           mod.disconnect();
           vi.stubGlobal('navigator', { userAgent: '', mediaDevices: createMockMediaDevices() });

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -366,9 +366,14 @@ function isLinux(): boolean {
   return /Linux/i.test(navigator.userAgent) && !/Android/i.test(navigator.userAgent);
 }
 
-/** Windows and macOS use the native Rust PCM bridge for screen-share audio. */
+/** Windows and macOS use the JS AudioWorklet bridge for native screen-share audio. */
 function usesNativeScreenShareAudio(): boolean {
   return isWindows() || isMac();
+}
+
+/** Linux captures share audio via the Rust PulseAudio/LiveKit pipeline. */
+function usesRustScreenShareAudio(): boolean {
+  return isLinux();
 }
 
 function isInactiveVideoLeakCandidate(transceiver: RTCRtpTransceiver): boolean {
@@ -3152,6 +3157,7 @@ export class LiveKitModule {
     const pubOpts = await this.prepareScreenSharePublishOptions();
     const profile = this.currentCaptureProfile;
     const nativeShareAudio = usesNativeScreenShareAudio();
+    const rustShareAudio = usesRustScreenShareAudio();
     if (DEBUG_WASAPI) console.log(LOG, '[wasapi-diag] startScreenShare: nativeShareAudio=%s profile.audio=%s userAgent=%s',
       nativeShareAudio, profile.audio, navigator.userAgent.slice(0, 60));
 
@@ -3164,9 +3170,9 @@ export class LiveKitModule {
       contentHint: profile.contentHint,
       surfaceSwitching: profile.surfaceSwitching,
       selfBrowserSurface: profile.selfBrowserSurface,
-      // Windows and macOS capture system audio via the native Rust bridge, so
-      // getDisplayMedia stays video-only and audio can be toggled independently.
-      audio: nativeShareAudio ? false : profile.audio,
+      // Windows/macOS and Linux capture system audio outside getDisplayMedia,
+      // so browser capture stays video-only and audio can be isolated.
+      audio: nativeShareAudio || rustShareAudio ? false : profile.audio,
       suppressLocalAudioPlayback: profile.suppressLocalAudioPlayback,
     };
 
@@ -3199,6 +3205,9 @@ export class LiveKitModule {
         await this.startWasapiScreenShareAudio();
         this.suppressLocalScreenShareAudio();
       }
+      if (rustShareAudio && profile.audio) {
+        await this.startLinuxScreenShareAudio();
+      }
       // Initialize adaptive quality state
       this.adaptiveState = {
         currentTier: 'full',
@@ -3225,9 +3234,12 @@ export class LiveKitModule {
         console.warn(LOG, 'capture constraints rejected, falling back to defaults:', err.message);
         this.callbacks.onSystemEvent('capture constraints rejected — using browser defaults');
         try {
+          const fallbackCaptureOpts = nativeShareAudio || rustShareAudio
+            ? { audio: false }
+            : undefined;
           this.stopAllInactiveVideoTransceivers();
           this.noteShareLeakPublishStart();
-          await this.room.localParticipant.setScreenShareEnabled(true);
+          await this.room.localParticipant.setScreenShareEnabled(true, fallbackCaptureOpts);
           this.captureShareLeakPublishDiagnostics();
           if (this.nativeCaptureLeakSession) {
             this.nativeCaptureLeakSession.activeRaw = await this.captureRawShareLeakMemorySnapshot();
@@ -3239,6 +3251,9 @@ export class LiveKitModule {
           if (nativeShareAudio && profile.audio) {
             await this.startWasapiScreenShareAudio();
             this.suppressLocalScreenShareAudio();
+          }
+          if (rustShareAudio && profile.audio) {
+            await this.startLinuxScreenShareAudio();
           }
           // Initialize adaptive quality state for fallback path too
           this.adaptiveState = {
@@ -3443,6 +3458,9 @@ export class LiveKitModule {
     this.clearScreenShareRuntimeState();
     if (usesNativeScreenShareAudio()) {
       await this.stopWasapiScreenShareAudio();
+    }
+    if (usesRustScreenShareAudio()) {
+      await this.stopLinuxScreenShareAudio();
     }
     await this.room.localParticipant.setScreenShareEnabled(false);
   }
@@ -3661,7 +3679,7 @@ export class LiveKitModule {
       contentHint: profile.contentHint,
       surfaceSwitching: profile.surfaceSwitching,
       selfBrowserSurface: profile.selfBrowserSurface,
-      audio: usesNativeScreenShareAudio() ? false : withAudio,
+      audio: usesNativeScreenShareAudio() || usesRustScreenShareAudio() ? false : withAudio,
       suppressLocalAudioPlayback: profile.suppressLocalAudioPlayback,
     };
 
@@ -3727,7 +3745,7 @@ export class LiveKitModule {
       contentHint: profile.contentHint,
       surfaceSwitching: profile.surfaceSwitching,
       selfBrowserSurface: profile.selfBrowserSurface,
-      audio: usesNativeScreenShareAudio() ? false : profile.audio,
+      audio: usesNativeScreenShareAudio() || usesRustScreenShareAudio() ? false : profile.audio,
       suppressLocalAudioPlayback: profile.suppressLocalAudioPlayback,
     };
 
@@ -5085,6 +5103,35 @@ export class LiveKitModule {
       await this.stopWasapiScreenShareAudio().catch(() => {});
       console.warn(LOG, '[wasapi] startWasapiScreenShareAudio FAILED:', err instanceof Error ? err.message : String(err), err);
       throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  /**
+   * Start Linux screen-share audio through the Rust PulseAudio pipeline.
+   *
+   * Unlike Windows/macOS, Linux publishes the ScreenShareAudio track from the
+   * Rust LiveKit connection, so the JS AudioWorklet bridge is not involved.
+   */
+  private async startLinuxScreenShareAudio(): Promise<void> {
+    try {
+      const sourceId = await invoke<string>('get_default_audio_monitor_fast');
+      const result = await invoke<AudioShareStartResult>('audio_share_start', { sourceId });
+      emitAudioCaptureSelectionTelemetry(result);
+      console.log(LOG, 'linux screen share audio started');
+    } catch (err) {
+      await this.stopLinuxScreenShareAudio().catch(() => {});
+      console.warn(LOG, '[linux-share-audio] start failed:', err instanceof Error ? err.message : String(err), err);
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+  }
+
+  /** Stop Linux screen-share audio capture. Idempotent on the Rust side. */
+  private async stopLinuxScreenShareAudio(): Promise<void> {
+    try {
+      await invoke('audio_share_stop');
+      if (DEBUG_SHARE_AUDIO) console.log(LOG, '[linux-share-audio] audio_share_stop invoked');
+    } catch (e) {
+      if (DEBUG_SHARE_AUDIO) console.warn(LOG, '[linux-share-audio] audio_share_stop failed (best-effort):', e);
     }
   }
 


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
