### PR TITLE
fixed

### DIFF
--- a/clients/wavis-gui/src/features/auth/__tests__/auth-helpers.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/auth-helpers.test.ts
@@ -70,7 +70,7 @@ vi.mock('@tauri-apps/plugin-http', () => ({
   }),
 }));
 
-describe('recovery ID keychain helpers', () => {
+describe('recovery ID storage helpers', () => {
   beforeEach(() => {
     mockStore = {};
     mockKeychain = {};
@@ -84,9 +84,11 @@ describe('recovery ID keychain helpers', () => {
     const auth = await import('../auth');
 
     await auth.storeRecoveryId('wvs-ABCD-1234');
+    expect(mockStore['recovery_id']).toBe('wvs-ABCD-1234');
     expect(await auth.getStoredRecoveryId()).toBe('wvs-ABCD-1234');
 
     await auth.deleteStoredRecoveryId();
+    expect(mockStore['recovery_id']).toBeUndefined();
     expect(await auth.getStoredRecoveryId()).toBeNull();
   });
 
@@ -104,11 +106,7 @@ describe('recovery ID keychain helpers', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(mockKeychain['wavis_recovery_id']).toBe('wvs-TRIM-0001');
-    expect(invoke).toHaveBeenCalledWith('store_token', {
-      key: 'wavis_recovery_id',
-      value: 'wvs-TRIM-0001',
-    });
+    expect(mockStore['recovery_id']).toBe('wvs-TRIM-0001');
     expect(fetchBodies).toMatchObject([
       { recovery_id: 'wvs-TRIM-0001', phrase: 'passphrase' },
     ]);
@@ -117,7 +115,7 @@ describe('recovery ID keychain helpers', () => {
 
   it('recoverAccount can skip storing the recovery ID', async () => {
     mockFetchMode = 'recover_ok';
-    mockKeychain = { wavis_recovery_id: 'wvs-OLD-0001' };
+    mockStore = { recovery_id: 'wvs-OLD-0001' };
     const auth = await import('../auth');
 
     const result = await auth.recoverAccount(
@@ -131,7 +129,7 @@ describe('recovery ID keychain helpers', () => {
     );
 
     expect(result.success).toBe(true);
-    expect(mockKeychain['wavis_recovery_id']).toBeUndefined();
+    expect(mockStore['recovery_id']).toBeUndefined();
   });
 
   it('registerUser stores the response recovery ID after success', async () => {
@@ -147,7 +145,7 @@ describe('recovery ID keychain helpers', () => {
     );
 
     expect(result).toEqual({ success: true, recovery_id: 'wvs-REG-0001' });
-    expect(mockKeychain['wavis_recovery_id']).toBe('wvs-REG-0001');
+    expect(mockStore['recovery_id']).toBe('wvs-REG-0001');
   });
 
   it('resetAuth deletes the stored recovery ID', async () => {
@@ -157,17 +155,17 @@ describe('recovery ID keychain helpers', () => {
       access_token: 'token',
       access_token_exp: Date.now() + 60_000,
       username: 'user',
+      recovery_id: 'wvs-OLD-0001',
     };
     mockKeychain = {
       wavis_refresh_token: 'refresh-token',
-      wavis_recovery_id: 'wvs-OLD-0001',
     };
     const auth = await import('../auth');
 
     await auth.resetAuth();
 
     expect(mockKeychain['wavis_refresh_token']).toBeUndefined();
-    expect(mockKeychain['wavis_recovery_id']).toBeUndefined();
-    expect(invoke).toHaveBeenCalledWith('delete_token', { key: 'wavis_recovery_id' });
+    expect(mockStore['recovery_id']).toBeUndefined();
+    expect(invoke).toHaveBeenCalledWith('delete_token', { key: 'wavis_refresh_token' });
   });
 });

--- a/clients/wavis-gui/src/features/auth/auth.ts
+++ b/clients/wavis-gui/src/features/auth/auth.ts
@@ -202,15 +202,18 @@ export async function getRefreshToken(): Promise<string | null> {
 }
 
 export async function storeRecoveryId(id: string): Promise<void> {
-  await invoke('store_token', { key: 'wavis_recovery_id', value: id });
+  const store = await getStore();
+  await store.set('recovery_id', id);
 }
 
 export async function getStoredRecoveryId(): Promise<string | null> {
-  return invoke<string | null>('get_token', { key: 'wavis_recovery_id' });
+  const store = await getStore();
+  return (await store.get<string>('recovery_id')) ?? null;
 }
 
 export async function deleteStoredRecoveryId(): Promise<void> {
-  await invoke('delete_token', { key: 'wavis_recovery_id' });
+  const store = await getStore();
+  await store.delete('recovery_id');
 }
 
 export async function setInsecureTls(value: boolean): Promise<void> {
@@ -297,7 +300,7 @@ export async function registerUser(
   onLog(makeLogEntry('Device registered: ' + body.device_id, 'success'));
 
   await storeRecoveryId(body.recovery_id);
-  onLog(makeLogEntry('Recovery ID stored in keychain', 'info'));
+  onLog(makeLogEntry('Recovery ID stored locally', 'info'));
 
   notifyTokenRefreshedCallbacks();
   return { success: true, recovery_id: body.recovery_id };
@@ -385,7 +388,7 @@ export async function recoverAccount(
 
   if (rememberRecoveryId) {
     await storeRecoveryId(trimmedRecoveryId);
-    onLog(makeLogEntry('Recovery ID stored in keychain', 'info'));
+    onLog(makeLogEntry('Recovery ID stored locally', 'info'));
   } else {
     await deleteStoredRecoveryId();
     onLog(makeLogEntry('Recovery ID not stored on this device', 'info'));
@@ -807,6 +810,6 @@ export async function resetAuth(): Promise<void> {
   try {
     await deleteStoredRecoveryId();
   } catch (err) {
-    console.error(LOG_PREFIX, 'Failed to delete recovery ID from keychain:', err);
+    console.error(LOG_PREFIX, 'Failed to delete recovery ID from local store:', err);
   }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
