### PR TITLE
fixed audio only share

### DIFF
--- a/clients/wavis-gui/src-tauri/src/audio_capture/platform/linux.rs
+++ b/clients/wavis-gui/src-tauri/src/audio_capture/platform/linux.rs
@@ -1322,13 +1322,14 @@ fn wait_for_pa_source(source_id: &str, timeout: std::time::Duration) -> bool {
 /// pulled in automatically by `pipewire-pulse`.
 #[cfg(target_os = "linux")]
 fn ensure_pactl_available() -> Result<(), String> {
-    match std::process::Command::new("pactl").arg("--version").output() {
+    match std::process::Command::new("pactl")
+        .arg("--version")
+        .output()
+    {
         Ok(o) if o.status.success() => Ok(()),
-        _ => Err(
-            "system audio sharing requires `pactl` — install it with: \
+        _ => Err("system audio sharing requires `pactl` — install it with: \
              sudo apt install pulseaudio-utils"
-                .to_string(),
-        ),
+            .to_string()),
     }
 }
 
@@ -1539,9 +1540,7 @@ fn audio_capture_loop(
             ) {
                 Ok(s) => {
                     if attempt > 1 {
-                        log::info!(
-                            "[audio_capture] pa_simple open succeeded on attempt {attempt}"
-                        );
+                        log::info!("[audio_capture] pa_simple open succeeded on attempt {attempt}");
                     }
                     opened = Some(s);
                     break;

--- a/clients/wavis-gui/src-tauri/src/audio_capture/platform/macos.rs
+++ b/clients/wavis-gui/src-tauri/src/audio_capture/platform/macos.rs
@@ -24,8 +24,7 @@ use super::super::audio_capture_state::{
 use super::macos_routing::{
     bare_sck_fallback_result, plan_virtual_device_teardown, select_default_path,
     select_macos_audio_share_decision, MacAudioShareDecision, MacosAudioCapturePath,
-    VirtualDeviceTeardownAction, VirtualDeviceTeardownSnapshot,
-    VirtualDeviceTeardownTrigger,
+    VirtualDeviceTeardownAction, VirtualDeviceTeardownSnapshot, VirtualDeviceTeardownTrigger,
 };
 use super::macos_virtual_device::{
     cleanup_stale_multi_output_devices, create_multi_output_device, destroy_multi_output_device,
@@ -824,7 +823,6 @@ fn sck_process_audio_buffer(
         }
     }
 }
-
 
 // ── enumerate_wavis_pids ──────────────────────────────────────────────────
 
@@ -1934,7 +1932,11 @@ fn audio_share_start_macos(
         );
     }
 
-    let selected_path = select_default_path(version, tap_result.is_some(), virtual_device_result.is_some());
+    let selected_path = select_default_path(
+        version,
+        tap_result.is_some(),
+        virtual_device_result.is_some(),
+    );
     let (decision, selected_result) =
         select_macos_audio_share_decision(tap_result, virtual_device_result);
     match decision {

--- a/clients/wavis-gui/src-tauri/src/bin/native_share_viewer.rs
+++ b/clients/wavis-gui/src-tauri/src/bin/native_share_viewer.rs
@@ -5,11 +5,11 @@ fn main() {
 }
 
 #[cfg(target_os = "linux")]
+use std::cell::RefCell;
+#[cfg(target_os = "linux")]
 use std::io::{Read, Write};
 #[cfg(target_os = "linux")]
 use std::net::TcpStream;
-#[cfg(target_os = "linux")]
-use std::cell::RefCell;
 #[cfg(target_os = "linux")]
 use std::rc::Rc;
 #[cfg(target_os = "linux")]
@@ -31,7 +31,9 @@ fn main() {
         eprintln!("native_share_viewer: missing stream URL");
         std::process::exit(2);
     };
-    let title = args.next().unwrap_or_else(|| "Wavis screen share".to_string());
+    let title = args
+        .next()
+        .unwrap_or_else(|| "Wavis screen share".to_string());
 
     gtk::init().expect("native_share_viewer: GTK init failed");
 
@@ -236,7 +238,9 @@ fn read_raw_frame(stream: &mut TcpStream, buffer: &mut Vec<u8>) -> Result<Viewer
 
     let expected_len = width as usize * height as usize * 4;
     if width == 0 || height == 0 || len != expected_len || len > 100_000_000 {
-        return Err(format!("invalid raw frame header: {width}x{height} len={len}"));
+        return Err(format!(
+            "invalid raw frame header: {width}x{height} len={len}"
+        ));
     }
 
     while buffer.len() < len {

--- a/clients/wavis-gui/src-tauri/src/bin/pw_capture_helper.rs
+++ b/clients/wavis-gui/src-tauri/src/bin/pw_capture_helper.rs
@@ -570,6 +570,14 @@ fn process_frame(
         return;
     }
 
+    if data_ref.chunk.is_null() {
+        if frame_num <= 3 {
+            eprintln!("pw_capture_helper: frame #{frame_num}: null chunk, skipping");
+        }
+        unsafe { stream.queue_raw_buffer(buffer_ptr) };
+        return;
+    }
+
     let chunk = unsafe { &*data_ref.chunk };
     let chunk_size = chunk.size as usize;
     let stride = chunk.stride as usize;

--- a/clients/wavis-gui/src-tauri/src/crash_handler.rs
+++ b/clients/wavis-gui/src-tauri/src/crash_handler.rs
@@ -8,12 +8,12 @@
 //! itself be in a broken state at crash time, so stderr is the only safe
 //! output channel.
 
-use std::panic;
-use std::fs;
-use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::{SystemTime, UNIX_EPOCH};
 use crate::bug_report::SharedLogBuffer;
+use std::fs;
+use std::panic;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Guards against the hook firing twice for one crash (WebView2 background-thread
 /// panic causes a second panic on the main event-loop thread ~1s later).
@@ -46,9 +46,10 @@ pub fn install(log_buffer: SharedLogBuffer) {
             "Unknown panic message".to_string()
         };
 
-        let location = panic_info.location().map(|loc| {
-            format!("{}:{}:{}", loc.file(), loc.line(), loc.column())
-        }).unwrap_or_else(|| "Unknown location".to_string());
+        let location = panic_info
+            .location()
+            .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
+            .unwrap_or_else(|| "Unknown location".to_string());
 
         let backtrace = std::backtrace::Backtrace::force_capture();
         let timestamp = SystemTime::now()
@@ -72,7 +73,9 @@ pub fn install(log_buffer: SharedLogBuffer) {
         if let Ok(buffer) = log_buffer.lock() {
             let lines = buffer.snapshot();
             if lines.is_empty() {
-                report.push_str("(no log records captured — crash occurred before any voice/room activity)\n");
+                report.push_str(
+                    "(no log records captured — crash occurred before any voice/room activity)\n",
+                );
             } else {
                 for line in lines {
                     report.push_str(&line);

--- a/clients/wavis-gui/src-tauri/src/debug_env.rs
+++ b/clients/wavis-gui/src-tauri/src/debug_env.rs
@@ -19,7 +19,6 @@ pub fn diagnostics_window_enabled() -> bool {
     env_flag("WAVIS_DIAGNOSTICS_WINDOW")
 }
 
-
 pub fn debug_share_audio_enabled() -> bool {
     env_flag("WAVIS_DEBUG_SHARE_AUDIO")
 }

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -583,6 +583,7 @@ fn main() {
             share_sources::fetch_source_thumbnail,
             share_sources::share_picker_select,
             share_sources::share_picker_cancel,
+            share_sources::share_picker_use_portal,
             portal_auth::authorize_screen_capture,
             portal_auth::get_capture_auth_status,
             screen_recording_auth::ensure_screen_recording_access,

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -2090,9 +2090,9 @@ pub fn screen_share_start_source(
             WindowsSourceKind::Screen => GdiCaptureTarget::Monitor(
                 windows::Win32::Graphics::Gdi::HMONITOR(handle_val as *mut _),
             ),
-            WindowsSourceKind::Window => GdiCaptureTarget::Window(
-                windows::Win32::Foundation::HWND(handle_val as *mut _),
-            ),
+            WindowsSourceKind::Window => {
+                GdiCaptureTarget::Window(windows::Win32::Foundation::HWND(handle_val as *mut _))
+            }
         };
         Box::new(
             GdiCapture::start(GdiCaptureConfig {
@@ -2840,8 +2840,14 @@ mod windows_capture_routing_tests {
 
     #[test]
     fn source_kind_routes_without_handle_probing() {
-        assert_eq!(parse_windows_source_kind(Some("screen")).unwrap(), WindowsSourceKind::Screen);
-        assert_eq!(parse_windows_source_kind(Some("window")).unwrap(), WindowsSourceKind::Window);
+        assert_eq!(
+            parse_windows_source_kind(Some("screen")).unwrap(),
+            WindowsSourceKind::Screen
+        );
+        assert_eq!(
+            parse_windows_source_kind(Some("window")).unwrap(),
+            WindowsSourceKind::Window
+        );
         assert!(parse_windows_source_kind(None).is_err());
     }
 

--- a/clients/wavis-gui/src-tauri/src/screen_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture.rs
@@ -7,12 +7,12 @@
 #[cfg(target_os = "linux")]
 pub mod codec_detect;
 pub mod frame_processor;
+#[cfg(target_os = "windows")]
+pub mod gdi_capture;
 #[cfg(target_os = "linux")]
 pub mod pipewire_capture;
 #[cfg(target_os = "linux")]
 pub mod source_capture;
-#[cfg(target_os = "windows")]
-pub mod gdi_capture;
 #[cfg(target_os = "windows")]
 pub mod win_capture;
 #[cfg(target_os = "linux")]

--- a/clients/wavis-gui/src-tauri/src/screen_capture/gdi_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture/gdi_capture.rs
@@ -22,8 +22,8 @@ use windows::Win32::Graphics::Gdi::{
 };
 use windows::Win32::Storage::Xps::{PrintWindow, PRINT_WINDOW_FLAGS, PW_CLIENTONLY};
 use windows::Win32::UI::WindowsAndMessaging::{
-    CURSOR_SHOWING, CURSORINFO, DI_NORMAL, DrawIconEx, GetClientRect, GetCursorInfo, GetIconInfo,
-    HICON, ICONINFO, IsIconic, PW_RENDERFULLCONTENT,
+    DrawIconEx, GetClientRect, GetCursorInfo, GetIconInfo, IsIconic, CURSORINFO, CURSOR_SHOWING,
+    DI_NORMAL, HICON, ICONINFO, PW_RENDERFULLCONTENT,
 };
 
 /// Windows handle newtypes do not auto-derive Send. These handles are safe to
@@ -34,8 +34,8 @@ enum SendCaptureTarget {
 }
 unsafe impl Send for SendCaptureTarget {}
 
-use super::{CaptureError, CapturedFrame, ScreenCapture};
 use super::win_capture::SharedWindowsCaptureDiagnostics;
+use super::{CaptureError, CapturedFrame, ScreenCapture};
 
 const LOG: &str = "[wavis:gdi-capture]";
 
@@ -92,7 +92,12 @@ unsafe fn alloc_gdi_resources(w: u32, h: u32) -> Option<GdiResources> {
         let _ = DeleteDC(mem_dc);
         return None;
     }
-    Some(GdiResources { mem_dc, bitmap, width: w, height: h })
+    Some(GdiResources {
+        mem_dc,
+        bitmap,
+        width: w,
+        height: h,
+    })
 }
 
 unsafe fn free_gdi_resources(r: GdiResources) {
@@ -258,7 +263,11 @@ fn capture_loop(
 
             // Reallocate if dimensions changed (e.g. window resize).
             if w != resources.width || h != resources.height {
-                log::info!("{LOG} window resized to {}x{}, reallocating GDI resources", w, h);
+                log::info!(
+                    "{LOG} window resized to {}x{}, reallocating GDI resources",
+                    w,
+                    h
+                );
                 let old = mem::replace(&mut resources, {
                     match alloc_gdi_resources(w, h) {
                         Some(r) => r,
@@ -382,11 +391,15 @@ fn capture_loop(
 
             let non_zero = data.iter().filter(|&&b| b != 0).count();
             if frame_count == 0 {
-                log::info!("{LOG} first frame: {}x{}, non_zero_bytes={}", w, h, non_zero);
+                log::info!(
+                    "{LOG} first frame: {}x{}, non_zero_bytes={}",
+                    w,
+                    h,
+                    non_zero
+                );
                 if let Ok(mut diag) = diagnostics.lock() {
                     diag.usable_frames = 1;
-                    diag.first_raw_frame_latency_ms =
-                        Some(started_at.elapsed().as_millis() as u64);
+                    diag.first_raw_frame_latency_ms = Some(started_at.elapsed().as_millis() as u64);
                     diag.startup_stage = "gdi_first_raw_frame".to_string();
                 }
             } else if frame_count.is_multiple_of(300) {
@@ -400,14 +413,26 @@ fn capture_loop(
             // DPI: PrintWindow uses the window's DPI context; GetClientRect returns physical
             // pixels on a per-monitor-V2-aware process (Tauri default). No scaling needed —
             // CapturedFrame dimensions match feed_video_frame and JPEG encode expectations.
-            crate::debug_eprintln!("{} frame #{} {}x{} non_zero={}", LOG, frame_count, w, h, non_zero);
+            crate::debug_eprintln!(
+                "{} frame #{} {}x{} non_zero={}",
+                LOG,
+                frame_count,
+                w,
+                h,
+                non_zero
+            );
 
             let timestamp_ms = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_millis() as u64;
 
-            let captured = CapturedFrame { width: w, height: h, data, timestamp_ms };
+            let captured = CapturedFrame {
+                width: w,
+                height: h,
+                data,
+                timestamp_ms,
+            };
 
             if let Ok(guard) = frame_callback.lock() {
                 if let Some(ref cb) = *guard {
@@ -537,13 +562,21 @@ mod tests {
     #[test]
     fn window_offset_and_hotspot() {
         // Window origin (100,200), cursor at (150,250), hotspot (5,3)
-        assert_eq!(compute_cursor_draw_pos((100, 200), (150, 250), (5, 3)), (45, 47));
+        assert_eq!(
+            compute_cursor_draw_pos((100, 200), (150, 250), (5, 3)),
+            (45, 47)
+        );
     }
 
     #[test]
     fn monitor_rect_preserves_virtual_desktop_offset() {
         assert_eq!(
-            monitor_rect_dimensions(RECT { left: -1920, top: 0, right: 0, bottom: 1080 }),
+            monitor_rect_dimensions(RECT {
+                left: -1920,
+                top: 0,
+                right: 0,
+                bottom: 1080
+            }),
             Some((-1920, 0, 1920, 1080)),
         );
     }
@@ -551,7 +584,12 @@ mod tests {
     #[test]
     fn monitor_rect_rejects_empty_dimensions() {
         assert_eq!(
-            monitor_rect_dimensions(RECT { left: 10, top: 20, right: 10, bottom: 20 }),
+            monitor_rect_dimensions(RECT {
+                left: 10,
+                top: 20,
+                right: 10,
+                bottom: 20
+            }),
             None,
         );
     }

--- a/clients/wavis-gui/src-tauri/src/screen_capture/win_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture/win_capture.rs
@@ -849,7 +849,10 @@ impl WinCapture {
         log::info!("{LOG} capture stopped");
         if let Ok(diag) = diagnostics.lock() {
             if diag.usable_frames == 0 {
-                log::warn!("{LOG} WGC stopped before first frame; {}", diag.compact_summary());
+                log::warn!(
+                    "{LOG} WGC stopped before first frame; {}",
+                    diag.compact_summary()
+                );
             }
         };
     }
@@ -922,9 +925,24 @@ mod tests {
 
     #[test]
     fn staging_texture_is_reused_only_for_matching_dimensions_and_format() {
-        assert!(staging_texture_matches(Some((1920, 1080, 87)), 1920, 1080, 87));
-        assert!(!staging_texture_matches(Some((1920, 1080, 87)), 1280, 720, 87));
-        assert!(!staging_texture_matches(Some((1920, 1080, 87)), 1920, 1080, 28));
+        assert!(staging_texture_matches(
+            Some((1920, 1080, 87)),
+            1920,
+            1080,
+            87
+        ));
+        assert!(!staging_texture_matches(
+            Some((1920, 1080, 87)),
+            1280,
+            720,
+            87
+        ));
+        assert!(!staging_texture_matches(
+            Some((1920, 1080, 87)),
+            1920,
+            1080,
+            28
+        ));
         assert!(!staging_texture_matches(None, 1920, 1080, 87));
     }
 

--- a/clients/wavis-gui/src-tauri/src/share_sources.rs
+++ b/clients/wavis-gui/src-tauri/src/share_sources.rs
@@ -178,6 +178,15 @@ pub fn share_picker_cancel(app: tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| format!("failed to emit share-picker:cancelled: {e}"))
 }
 
+/// Relay a request to use the native portal/system picker to the main window.
+#[tauri::command]
+pub fn share_picker_use_portal(app: tauri::AppHandle) -> Result<(), String> {
+    use tauri::Emitter;
+
+    app.emit_to("main", "share-picker:use-portal", ())
+        .map_err(|e| format!("failed to emit share-picker:use-portal: {e}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/clients/wavis-gui/src-tauri/src/share_sources/capture/pipewire.rs
+++ b/clients/wavis-gui/src-tauri/src/share_sources/capture/pipewire.rs
@@ -228,6 +228,15 @@ fn enumerate_pipewire_inner() -> Result<Vec<ShareSource>, String> {
 /// Timeout for PulseAudio enumeration to avoid hanging on an unresponsive daemon.
 const PA_ENUM_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2000);
 
+fn is_wayland_session() -> bool {
+    std::env::var("WAYLAND_DISPLAY")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+        || std::env::var("XDG_SESSION_TYPE")
+            .map(|value| value.eq_ignore_ascii_case("wayland"))
+            .unwrap_or(false)
+}
+
 /// Enumerate PulseAudio monitor sources using the threaded mainloop pattern.
 fn enumerate_pulseaudio_sources() -> Result<Vec<ShareSource>, String> {
     use std::sync::mpsc;
@@ -255,6 +264,34 @@ fn enumerate_pulseaudio_sources() -> Result<Vec<ShareSource>, String> {
             Err("PulseAudio unavailable: enumeration thread panicked".to_string())
         }
     }
+}
+
+/// Fallback source enumeration through pactl. This mirrors the audio capture
+/// start path and avoids PulseAudio threaded-mainloop flakiness on PipeWire.
+fn enumerate_default_pactl_audio_source() -> Result<ShareSource, String> {
+    let output = std::process::Command::new("pactl")
+        .arg("info")
+        .output()
+        .map_err(|e| format!("pactl failed: {e}"))?;
+
+    if !output.status.success() {
+        return Err("pactl returned error".to_string());
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(sink_name) = line.strip_prefix("Default Sink: ") {
+            return Ok(ShareSource {
+                id: format!("{}.monitor", sink_name.trim()),
+                name: "System Audio".to_string(),
+                source_type: ShareSourceType::SystemAudio,
+                thumbnail: None,
+                app_name: None,
+            });
+        }
+    }
+
+    Err("no default sink in pactl output".to_string())
 }
 
 /// Inner PulseAudio enumeration logic. Must run on a dedicated thread.
@@ -365,18 +402,19 @@ fn enumerate_pulseaudio_inner() -> Result<Vec<ShareSource>, String> {
 pub(super) async fn list_sources() -> Result<EnumerationResult, String> {
     let mut warnings = Vec::new();
 
-    let video_sources = match enumerate_pipewire_sources() {
-        Ok(sources) => sources,
-        Err(e) => {
-            if e.contains("permission")
-                || e.contains("denied")
-                || e.contains("not allowed")
-                || e.contains("access")
-            {
-                warnings.push("Direct PipeWire access unavailable - use system picker".to_string());
+    let video_sources = if is_wayland_session() {
+        warnings.push(
+            "Direct PipeWire access unavailable on Wayland - use system picker".to_string(),
+        );
+        Vec::new()
+    } else {
+        match enumerate_pipewire_sources() {
+            Ok(sources) => sources,
+            Err(e) => {
+                warnings.push(format!(
+                    "Direct PipeWire access unavailable - use system picker ({e})"
+                ));
                 Vec::new()
-            } else {
-                return Err(e);
             }
         }
     };
@@ -386,10 +424,29 @@ pub(super) async fn list_sources() -> Result<EnumerationResult, String> {
     }
 
     let audio_sources = match enumerate_pulseaudio_sources() {
+        Ok(sources) if sources.is_empty() => match enumerate_default_pactl_audio_source() {
+            Ok(source) => vec![source],
+            Err(e) => {
+                warnings.push(format!("Audio source enumeration unavailable: {e}"));
+                Vec::new()
+            }
+        },
         Ok(sources) => sources,
         Err(e) => {
-            warnings.push(format!("Audio source enumeration unavailable: {e}"));
-            Vec::new()
+            match enumerate_default_pactl_audio_source() {
+                Ok(source) => {
+                    warnings.push(format!(
+                        "Audio source list unavailable, using default monitor: {e}"
+                    ));
+                    vec![source]
+                }
+                Err(fallback_error) => {
+                    warnings.push(format!(
+                        "Audio source enumeration unavailable: {e}; pactl fallback failed: {fallback_error}"
+                    ));
+                    Vec::new()
+                }
+            }
         }
     };
 

--- a/clients/wavis-gui/src-tauri/src/share_sources/capture/windows.rs
+++ b/clients/wavis-gui/src-tauri/src/share_sources/capture/windows.rs
@@ -440,8 +440,8 @@ fn enumerate_window_audio_sources(
 fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32, u32)>, String> {
     use windows::Win32::Foundation::HWND;
     use windows::Win32::Graphics::Gdi::{
-        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
-        GetDC, GetMonitorInfoW, ReleaseDC, SelectObject, HMONITOR, MONITORINFO, SRCCOPY,
+        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject, GetDC,
+        GetMonitorInfoW, ReleaseDC, SelectObject, HMONITOR, MONITORINFO, SRCCOPY,
     };
     use windows::Win32::Storage::Xps::{PrintWindow, PRINT_WINDOW_FLAGS, PW_CLIENTONLY};
     use windows::Win32::UI::WindowsAndMessaging::{GetClientRect, PW_RENDERFULLCONTENT};
@@ -449,7 +449,10 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
     let handle_val: isize = match source_id.parse() {
         Ok(value) => value,
         Err(_) => {
-            crate::debug_eprintln!("[share-thumb] source_id '{}' is not an isize handle", source_id);
+            crate::debug_eprintln!(
+                "[share-thumb] source_id '{}' is not an isize handle",
+                source_id
+            );
             return Ok(None);
         }
     };
@@ -467,7 +470,11 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
             let w = (client_rect.right - client_rect.left) as u32;
             let h = (client_rect.bottom - client_rect.top) as u32;
             if w == 0 || h == 0 {
-                crate::debug_eprintln!("[share-thumb] window {}x{} has zero client dimension", w, h);
+                crate::debug_eprintln!(
+                    "[share-thumb] window {}x{} has zero client dimension",
+                    w,
+                    h
+                );
                 return Ok(None);
             }
 
@@ -506,7 +513,12 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
             let _ = DeleteObject(bitmap);
             let _ = DeleteDC(mem_dc);
             ReleaseDC(HWND::default(), screen_dc);
-            crate::debug_eprintln!("[share-thumb] window capture {}x{}: rgba={}", w, h, rgba.is_some());
+            crate::debug_eprintln!(
+                "[share-thumb] window capture {}x{}: rgba={}",
+                w,
+                h,
+                rgba.is_some()
+            );
 
             return match rgba {
                 Some(data) => Ok(Some((data, w, h))),
@@ -522,13 +534,22 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
             ..std::mem::zeroed()
         };
         if !GetMonitorInfoW(monitor, &mut mi).as_bool() {
-            crate::debug_eprintln!("[share-thumb] GetMonitorInfoW failed for handle {}", handle_val);
+            crate::debug_eprintln!(
+                "[share-thumb] GetMonitorInfoW failed for handle {}",
+                handle_val
+            );
             return Ok(None);
         }
 
         let w = (mi.rcMonitor.right - mi.rcMonitor.left) as u32;
         let h = (mi.rcMonitor.bottom - mi.rcMonitor.top) as u32;
-        crate::debug_eprintln!("[share-thumb] monitor rect ({},{}) {}x{}", mi.rcMonitor.left, mi.rcMonitor.top, w, h);
+        crate::debug_eprintln!(
+            "[share-thumb] monitor rect ({},{}) {}x{}",
+            mi.rcMonitor.left,
+            mi.rcMonitor.top,
+            w,
+            h
+        );
         if w == 0 || h == 0 {
             crate::debug_eprintln!("[share-thumb] monitor has zero dimension");
             return Ok(None);
@@ -557,7 +578,8 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
         let old_bmp = SelectObject(mem_dc, bitmap);
         let _ = BitBlt(
             mem_dc,
-            0, 0,
+            0,
+            0,
             w as i32,
             h as i32,
             screen_dc,
@@ -572,7 +594,12 @@ fn capture_single_frame_windows(source_id: &str) -> Result<Option<(Vec<u8>, u32,
         let _ = DeleteObject(bitmap);
         let _ = DeleteDC(mem_dc);
         ReleaseDC(HWND::default(), screen_dc);
-        crate::debug_eprintln!("[share-thumb] monitor capture {}x{}: rgba={}", w, h, rgba.is_some());
+        crate::debug_eprintln!(
+            "[share-thumb] monitor capture {}x{}: rgba={}",
+            w,
+            h,
+            rgba.is_some()
+        );
 
         match rgba {
             Some(data) => Ok(Some((data, w, h))),
@@ -608,7 +635,12 @@ unsafe fn read_bitmap_rgba(
     };
 
     let mut bgra = vec![0u8; (w * h * 4) as usize];
-    crate::debug_eprintln!("[share-thumb] GetDIBits: {}x{} ({} bytes)", w, h, bgra.len());
+    crate::debug_eprintln!(
+        "[share-thumb] GetDIBits: {}x{} ({} bytes)",
+        w,
+        h,
+        bgra.len()
+    );
     let rows = GetDIBits(
         screen_dc,
         bitmap,
@@ -633,9 +665,13 @@ unsafe fn read_bitmap_rgba(
     // GDI BitBlt returns a valid (non-zero row count) but all-black bitmap for
     // GPU/DirectX-rendered windows it cannot read. Treat a fully-black frame as
     // a capture failure so callers show the name fallback instead.
-    let is_all_black = bgra.chunks_exact(4).all(|p| p[0] == 0 && p[1] == 0 && p[2] == 0);
+    let is_all_black = bgra
+        .chunks_exact(4)
+        .all(|p| p[0] == 0 && p[1] == 0 && p[2] == 0);
     if is_all_black {
-        crate::debug_eprintln!("[share-thumb] all-black frame detected, treating as capture failure");
+        crate::debug_eprintln!(
+            "[share-thumb] all-black frame detected, treating as capture failure"
+        );
         return None;
     }
 

--- a/clients/wavis-gui/src-tauri/src/taskbar_toolbar.rs
+++ b/clients/wavis-gui/src-tauri/src/taskbar_toolbar.rs
@@ -19,7 +19,7 @@ use tauri::{App, Emitter, Listener, Manager};
 use windows::Win32::{
     Foundation::{HWND, LPARAM, LRESULT, WPARAM},
     UI::WindowsAndMessaging::{
-        CallWindowProcW, PostMessageW, SetWindowLongPtrW, GWLP_WNDPROC, WNDPROC, WM_COMMAND,
+        CallWindowProcW, PostMessageW, SetWindowLongPtrW, GWLP_WNDPROC, WM_COMMAND, WNDPROC,
     },
 };
 

--- a/clients/wavis-gui/src-tauri/src/tray.rs
+++ b/clients/wavis-gui/src-tauri/src/tray.rs
@@ -88,8 +88,11 @@ pub fn setup_tray(app: &App) -> Result<(), Box<dyn std::error::Error>> {
     app.listen("tray-state-update", move |event| {
         if let Ok(payload) = serde_json::from_str::<TrayStatePayload>(event.payload()) {
             let _ = mute_state_item.set_text(if payload.is_muted { "Unmute" } else { "Mute" });
-            let _ = deafen_state_item
-                .set_text(if payload.is_deafened { "Undeafen" } else { "Deafen" });
+            let _ = deafen_state_item.set_text(if payload.is_deafened {
+                "Undeafen"
+            } else {
+                "Deafen"
+            });
             let _ = mute_state_item.set_enabled(payload.in_voice_session);
             let _ = deafen_state_item.set_enabled(payload.in_voice_session);
             let _ = leave_state_item.set_enabled(payload.in_voice_session);
@@ -186,7 +189,10 @@ pub fn show_main_window(
         let _ = window.set_focus();
     }
     visibility.hidden.store(false, Ordering::SeqCst);
-    let _ = app.emit("window-visibility-changed", WindowVisibilityPayload { visible: true });
+    let _ = app.emit(
+        "window-visibility-changed",
+        WindowVisibilityPayload { visible: true },
+    );
     Ok(())
 }
 

--- a/clients/wavis-gui/src/features/screen-share/SharePicker.tsx
+++ b/clients/wavis-gui/src/features/screen-share/SharePicker.tsx
@@ -22,6 +22,7 @@ const MODES: { key: ShareMode; label: string; sourceType: ShareSourceType }[] = 
 const ECHO_WARNING_SUBSTRING = 'echo possible';
 const DEBUG_SCREEN_CAPTURE = import.meta.env.VITE_DEBUG_SCREEN_CAPTURE === 'true';
 const LOG = '[share-picker]';
+const PORTAL_SOURCE_ID = 'portal';
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
@@ -42,6 +43,7 @@ export interface SharePickerProps {
   modeScope?: 'all' | 'video_only';
   initialWithAudio?: boolean;
   onSelect?: (selection: ShareSelection) => void;
+  onPortalFallback?: () => void;
   onCancel?: () => void;
 }
 
@@ -76,6 +78,36 @@ export function filterSourcesByMode(
   return sources.filter((s) => s.source_type === entry.sourceType);
 }
 
+function isPortalSource(source: ShareSource): boolean {
+  return source.id === PORTAL_SOURCE_ID;
+}
+
+function withPortalFallbackSources(enumResult: EnumerationResult | null): ShareSource[] {
+  const sources = enumResult?.sources ?? [];
+  if (enumResult?.fallback_reason !== 'portal') return sources;
+
+  const next = [...sources];
+  if (!next.some((source) => source.source_type === 'screen')) {
+    next.push({
+      id: PORTAL_SOURCE_ID,
+      name: 'Screen or display',
+      source_type: 'screen',
+      thumbnail: null,
+      app_name: 'System picker',
+    });
+  }
+  if (!next.some((source) => source.source_type === 'window')) {
+    next.push({
+      id: PORTAL_SOURCE_ID,
+      name: 'Window or app',
+      source_type: 'window',
+      thumbnail: null,
+      app_name: 'System picker',
+    });
+  }
+  return next;
+}
+
 /** Pick the first mode that has sources, or default to screen_audio. */
 function pickDefaultMode(sources: ShareSource[]): ShareMode {
   for (const m of MODES) {
@@ -86,10 +118,15 @@ function pickDefaultMode(sources: ShareSource[]): ShareMode {
 
 /** Pick the first mode that has sources and is not blocked by an occupied slot. */
 export function pickInitialMode(sources: ShareSource[], occupied: OccupiedSlots): ShareMode {
-  for (const m of MODES) {
-    const blocked = m.key === 'audio_only' ? occupied.audioOccupied : occupied.videoOccupied;
-    if (!blocked && sources.some((s) => s.source_type === m.sourceType)) {
-      return m.key;
+  for (const allowPortal of [false, true]) {
+    for (const m of MODES) {
+      const blocked = m.key === 'audio_only' ? occupied.audioOccupied : occupied.videoOccupied;
+      const hasSource = sources.some((s) =>
+        s.source_type === m.sourceType && (allowPortal || !isPortalSource(s)),
+      );
+      if (!blocked && hasSource) {
+        return m.key;
+      }
     }
   }
   return pickDefaultMode(sources);
@@ -279,18 +316,18 @@ export default function SharePicker(props: SharePickerProps) {
     ? (props.occupied ?? { videoOccupied: false, audioOccupied: false })
     : (parsed?.occupied ?? { videoOccupied: false, audioOccupied: false });
 
-  const initSources = enumResult?.sources ?? [];
+  const initPickerSources = withPortalFallbackSources(enumResult);
   const modeScope = props.modeScope ?? 'all';
   const initialMode = modeScope === 'video_only'
-    ? pickInitialVideoMode(initSources, occupied)
-    : pickInitialMode(initSources, occupied);
+    ? pickInitialVideoMode(initPickerSources, occupied)
+    : pickInitialMode(initPickerSources, occupied);
 
   const [activeMode, setActiveMode] = useState<ShareMode>(() =>
-    initSources.length > 0 ? initialMode : 'screen_audio',
+    initPickerSources.length > 0 ? initialMode : 'screen_audio',
   );
   const [selectedSource, setSelectedSource] = useState<ShareSource | null>(null);
   const [withAudio, setWithAudio] = useState<boolean>(() =>
-    props.initialWithAudio ?? defaultWithAudioForMode(initSources.length > 0 ? initialMode : 'screen_audio', occupied),
+    props.initialWithAudio ?? defaultWithAudioForMode(initPickerSources.length > 0 ? initialMode : 'screen_audio', occupied),
   );
   // TODO(persistence): resets on each picker open; follow-up is to persist per-app in settings store keyed by app_name.
   const [compatibilityMode, setCompatibilityMode] = useState(false);
@@ -307,7 +344,7 @@ export default function SharePicker(props: SharePickerProps) {
     let cancelled = false;
 
     const visualSources = enumResult.sources.filter(
-      (s) => s.source_type === 'screen' || s.source_type === 'window',
+      (s) => !isPortalSource(s) && (s.source_type === 'screen' || s.source_type === 'window'),
     );
 
     if (visualSources.length > 0) {
@@ -340,7 +377,7 @@ export default function SharePicker(props: SharePickerProps) {
   const isWindowsPlatform = /Windows NT/i.test(navigator.userAgent || '');
 
   /* ── Derived ── */
-  const sources = enumResult?.sources ?? [];
+  const sources = withPortalFallbackSources(enumResult);
   const warnings = enumResult?.warnings ?? [];
   const filteredSources = filterSourcesByMode(sources, activeMode);
   const isVisualMode = activeMode !== 'audio_only';
@@ -429,7 +466,7 @@ export default function SharePicker(props: SharePickerProps) {
     const selection: ShareSelection = {
       mode: activeMode,
       sourceId: selectedSource.id,
-      sourceName: selectedSource.name,
+      sourceName: isPortalSource(selectedSource) ? 'System picker' : selectedSource.name,
       withAudio: activeMode === 'audio_only' ? false : withAudio,
       sourceKind: selectedSource.source_type === 'window' ? 'window' : 'screen',
       compatibilityMode,
@@ -451,6 +488,16 @@ export default function SharePicker(props: SharePickerProps) {
       props.onCancel?.();
     } else {
       await invoke('share_picker_cancel');
+      await getCurrentWindow().close();
+    }
+  }, [isInline, props]);
+
+  /* ── Portal fallback action ── */
+  const handlePortalFallback = useCallback(async () => {
+    if (isInline) {
+      props.onPortalFallback?.();
+    } else {
+      await invoke('share_picker_use_portal');
       await getCurrentWindow().close();
     }
   }, [isInline, props]);
@@ -524,7 +571,7 @@ export default function SharePicker(props: SharePickerProps) {
               ⚠ Direct access unavailable
             </span>
             <button
-              onClick={handleCancel}
+              onClick={handlePortalFallback}
               className="border border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg transition-colors px-4 py-1 focus:outline focus:outline-2 focus:outline-wavis-accent"
             >
               Use system picker

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1424,6 +1424,21 @@ export default function ActiveRoom() {
       }),
     );
 
+    cleanups.push(
+      listen('share-picker:use-portal', async () => {
+        setPendingSharePickerData(null);
+        setShareStarting(true);
+        try {
+          await startPortalShare();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          showTransientScreenShareError(msg);
+        } finally {
+          setShareStarting(false);
+        }
+      }),
+    );
+
     // Share indicator stop button (now with target: 'video' | 'audio' | 'all')
     cleanups.push(
       listen<{ target?: 'video' | 'audio' | 'all' }>('share-indicator:stop', (event) => {
@@ -2161,18 +2176,6 @@ export default function ActiveRoom() {
           showTransientScreenShareError(msg);
           toast.error(msg);
         }
-        return;
-      }
-
-      const captureAuthStatus = await invoke<{
-        display_server: string;
-        authorized: boolean;
-        needs_auth: boolean;
-        was_attempted: boolean;
-      }>('get_capture_auth_status');
-
-      if (captureAuthStatus.display_server === 'wayland') {
-        await startPortalShare();
         return;
       }
 

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
@@ -432,7 +432,7 @@ describe('Audio share error propagation and toast display (Task 4.4)', () => {
       command: 'screen_share_start_source',
       args: expect.objectContaining({ sourceId: 'screen-1' }),
     });
-    expect(invokeCalls).toContainEqual({ command: 'get_default_audio_monitor', args: undefined });
+    expect(invokeCalls).toContainEqual({ command: 'get_default_audio_monitor_fast', args: undefined });
     expect(
       getState().events.some((event) =>
         event.message.includes('remote mic and system-audio still share one subscriber volume slot on Linux'),

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -4670,6 +4670,7 @@ export async function startCustomShare(selection: ShareSelection, options: Start
     // 3. Start video first (if needed)
     if (needsVideo) {
       const sourceKind = selection.sourceKind ?? (selection.mode === 'window' ? 'window' : 'screen');
+      const isPortalVideo = selection.sourceId === 'portal';
       const defaultNativeLeakBackend = sourceKind === 'screen'
         ? 'native-gdi-screen'
         : 'native-gdi-window';
@@ -4816,19 +4817,7 @@ export async function startCustomShare(selection: ShareSelection, options: Start
           }
         }
         videoStarted = true;
-      } else if (selection.sourceId === 'portal') {
-        if (lkModule && lkModule instanceof LiveKitModule && !options.isSourceChange) {
-          // Normal start: set up early-frame buffering before Rust capture begins.
-          lkModule.beginNativeCaptureLeakSession({
-            shareSessionId,
-            mode: selection.mode as 'screen_audio' | 'window',
-            sourceId: selection.sourceId,
-            sourceName: selection.sourceName,
-            sourceKind,
-            captureBackend: defaultNativeLeakBackend,
-          });
-          lkModule.prepareNativeCapture();
-        }
+      } else if (isPortalVideo) {
         await invoke('screen_share_start');
         videoStarted = true;
       } else {
@@ -4858,7 +4847,7 @@ export async function startCustomShare(selection: ShareSelection, options: Start
       // via invoke('screen_share_poll_frame') that uses the ipc:// protocol
       // (HTTP-like), completely bypassing PostMessage/HWND. This is immune
       // to the HWND corruption caused by child windows (SharePicker).
-      if (!isWindowsPlatform() && lkModule && lkModule instanceof LiveKitModule) {
+      if (!isWindowsPlatform() && !isPortalVideo && lkModule && lkModule instanceof LiveKitModule) {
         if (options.isSourceChange) {
           // Source change: feed new Rust frames into the existing generator so
           // viewers stay subscribed without a TrackUnpublished/TrackPublished cycle.
@@ -4878,8 +4867,11 @@ export async function startCustomShare(selection: ShareSelection, options: Start
         if (selection.mode === 'audio_only') {
           audioSourceId = selection.sourceId;
         } else {
-          if (DEBUG_WASAPI) console.log(LOG, '[wasapi] resolving default audio monitor via get_default_audio_monitor');
-          audioSourceId = await invoke<string>('get_default_audio_monitor');
+          const monitorCommand = isLinuxPlatform()
+            ? 'get_default_audio_monitor_fast'
+            : 'get_default_audio_monitor';
+          if (DEBUG_WASAPI) console.log(LOG, '[wasapi] resolving default audio monitor via', monitorCommand);
+          audioSourceId = await invoke<string>(monitorCommand);
           if (DEBUG_WASAPI) console.log(LOG, '[wasapi] default audio monitor resolved:', audioSourceId);
         }
         if (DEBUG_WASAPI) console.log(LOG, '[wasapi] invoking audio_share_start, sourceId:', audioSourceId);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
