### PR TITLE
feat: show window on tray click and expand tray menu

### DIFF
--- a/clients/wavis-gui/src-tauri/src/tray.rs
+++ b/clients/wavis-gui/src-tauri/src/tray.rs
@@ -5,8 +5,8 @@ use std::sync::{
 
 use serde::{Deserialize, Serialize};
 use tauri::{
-    menu::{Menu, MenuItem},
-    tray::TrayIconBuilder,
+    menu::{IsMenuItem, Menu, MenuItem, PredefinedMenuItem},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     App, Emitter, Listener, Manager,
 };
 
@@ -28,6 +28,21 @@ pub struct WindowVisibility {
 #[derive(Deserialize)]
 struct MinimizeToTrayPayload {
     enabled: bool,
+}
+
+#[derive(Deserialize)]
+struct TrayStatePayload {
+    #[serde(rename = "inVoiceSession")]
+    in_voice_session: bool,
+    #[serde(rename = "isMuted")]
+    is_muted: bool,
+    #[serde(rename = "isDeafened")]
+    is_deafened: bool,
+}
+
+#[derive(Clone, Serialize)]
+struct TrayEventPayload {
+    action: &'static str,
 }
 
 #[derive(Clone, Serialize)]
@@ -58,14 +73,33 @@ pub fn setup_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {
 
     // ── Tray menu ──
     let show = MenuItem::with_id(app, "show", "Show Wavis", true, None::<&str>)?;
-    let mute = MenuItem::with_id(app, "mute", "Toggle Mute", true, None::<&str>)?;
+    let mute = MenuItem::with_id(app, "mute", "Mute", false, None::<&str>)?;
+    let deafen = MenuItem::with_id(app, "deafen", "Deafen", false, None::<&str>)?;
+    let leave = MenuItem::with_id(app, "leave", "Leave Room", false, None::<&str>)?;
+    let separator = PredefinedMenuItem::separator(app)?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
 
-    let menu = Menu::with_items(app, &[&show, &mute, &quit])?;
+    let menu_items: [&dyn IsMenuItem<_>; 6] = [&show, &separator, &mute, &deafen, &leave, &quit];
+    let menu = Menu::with_items(app, &menu_items)?;
 
-    let _tray = TrayIconBuilder::new()
+    let mute_state_item = mute.clone();
+    let deafen_state_item = deafen.clone();
+    let leave_state_item = leave.clone();
+    app.listen("tray-state-update", move |event| {
+        if let Ok(payload) = serde_json::from_str::<TrayStatePayload>(event.payload()) {
+            let _ = mute_state_item.set_text(if payload.is_muted { "Unmute" } else { "Mute" });
+            let _ = deafen_state_item
+                .set_text(if payload.is_deafened { "Undeafen" } else { "Deafen" });
+            let _ = mute_state_item.set_enabled(payload.in_voice_session);
+            let _ = deafen_state_item.set_enabled(payload.in_voice_session);
+            let _ = leave_state_item.set_enabled(payload.in_voice_session);
+        }
+    });
+
+    let mut builder = TrayIconBuilder::new()
         .menu(&menu)
         .show_menu_on_left_click(false)
+        .icon_as_template(true)
         .on_menu_event(move |app, event| match event.id.as_ref() {
             "show" => {
                 if let Some(window) = app.get_webview_window("main") {
@@ -83,9 +117,57 @@ pub fn setup_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {
             "quit" => {
                 app.exit(0);
             }
+            "mute" => {
+                let _ = app.emit(
+                    "tray-event",
+                    TrayEventPayload {
+                        action: "toggle-mute",
+                    },
+                );
+            }
+            "deafen" => {
+                let _ = app.emit(
+                    "tray-event",
+                    TrayEventPayload {
+                        action: "toggle-deafen",
+                    },
+                );
+            }
+            "leave" => {
+                let _ = app.emit("tray-event", TrayEventPayload { action: "leave" });
+            }
             _ => {}
-        })
-        .build(app)?;
+        });
+
+    if let Some(icon) = app.default_window_icon() {
+        builder = builder.icon(icon.clone());
+    }
+
+    let _tray = builder.build(app)?;
+
+    // Global handler — fires for every tray icon event with no per-icon ID
+    // matching, making it reliable across all Tauri runtime versions.
+    app.on_tray_icon_event(|app, event| {
+        if let TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        } = event
+        {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+            if let Some(vis) = app.try_state::<WindowVisibility>() {
+                vis.hidden.store(false, Ordering::SeqCst);
+            }
+            let _ = app.emit(
+                "window-visibility-changed",
+                WindowVisibilityPayload { visible: true },
+            );
+        }
+    });
 
     Ok(())
 }

--- a/clients/wavis-gui/src-tauri/tauri.conf.json
+++ b/clients/wavis-gui/src-tauri/tauri.conf.json
@@ -21,10 +21,6 @@
         "decorations": false
       }
     ],
-    "trayIcon": {
-      "iconPath": "icons/icon.png",
-      "iconAsTemplate": true
-    },
     "security": {
       "csp": null
     },

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -593,6 +593,9 @@ export default function ActiveRoom() {
         case 'toggle-mute':
           toggleSelfMute();
           break;
+        case 'toggle-deafen':
+          toggleSelfDeafen();
+          break;
         case 'leave':
           navigateAwayFromRoom('/', 'immediate');
           break;
@@ -612,13 +615,14 @@ export default function ActiveRoom() {
     updateTrayState({
       inVoiceSession: inVoice,
       isMuted: selfP?.isMuted ?? false,
+      isDeafened: roomState.isDeafened,
     });
-  }, [roomState?.machineState, roomState?.participants, roomState?.selfParticipantId]);
+  }, [roomState?.machineState, roomState?.participants, roomState?.selfParticipantId, roomState?.isDeafened]);
 
   // Send "not in voice" on unmount so tray items get disabled
   useEffect(() => {
     return () => {
-      updateTrayState({ inVoiceSession: false, isMuted: false });
+      updateTrayState({ inVoiceSession: false, isMuted: false, isDeafened: false });
     };
   }, []);
 
@@ -3014,6 +3018,13 @@ export default function ActiveRoom() {
               style={{ color: isVideoOrFallbackSharing ? 'var(--wavis-danger)' : 'var(--wavis-text-secondary)' }}
               title={isVideoOrFallbackSharing ? '/stopshare' : '/share'}
             ><span className="inline-flex w-3 h-3 items-center justify-center leading-none">◉</span></button>
+            <span className="text-wavis-text-secondary opacity-30 select-none leading-none">│</span>
+            <button
+              onClick={() => navigateAwayFromRoom('/', 'immediate')}
+              className="px-1.5 h-5 flex items-center justify-center hover:opacity-70 transition-opacity"
+              style={{ color: 'var(--wavis-danger)' }}
+              title="/leave"
+            ><span className="inline-flex w-3 h-3 items-center justify-center leading-none">x</span></button>
           </div>
         )}
       </div>
@@ -3023,6 +3034,7 @@ export default function ActiveRoom() {
             <div className="flex flex-col md:flex-row gap-1">
               <button onClick={toggleSelfMute} disabled={selfP?.isHostMuted} title={selfP?.isMuted ? `/unmute (${hotkeys.mute})` : `/mute (${hotkeys.mute})`} className={`flex-1 py-0.5 px-1 text-xs text-center transition-colors border disabled:opacity-40 disabled:cursor-not-allowed ${selfP?.isMuted ? 'border-wavis-danger text-wavis-danger bg-wavis-danger/8 hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>{selfP?.isMuted ? '/unmute' : '/mute'}</button>
               <button onClick={toggleSelfDeafen} className={`flex-1 py-0.5 px-1 text-xs text-center transition-colors border ${roomState.isDeafened ? 'border-wavis-purple text-wavis-purple hover:bg-wavis-purple hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>{roomState.isDeafened ? '/undeafen' : '/deafen'}</button>
+              <button onClick={() => navigateAwayFromRoom('/', 'immediate')} className="flex-1 py-0.5 px-1 text-xs text-center transition-colors border border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-wavis-bg">/leave</button>
             </div>
             {showCameraButton && (
               <button

--- a/clients/wavis-gui/src/features/voice/__tests__/quick-actions-no-video.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/quick-actions-no-video.test.ts
@@ -8,20 +8,20 @@
 
 import { describe, it, expect } from 'vitest';
 import type { TrayAction } from '../tray-bridge';
-import { computeTrayMenuState, muteMenuLabel } from '../tray-bridge';
+import { computeTrayMenuState, deafenMenuLabel, muteMenuLabel } from '../tray-bridge';
 
 /* ─── TrayAction exhaustive check ─────────────────────────────────── */
 
 describe('Feature: video-feed — Quick_Actions has no video controls (Req 4.5, 4.6, 8.1–8.4)', () => {
-  const PRE_VIDEO_FEED_ACTIONS: readonly TrayAction[] = ['toggle-mute', 'leave', 'show'];
+  const PRE_VIDEO_FEED_ACTIONS: readonly TrayAction[] = ['toggle-mute', 'toggle-deafen', 'leave', 'show'];
 
   it('TrayAction set is exactly the pre-video-feed set', () => {
-    const actions: TrayAction[] = ['toggle-mute', 'leave', 'show'];
+    const actions: TrayAction[] = ['toggle-mute', 'toggle-deafen', 'leave', 'show'];
     expect(new Set(actions)).toEqual(new Set(PRE_VIDEO_FEED_ACTIONS));
   });
 
   it('contains no video-toggle action', () => {
-    const actions: string[] = ['toggle-mute', 'leave', 'show'];
+    const actions: string[] = ['toggle-mute', 'toggle-deafen', 'leave', 'show'];
     const videoRelated = actions.filter(
       (a) =>
         a.includes('video') ||
@@ -34,7 +34,7 @@ describe('Feature: video-feed — Quick_Actions has no video controls (Req 4.5, 
   });
 
   it('computeTrayMenuState exposes no video-related fields', () => {
-    const state = computeTrayMenuState({ inVoiceSession: true, isMuted: false });
+    const state = computeTrayMenuState({ inVoiceSession: true, isMuted: false, isDeafened: false });
     const keys = Object.keys(state);
     const videoRelated = keys.filter(
       (k) => k.toLowerCase().includes('video') || k.toLowerCase().includes('camera'),
@@ -42,13 +42,15 @@ describe('Feature: video-feed — Quick_Actions has no video controls (Req 4.5, 
     expect(videoRelated).toEqual([]);
   });
 
-  it('pre-video-feed controls (mute + leave) are preserved with same labels', () => {
+  it('pre-video-feed controls are preserved with same labels', () => {
     expect(muteMenuLabel(false)).toBe('Mute');
     expect(muteMenuLabel(true)).toBe('Unmute');
+    expect(deafenMenuLabel(false)).toBe('Deafen');
+    expect(deafenMenuLabel(true)).toBe('Undeafen');
   });
 
-  it('tray menu state has exactly muteEnabled and leaveEnabled', () => {
-    const state = computeTrayMenuState({ inVoiceSession: true, isMuted: false });
-    expect(Object.keys(state).sort()).toEqual(['leaveEnabled', 'muteEnabled']);
+  it('tray menu state has exactly muteEnabled, deafenEnabled, and leaveEnabled', () => {
+    const state = computeTrayMenuState({ inVoiceSession: true, isMuted: false, isDeafened: false });
+    expect(Object.keys(state).sort()).toEqual(['deafenEnabled', 'leaveEnabled', 'muteEnabled']);
   });
 });

--- a/clients/wavis-gui/src/features/voice/__tests__/tray-bridge.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/tray-bridge.test.ts
@@ -19,7 +19,7 @@ vi.mock('@tauri-apps/api/event', () => ({
 
 /* ─── Import after mock ─────────────────────────────────────────── */
 
-import { computeTrayMenuState, muteMenuLabel } from '../tray-bridge';
+import { computeTrayMenuState, deafenMenuLabel, muteMenuLabel, shouldHideOnClose } from '../tray-bridge';
 import type { TrayStateUpdate } from '../tray-bridge';
 
 /* ─── Arbitraries ───────────────────────────────────────────────── */
@@ -27,6 +27,7 @@ import type { TrayStateUpdate } from '../tray-bridge';
 const arbTrayStateUpdate: fc.Arbitrary<TrayStateUpdate> = fc.record({
   inVoiceSession: fc.boolean(),
   isMuted: fc.boolean(),
+  isDeafened: fc.boolean(),
 });
 
 /* ═══ Property 12: Tray menu items disabled when no voice session ══ */
@@ -34,13 +35,14 @@ const arbTrayStateUpdate: fc.Arbitrary<TrayStateUpdate> = fc.record({
 // **Validates: Requirements 1.3**
 
 describe('Property 12: Tray menu items disabled when no voice session', () => {
-  it('when inVoiceSession is false, mute and leave are disabled', () => {
+  it('when inVoiceSession is false, mute, deafen, and leave are disabled', () => {
     fc.assert(
       fc.property(
         arbTrayStateUpdate.filter((u) => !u.inVoiceSession),
         (update) => {
           const state = computeTrayMenuState(update);
           expect(state.muteEnabled).toBe(false);
+          expect(state.deafenEnabled).toBe(false);
           expect(state.leaveEnabled).toBe(false);
         },
       ),
@@ -48,13 +50,14 @@ describe('Property 12: Tray menu items disabled when no voice session', () => {
     );
   });
 
-  it('when inVoiceSession is true, mute and leave are enabled', () => {
+  it('when inVoiceSession is true, mute, deafen, and leave are enabled', () => {
     fc.assert(
       fc.property(
         arbTrayStateUpdate.filter((u) => u.inVoiceSession),
         (update) => {
           const state = computeTrayMenuState(update);
           expect(state.muteEnabled).toBe(true);
+          expect(state.deafenEnabled).toBe(true);
           expect(state.leaveEnabled).toBe(true);
         },
       ),
@@ -62,11 +65,12 @@ describe('Property 12: Tray menu items disabled when no voice session', () => {
     );
   });
 
-  it('muteEnabled and leaveEnabled always equal inVoiceSession', () => {
+  it('muteEnabled, deafenEnabled, and leaveEnabled always equal inVoiceSession', () => {
     fc.assert(
       fc.property(arbTrayStateUpdate, (update) => {
         const state = computeTrayMenuState(update);
         expect(state.muteEnabled).toBe(update.inVoiceSession);
+        expect(state.deafenEnabled).toBe(update.inVoiceSession);
         expect(state.leaveEnabled).toBe(update.inVoiceSession);
       }),
       { numRuns: 100 },
@@ -116,7 +120,21 @@ describe('Property 13: Mute label reflects mute state', () => {
 // Feature: gui-feature-completion, Property 7
 // **Validates: Requirements 18.1, 18.2**
 
-import { shouldHideOnClose } from '../tray-bridge';
+describe('Deafen label reflects deafen state', () => {
+  it('for any boolean isDeafened, label is "Undeafen" iff deafened, "Deafen" iff not', () => {
+    fc.assert(
+      fc.property(fc.boolean(), (isDeafened) => {
+        const label = deafenMenuLabel(isDeafened);
+        if (isDeafened) {
+          expect(label).toBe('Undeafen');
+        } else {
+          expect(label).toBe('Deafen');
+        }
+      }),
+      { numRuns: 100 },
+    );
+  });
+});
 
 describe('Property 7: Close behavior follows minimize-to-tray setting', () => {
   it('window is hidden on close iff minimizeToTray is true', () => {

--- a/clients/wavis-gui/src/features/voice/tray-bridge.ts
+++ b/clients/wavis-gui/src/features/voice/tray-bridge.ts
@@ -13,23 +13,26 @@ import { emit, listen } from '@tauri-apps/api/event';
 // ─── Types ─────────────────────────────────────────────────────────
 
 /** Actions the Rust tray menu can send to the frontend. */
-export type TrayAction = 'toggle-mute' | 'leave' | 'show';
+export type TrayAction = 'toggle-mute' | 'toggle-deafen' | 'leave' | 'show';
 
 /** State the frontend sends to Rust to update tray menu items. */
 export interface TrayStateUpdate {
   inVoiceSession: boolean;
   isMuted: boolean;
+  isDeafened: boolean;
 }
 
 /** Enable/disable state for tray menu items. */
 export interface TrayMenuState {
   muteEnabled: boolean;
+  deafenEnabled: boolean;
   leaveEnabled: boolean;
 }
 
 // ─── Constants ─────────────────────────────────────────────────────
 
 const LOG = '[wavis:tray]';
+const DEBUG_TRAY = import.meta.env.VITE_DEBUG_TRAY === 'true';
 const TRAY_EVENT = 'tray-event';
 const TRAY_STATE_UPDATE_EVENT = 'tray-state-update';
 
@@ -42,6 +45,7 @@ const TRAY_STATE_UPDATE_EVENT = 'tray-state-update';
 export function computeTrayMenuState(update: TrayStateUpdate): TrayMenuState {
   return {
     muteEnabled: update.inVoiceSession,
+    deafenEnabled: update.inVoiceSession,
     leaveEnabled: update.inVoiceSession,
   };
 }
@@ -52,6 +56,14 @@ export function computeTrayMenuState(update: TrayStateUpdate): TrayMenuState {
  */
 export function muteMenuLabel(isMuted: boolean): string {
   return isMuted ? 'Unmute' : 'Mute';
+}
+
+/**
+ * Return the label for the deafen menu item based on current deafen state.
+ * "Undeafen" when deafened, "Deafen" when not deafened.
+ */
+export function deafenMenuLabel(isDeafened: boolean): string {
+  return isDeafened ? 'Undeafen' : 'Deafen';
 }
 
 /**
@@ -72,7 +84,7 @@ export function listenTrayEvents(handler: (action: TrayAction) => void): () => v
   let unlisten: (() => void) | null = null;
 
   listen<{ action: TrayAction }>(TRAY_EVENT, (event) => {
-    console.log(LOG, 'received tray action:', event.payload.action);
+    if (DEBUG_TRAY) console.log(LOG, 'received tray action:', event.payload.action);
     handler(event.payload.action);
   })
     .then((fn) => {


### PR DESCRIPTION
Closes #206. This PR implements window restoration (show/unminimize/focus) on tray icon left-click and expands the tray menu with Mute, Deafen, and Leave Room controls synced with the app state.