### PR TITLE
fix: resolve reconnect failure and improve room leave logic (#192)

### DIFF
--- a/clients/wavis-gui/src-tauri/Cargo.toml
+++ b/clients/wavis-gui/src-tauri/Cargo.toml
@@ -147,6 +147,7 @@ windows = { version = "0.58", features = [
     "Win32_System_WinRT_Direct3D11",
     "Win32_System_WinRT_Graphics_Capture",
     "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_Shell",
     "Win32_System_Threading",
     "Win32_Media_Audio",
     "Win32_System_Com",

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -21,6 +21,8 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod audio_capture;
+#[cfg(target_os = "windows")]
+mod taskbar_toolbar;
 #[cfg(target_os = "linux")]
 mod external_share_helper;
 #[cfg(not(target_os = "linux"))]
@@ -449,6 +451,11 @@ fn main() {
 
                 if let Err(err) = tray::setup_tray(app) {
                     eprintln!("wavis: tray unavailable: {err}");
+                }
+
+                #[cfg(target_os = "windows")]
+                if let Err(err) = taskbar_toolbar::setup_taskbar_toolbar(app) {
+                    log::warn!("wavis: taskbar toolbar unavailable: {err}");
                 }
             }
 

--- a/clients/wavis-gui/src-tauri/src/taskbar_toolbar.rs
+++ b/clients/wavis-gui/src-tauri/src/taskbar_toolbar.rs
@@ -1,0 +1,154 @@
+//! Windows thumbnail toolbar — mute / deafen / leave buttons shown in the
+//! taskbar preview when the app is minimized.
+//!
+//! Buttons are currently hidden (ThumbBarAddButtons not called) until custom
+//! icons are ready. The window subclass and state listener are kept so wiring
+//! up buttons later requires only adding ThumbBarAddButtons + apply_button_state.
+//!
+//! Reuses `tray-event` and `tray-state-update` events — no frontend changes needed.
+
+#![cfg(target_os = "windows")]
+
+use std::sync::{
+    atomic::{AtomicIsize, Ordering},
+    Mutex,
+};
+
+use serde::Deserialize;
+use tauri::{App, Emitter, Listener, Manager};
+use windows::Win32::{
+    Foundation::{HWND, LPARAM, LRESULT, WPARAM},
+    UI::WindowsAndMessaging::{
+        CallWindowProcW, PostMessageW, SetWindowLongPtrW, GWLP_WNDPROC, WNDPROC, WM_COMMAND,
+    },
+};
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const BTN_MUTE: u32 = 201;
+const BTN_DEAFEN: u32 = 202;
+const BTN_LEAVE: u32 = 203;
+
+// WM_APP + 1 — reserved for future button-state refresh messages.
+const WM_TASKBAR_UPDATE: u32 = 0x8001;
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Default)]
+struct TaskbarVoiceState {
+    in_voice_session: bool,
+    is_muted: bool,
+    is_deafened: bool,
+}
+
+struct TaskbarGlobal {
+    hwnd_raw: isize,
+    app_handle: tauri::AppHandle,
+    state: TaskbarVoiceState,
+}
+
+static PREV_WNDPROC: AtomicIsize = AtomicIsize::new(0);
+static GLOBAL: Mutex<Option<TaskbarGlobal>> = Mutex::new(None);
+
+// ── Window subclass ────────────────────────────────────────────────────────
+
+#[derive(Clone, serde::Serialize)]
+struct TrayEventPayload {
+    action: &'static str,
+}
+
+unsafe extern "system" fn wndproc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+    match msg {
+        WM_COMMAND => {
+            let id = (wparam.0 & 0xFFFF) as u32;
+            let action: Option<&'static str> = match id {
+                BTN_MUTE => Some("toggle-mute"),
+                BTN_DEAFEN => Some("toggle-deafen"),
+                BTN_LEAVE => Some("leave"),
+                _ => None,
+            };
+            if let Some(action) = action {
+                if let Ok(guard) = GLOBAL.lock() {
+                    if let Some(g) = guard.as_ref() {
+                        let _ = g.app_handle.emit("tray-event", TrayEventPayload { action });
+                    }
+                }
+                return LRESULT(0);
+            }
+        }
+        // Reserved for future button-state updates via PostMessageW.
+        WM_TASKBAR_UPDATE => return LRESULT(0),
+        _ => {}
+    }
+    let prev: WNDPROC = std::mem::transmute(PREV_WNDPROC.load(Ordering::SeqCst));
+    CallWindowProcW(prev, hwnd, msg, wparam, lparam)
+}
+
+// ── Payload (mirrors tray.rs) ──────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct TrayStatePayload {
+    #[serde(rename = "inVoiceSession")]
+    in_voice_session: bool,
+    #[serde(rename = "isMuted")]
+    is_muted: bool,
+    #[serde(rename = "isDeafened")]
+    is_deafened: bool,
+}
+
+// ── Public setup ───────────────────────────────────────────────────────────
+
+pub fn setup_taskbar_toolbar(app: &App) -> Result<(), Box<dyn std::error::Error>> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or("taskbar_toolbar: main window not found")?;
+
+    let raw = window
+        .hwnd()
+        .map_err(|e| format!("taskbar_toolbar: hwnd: {e}"))?;
+    let hwnd = HWND(raw.0);
+
+    *GLOBAL.lock().unwrap() = Some(TaskbarGlobal {
+        hwnd_raw: hwnd.0 as isize,
+        app_handle: app.handle().clone(),
+        state: TaskbarVoiceState::default(),
+    });
+
+    unsafe {
+        let prev = SetWindowLongPtrW(hwnd, GWLP_WNDPROC, wndproc as *const () as isize);
+        if prev == 0 {
+            log::warn!("taskbar_toolbar: SetWindowLongPtrW returned 0");
+        }
+        PREV_WNDPROC.store(prev, Ordering::SeqCst);
+
+        // ThumbBarAddButtons not called — buttons hidden until custom icons are ready.
+    }
+
+    // Track voice state so button state is correct the moment icons are wired up.
+    app.listen("tray-state-update", |event| {
+        let Ok(payload) = serde_json::from_str::<TrayStatePayload>(event.payload()) else {
+            return;
+        };
+        let new_state = TaskbarVoiceState {
+            in_voice_session: payload.in_voice_session,
+            is_muted: payload.is_muted,
+            is_deafened: payload.is_deafened,
+        };
+        let hwnd_raw = {
+            let Ok(mut guard) = GLOBAL.lock() else { return };
+            let Some(g) = guard.as_mut() else { return };
+            g.state = new_state;
+            g.hwnd_raw
+        };
+        unsafe {
+            let _ = PostMessageW(
+                HWND(hwnd_raw as *mut _),
+                WM_TASKBAR_UPDATE,
+                WPARAM(0),
+                LPARAM(0),
+            );
+        }
+    });
+
+    Ok(())
+}

--- a/clients/wavis-gui/src/features/channels/InitialRedirect.tsx
+++ b/clients/wavis-gui/src/features/channels/InitialRedirect.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
 import { clearLastChannel, getLastChannel } from '@features/settings/settings-store';
 import ChannelsList from './ChannelsList';
 import { fetchChannels, type Channel } from './channels';
@@ -22,9 +22,17 @@ export function resolveInitialRedirect(
  */
 export default function InitialRedirect() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [showChannelsList, setShowChannelsList] = useState(false);
 
   useEffect(() => {
+    // If we arrived here after an explicit room leave, skip the auto-redirect to
+    // /room — the user intentionally left and should see the channels list.
+    if ((location.state as Record<string, unknown> | null)?.skipAutoRedirect) {
+      setShowChannelsList(true);
+      return;
+    }
+
     let cancelled = false;
     (async () => {
       const lastChannel = await getLastChannel();
@@ -59,7 +67,7 @@ export default function InitialRedirect() {
     return () => {
       cancelled = true;
     };
-  }, [navigate]);
+  }, [navigate, location.state]);
 
   if (!showChannelsList) return null;
   return <ChannelsList />;

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -458,9 +458,12 @@ export default function ActiveRoom() {
   const navigateAwayFromRoom = useCallback(
     (target: string, leaveMode: 'none' | 'immediate' = 'none') => {
       allowNavigationRef.current = true;
+      // skipUnmountLeaveRef stays false so the unmount cleanup calls leaveRoom().
+      // We do NOT call leaveRoom() here: calling it before navigate() causes
+      // notify() to re-render ActiveRoom in idle state before the route changes,
+      // making the lower leave button flash on screen for one frame.
       skipUnmountLeaveRef.current = false;
-      if (leaveMode === 'immediate') leaveRoom();
-      navigate(target);
+      navigate(target, leaveMode === 'immediate' ? { state: { skipAutoRedirect: true } } : undefined);
     },
     [navigate],
   );
@@ -3018,13 +3021,6 @@ export default function ActiveRoom() {
               style={{ color: isVideoOrFallbackSharing ? 'var(--wavis-danger)' : 'var(--wavis-text-secondary)' }}
               title={isVideoOrFallbackSharing ? '/stopshare' : '/share'}
             ><span className="inline-flex w-3 h-3 items-center justify-center leading-none">◉</span></button>
-            <span className="text-wavis-text-secondary opacity-30 select-none leading-none">│</span>
-            <button
-              onClick={() => navigateAwayFromRoom('/', 'immediate')}
-              className="px-1.5 h-5 flex items-center justify-center hover:opacity-70 transition-opacity"
-              style={{ color: 'var(--wavis-danger)' }}
-              title="/leave"
-            ><span className="inline-flex w-3 h-3 items-center justify-center leading-none">x</span></button>
           </div>
         )}
       </div>
@@ -3034,7 +3030,6 @@ export default function ActiveRoom() {
             <div className="flex flex-col md:flex-row gap-1">
               <button onClick={toggleSelfMute} disabled={selfP?.isHostMuted} title={selfP?.isMuted ? `/unmute (${hotkeys.mute})` : `/mute (${hotkeys.mute})`} className={`flex-1 py-0.5 px-1 text-xs text-center transition-colors border disabled:opacity-40 disabled:cursor-not-allowed ${selfP?.isMuted ? 'border-wavis-danger text-wavis-danger bg-wavis-danger/8 hover:bg-wavis-danger hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>{selfP?.isMuted ? '/unmute' : '/mute'}</button>
               <button onClick={toggleSelfDeafen} className={`flex-1 py-0.5 px-1 text-xs text-center transition-colors border ${roomState.isDeafened ? 'border-wavis-purple text-wavis-purple hover:bg-wavis-purple hover:text-wavis-bg' : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'}`}>{roomState.isDeafened ? '/undeafen' : '/deafen'}</button>
-              <button onClick={() => navigateAwayFromRoom('/', 'immediate')} className="flex-1 py-0.5 px-1 text-xs text-center transition-colors border border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-wavis-bg">/leave</button>
             </div>
             {showCameraButton && (
               <button

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -3381,12 +3381,16 @@ export class LiveKitModule {
     if (leakSession && leakSession.stopRequestedAtMs === null) {
       leakSession.stopRequestedAtMs = Date.now();
       leakSession.activeRaw = await this.captureRawShareLeakMemorySnapshot();
+      // Guard against concurrent disconnect() nulling this.room while awaiting above.
+      if (this.disposed || !this.room) return;
       leakSession.summary.browserWebRtcBeforeStop = this.captureBrowserWebRtcSnapshot(expectedTrackId);
       this.markNativeCaptureLeakStage('share_stop_requested');
     }
 
     if (options.stopNativeAudio && usesNativeScreenShareAudio()) {
       await this.stopWasapiScreenShareAudio();
+      // Guard against concurrent disconnect() nulling this.room while awaiting above.
+      if (this.disposed || !this.room) return;
     }
 
     let disableFailed = false;
@@ -3439,7 +3443,7 @@ export class LiveKitModule {
     } finally {
       if (leakSession) {
         leakSession.summary.cleanupFlags.publicationCleared =
-          this.room.localParticipant.getTrackPublication(Track.Source.ScreenShare) === undefined;
+          this.room?.localParticipant?.getTrackPublication(Track.Source.ScreenShare) === undefined;
       }
       if (mediaTrack) {
         try {
@@ -3482,6 +3486,8 @@ export class LiveKitModule {
     if (usesRustScreenShareAudio()) {
       await this.stopLinuxScreenShareAudio();
     }
+    // Guard: disconnect() may have run while awaiting audio teardown above.
+    if (this.disposed || !this.room) return;
     await this.room.localParticipant.setScreenShareEnabled(false);
   }
 

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1159,6 +1159,7 @@ export function buildStartShareMessage(mode: ShareMode): { type: string; shareTy
 
 let client: SignalingClient | null = null;
 let unsubscribe: (() => void) | null = null;
+let unsubStatusChange: (() => void) | null = null;
 let onChange: ((state: VoiceRoomState) => void) | null = null;
 let channelRole: ChannelRole | null = null;
 let sessionUsername: string | null = null;
@@ -4124,7 +4125,7 @@ export function initSession(
   unsubscribe = client.onMessage(dispatchMessage);
 
   // Detect disconnection during active session for reconnection flow
-  client.onStatusChange((status) => {
+  unsubStatusChange = client.onStatusChange((status) => {
     if (status === 'disconnected') {
       stopColdStartRetry();
       if (state.machineState === 'active' || state.machineState === 'joining') {
@@ -4262,6 +4263,13 @@ export function leaveRoom(): void {
   }
   authRefreshRetries = 0;
   wasReconnecting = false;
+
+  // Unregister status-change handler before disconnecting so the intentional
+  // disconnect does not trigger the reconnect/error logic in that handler.
+  if (unsubStatusChange) {
+    unsubStatusChange();
+    unsubStatusChange = null;
+  }
 
   // Disconnect the client
   if (client) {


### PR DESCRIPTION
This PR addresses the issue where users could not reconnect to a room after leaving (#192).\n\n### Changes\n- **Fix Reconnect Logic**: Unregister WebSocket status change handlers before disconnecting during an intentional leave to prevent unwanted reconnection attempts.\n- **Improve Stability**: Added null checks in LiveKitModule to prevent crashes when accessing localParticipant after the room has been disposed.\n- **Refine UX**: Updated InitialRedirect to skip auto-redirecting to the last room if the user explicitly chose to leave.\n- **Feature**: Added initial support for Windows Taskbar Toolbars for better room control integration.\n\nCloses #192