### PR TITLE
fix

### DIFF
--- a/clients/shared/src/livekit_connection.rs
+++ b/clients/shared/src/livekit_connection.rs
@@ -69,6 +69,12 @@ pub struct RealLiveKitConnection {
     /// The callback MUST NOT block — it is invoked on a background task.
     #[allow(clippy::type_complexity)]
     audio_cb: Arc<Mutex<Option<Box<dyn Fn(&str, &[f32]) + Send + 'static>>>>,
+    /// Callback for when a remote screen-share audio track is subscribed.
+    #[allow(clippy::type_complexity)]
+    screen_share_audio_available_cb: Arc<Mutex<Option<Box<dyn Fn(&str) + Send + 'static>>>>,
+    /// Callback for when a remote screen-share audio track is unsubscribed.
+    #[allow(clippy::type_complexity)]
+    screen_share_audio_ended_cb: Arc<Mutex<Option<Box<dyn Fn(&str) + Send + 'static>>>>,
     /// Background task handle for the room event listener loop.
     event_task: Arc<Mutex<Option<JoinHandle<()>>>>,
     /// Background task that pushes mic PCM into the NativeAudioSource.
@@ -163,6 +169,8 @@ impl RealLiveKitConnection {
             published_track: Arc::new(Mutex::new(None)),
             mic_enabled: Arc::new(AtomicBool::new(false)),
             audio_cb: Arc::new(Mutex::new(None)),
+            screen_share_audio_available_cb: Arc::new(Mutex::new(None)),
+            screen_share_audio_ended_cb: Arc::new(Mutex::new(None)),
             event_task: Arc::new(Mutex::new(None)),
             capture_task: Arc::new(Mutex::new(None)),
             closing: Arc::new(AtomicBool::new(false)),
@@ -306,6 +314,8 @@ impl LiveKitConnection for RealLiveKitConnection {
 
         // Clone Arcs for the background event task.
         let audio_cb = Arc::clone(&self.audio_cb);
+        let screen_share_audio_available_cb = Arc::clone(&self.screen_share_audio_available_cb);
+        let screen_share_audio_ended_cb = Arc::clone(&self.screen_share_audio_ended_cb);
         let video_frame_cb = Arc::clone(&self.video.video_frame_cb);
         let video_track_ended_cb = Arc::clone(&self.video.video_track_ended_cb);
         let camera_frame_cb = Arc::clone(&self.video.camera_frame_cb);
@@ -369,6 +379,13 @@ impl LiveKitConnection for RealLiveKitConnection {
                             publication.sid(),
                             publication.name(),
                         );
+                        if source == TrackSource::ScreenshareAudio {
+                            if let Some(cb) =
+                                screen_share_audio_available_cb.lock().unwrap().as_ref()
+                            {
+                                cb(&participant_id);
+                            }
+                        }
                         let audio_cb = Arc::clone(&audio_cb);
                         let closing2 = Arc::clone(&closing);
                         #[cfg(feature = "real-backends")]
@@ -461,6 +478,25 @@ impl LiveKitConnection for RealLiveKitConnection {
                             }
                         } else if let Some(cb) = video_track_ended_cb.lock().unwrap().as_ref() {
                             cb(&participant_id);
+                        }
+                    }
+                    livekit::RoomEvent::TrackUnsubscribed {
+                        track: RemoteTrack::Audio(_),
+                        publication,
+                        participant,
+                        ..
+                    } => {
+                        let participant_id = participant.identity().to_string();
+                        let source = publication.source();
+                        log::info!(
+                            "livekit_audio: audio track unsubscribed from {participant_id}, source={source:?}"
+                        );
+                        if source == TrackSource::ScreenshareAudio {
+                            if let Some(cb) =
+                                screen_share_audio_ended_cb.lock().unwrap().as_ref()
+                            {
+                                cb(&participant_id);
+                            }
                         }
                     }
                     livekit::RoomEvent::ParticipantDisconnected(participant) => {
@@ -630,6 +666,14 @@ impl LiveKitConnection for RealLiveKitConnection {
 
     fn on_camera_track_ended(&self, cb: Box<dyn Fn(&str) + Send + 'static>) {
         *self.video.camera_track_ended_cb.lock().unwrap() = Some(cb);
+    }
+
+    fn on_screen_share_audio_available(&self, cb: Box<dyn Fn(&str) + Send + 'static>) {
+        *self.screen_share_audio_available_cb.lock().unwrap() = Some(cb);
+    }
+
+    fn on_screen_share_audio_ended(&self, cb: Box<dyn Fn(&str) + Send + 'static>) {
+        *self.screen_share_audio_ended_cb.lock().unwrap() = Some(cb);
     }
 
     // Task 4.3

--- a/clients/shared/src/room_session/mod.rs
+++ b/clients/shared/src/room_session/mod.rs
@@ -146,6 +146,16 @@ pub trait LiveKitConnection: Send + Sync {
     /// Default: no-op.
     fn on_camera_track_ended(&self, _cb: Box<dyn Fn(&str) + Send + 'static>) {}
 
+    /// Register callback for when a remote screen-share audio track is
+    /// subscribed. Receives `(identity)`.
+    /// Default: no-op.
+    fn on_screen_share_audio_available(&self, _cb: Box<dyn Fn(&str) + Send + 'static>) {}
+
+    /// Register callback for when a remote screen-share audio track ends.
+    /// Receives `(identity)`.
+    /// Default: no-op.
+    fn on_screen_share_audio_ended(&self, _cb: Box<dyn Fn(&str) + Send + 'static>) {}
+
     /// Publish a second audio track for system audio capture (screen share audio).
     /// Creates a `NativeAudioSource` and `LocalAudioTrack` published with
     /// `TrackSource::ScreenShareAudio` so receivers can distinguish it from the mic.

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -218,6 +218,12 @@ struct ScreenShareAvailablePayload {
 
 #[cfg(target_os = "linux")]
 #[derive(Clone, Serialize)]
+struct ScreenShareAudioPayload {
+    identity: String,
+}
+
+#[cfg(target_os = "linux")]
+#[derive(Clone, Serialize)]
 pub struct PolledCameraFrame {
     pub identity: String,
     pub frame: String,
@@ -1131,6 +1137,30 @@ pub fn media_connect(
                 serde_json::json!({
                     "identity": identity,
                 }),
+            );
+        }));
+
+        let app_audio_available = app.clone();
+        conn.on_screen_share_audio_available(Box::new(move |identity| {
+            log::info!("{LOG} remote screen share audio available: {identity}");
+            let _ = app_audio_available.emit_to(
+                "main",
+                "screen_share_audio_available",
+                ScreenShareAudioPayload {
+                    identity: identity.to_string(),
+                },
+            );
+        }));
+
+        let app_audio_ended = app.clone();
+        conn.on_screen_share_audio_ended(Box::new(move |identity| {
+            log::info!("{LOG} remote screen share audio ended: {identity}");
+            let _ = app_audio_ended.emit_to(
+                "main",
+                "screen_share_audio_ended",
+                ScreenShareAudioPayload {
+                    identity: identity.to_string(),
+                },
             );
         }));
 

--- a/clients/wavis-gui/src/features/voice/__tests__/preservation.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/preservation.test.ts
@@ -54,6 +54,8 @@ function makeCallbacks(): MediaCallbacks {
     onParticipantMuteChanged: vi.fn(),
     onSystemEvent: vi.fn(),
     onShareQualityInfo: vi.fn(),
+    onAudioOnlySharerAdded: vi.fn(),
+    onAudioOnlySharerRemoved: vi.fn(),
   };
 }
 
@@ -239,6 +241,41 @@ describe('Property 2: Preservation — NativeMediaModule audio IPC baseline', ()
     await mod_.setMicEnabled(false);
 
     expect(invoke).toHaveBeenCalledWith('media_set_mic_enabled', { enabled: false });
+  });
+
+  it('setRemoteShareType(audio_only) marks native audio-only shares and enables share audio', () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    mod_.setRemoteShareType('peer-a', 'audio_only');
+    mod_.setRemoteShareType('peer-a', 'audio_only');
+
+    expect(callbacks.onAudioOnlySharerAdded).toHaveBeenCalledTimes(1);
+    expect(callbacks.onAudioOnlySharerAdded).toHaveBeenCalledWith('peer-a');
+    expect(invoke).toHaveBeenCalledWith('media_attach_screen_share_audio', { id: 'peer-a' });
+  });
+
+  it('setRemoteShareType(non-audio) removes native audio-only shares and disables share audio', () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    mod_.setRemoteShareType('peer-a', 'audio_only');
+    vi.clearAllMocks();
+    mod_.setRemoteShareType('peer-a', 'screen_audio');
+
+    expect(callbacks.onAudioOnlySharerRemoved).toHaveBeenCalledTimes(1);
+    expect(callbacks.onAudioOnlySharerRemoved).toHaveBeenCalledWith('peer-a');
+    expect(invoke).toHaveBeenCalledWith('media_detach_screen_share_audio', { id: 'peer-a' });
+  });
+
+  it('clearRemoteShareType removes native audio-only shares and disables share audio', () => {
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    mod_.setRemoteShareType('peer-a', 'audio_only');
+    vi.clearAllMocks();
+    mod_.clearRemoteShareType('peer-a');
+
+    expect(callbacks.onAudioOnlySharerRemoved).toHaveBeenCalledTimes(1);
+    expect(callbacks.onAudioOnlySharerRemoved).toHaveBeenCalledWith('peer-a');
+    expect(invoke).toHaveBeenCalledWith('media_detach_screen_share_audio', { id: 'peer-a' });
   });
 
   /**

--- a/clients/wavis-gui/src/features/voice/native-media.ts
+++ b/clients/wavis-gui/src/features/voice/native-media.ts
@@ -19,6 +19,7 @@ import {
 } from '@features/settings/settings-store';
 
 const LOG = '[wavis:native-media]';
+type RemoteShareType = 'screen_audio' | 'window' | 'audio_only' | 'browser';
 
 /* ─── Tauri Event Payload Types ─────────────────────────────────── */
 
@@ -31,6 +32,10 @@ interface ScreenShareAvailablePayload {
 }
 
 interface ScreenShareEndedPayload {
+  identity: string;
+}
+
+interface ScreenShareAudioPayload {
   identity: string;
 }
 
@@ -131,6 +136,8 @@ export class NativeMediaModule {
   private unlistenFrame: UnlistenFn | null = null;
   private unlistenAvailable: UnlistenFn | null = null;
   private unlistenEnded: UnlistenFn | null = null;
+  private unlistenAudioAvailable: UnlistenFn | null = null;
+  private unlistenAudioEnded: UnlistenFn | null = null;
   private unlistenCameraAvailable: UnlistenFn | null = null;
   private unlistenCameraEnded: UnlistenFn | null = null;
   private disposed = false;
@@ -138,6 +145,9 @@ export class NativeMediaModule {
   private activeCameras = new Map<string, ActiveCameraEntry>();
   private localCamera: ActiveCameraEntry | null = null;
   private localCameraTrack: MediaStreamTrack | null = null;
+  private remoteShareTypes = new Map<string, RemoteShareType | undefined>();
+  private audioOnlySharers = new Set<string>();
+  private inferredAudioOnlySharers = new Set<string>();
 
   constructor(callbacks: MediaCallbacks) {
     this.callbacks = callbacks;
@@ -231,7 +241,21 @@ export class NativeMediaModule {
       this.handleScreenShareEnded(event.payload.identity);
     });
 
-    // 5. Subscribe to remote camera availability events. The Rust native
+    // 5. Subscribe to remote screen-share audio availability events. The Rust
+    // native path can receive ScreenshareAudio without any video frames, so
+    // this is the Linux/WebKit equivalent of LiveKitModule's audio-only
+    // publication inference.
+    this.unlistenAudioAvailable = await listen<ScreenShareAudioPayload>('screen_share_audio_available', (event) => {
+      if (this.disposed) return;
+      this.handleScreenShareAudioAvailable(event.payload.identity);
+    });
+
+    this.unlistenAudioEnded = await listen<ScreenShareAudioPayload>('screen_share_audio_ended', (event) => {
+      if (this.disposed) return;
+      this.handleScreenShareAudioEnded(event.payload.identity);
+    });
+
+    // 6. Subscribe to remote camera availability events. The Rust native
     // LiveKit path decodes camera frames, and this module paints them into a
     // canvas-backed MediaStreamTrack so the existing VideoTile UI can render.
     this.unlistenCameraAvailable = await listen<CameraAvailablePayload>('camera_available', (event) => {
@@ -244,7 +268,7 @@ export class NativeMediaModule {
       this.handleCameraEnded(event.payload.identity);
     });
 
-    // 6. Tell Rust which persisted devices to open before it starts CPAL streams.
+    // 7. Tell Rust which persisted devices to open before it starts CPAL streams.
     try {
       const denoiseEnabled = await getDenoiseEnabled();
       const [inputDeviceId, outputDeviceId] = await Promise.all([
@@ -275,6 +299,8 @@ export class NativeMediaModule {
     if (this.unlistenFrame) { this.unlistenFrame(); this.unlistenFrame = null; }
     if (this.unlistenAvailable) { this.unlistenAvailable(); this.unlistenAvailable = null; }
     if (this.unlistenEnded) { this.unlistenEnded(); this.unlistenEnded = null; }
+    if (this.unlistenAudioAvailable) { this.unlistenAudioAvailable(); this.unlistenAudioAvailable = null; }
+    if (this.unlistenAudioEnded) { this.unlistenAudioEnded(); this.unlistenAudioEnded = null; }
     if (this.unlistenCameraAvailable) { this.unlistenCameraAvailable(); this.unlistenCameraAvailable = null; }
     if (this.unlistenCameraEnded) { this.unlistenCameraEnded(); this.unlistenCameraEnded = null; }
 
@@ -337,6 +363,47 @@ export class NativeMediaModule {
   /** Remove a participant's screen share audio from the native Rust mix. */
   detachScreenShareAudio(participantIdentity: string): void {
     invoke('media_detach_screen_share_audio', { id: participantIdentity }).catch(() => {});
+  }
+
+  /** Keep native Linux audio-only shares in sync with signaling metadata. */
+  setRemoteShareType(participantIdentity: string, shareType?: RemoteShareType): void {
+    this.applyRemoteShareType(participantIdentity, shareType, false);
+  }
+
+  private applyRemoteShareType(
+    participantIdentity: string,
+    shareType: RemoteShareType | undefined,
+    inferred: boolean,
+  ): void {
+    if (inferred) {
+      this.inferredAudioOnlySharers.add(participantIdentity);
+    } else {
+      this.inferredAudioOnlySharers.delete(participantIdentity);
+    }
+    this.remoteShareTypes.set(participantIdentity, shareType);
+    if (shareType === 'audio_only') {
+      if (!this.audioOnlySharers.has(participantIdentity)) {
+        this.audioOnlySharers.add(participantIdentity);
+        this.callbacks.onAudioOnlySharerAdded?.(participantIdentity);
+      }
+      this.attachScreenShareAudio(participantIdentity);
+      return;
+    }
+
+    if (this.audioOnlySharers.delete(participantIdentity)) {
+      this.callbacks.onAudioOnlySharerRemoved?.(participantIdentity);
+      this.detachScreenShareAudio(participantIdentity);
+    }
+  }
+
+  /** Remove stale remote share metadata when signaling says the share ended. */
+  clearRemoteShareType(participantIdentity: string): void {
+    this.remoteShareTypes.delete(participantIdentity);
+    this.inferredAudioOnlySharers.delete(participantIdentity);
+    if (this.audioOnlySharers.delete(participantIdentity)) {
+      this.callbacks.onAudioOnlySharerRemoved?.(participantIdentity);
+      this.detachScreenShareAudio(participantIdentity);
+    }
   }
 
   /** Set master volume (0–100). */
@@ -516,6 +583,11 @@ export class NativeMediaModule {
   private handleScreenShareAvailable(identity: string): void {
     if (this.activeShares.has(identity)) return;
 
+    if (this.inferredAudioOnlySharers.has(identity)) {
+      this.inferredAudioOnlySharers.delete(identity);
+      this.setRemoteShareType(identity, undefined);
+    }
+
     const entry: ActiveShareEntry = {
       stream: null,
       canvas: null,
@@ -525,6 +597,24 @@ export class NativeMediaModule {
 
     console.log(LOG, `screen share available (native viewer path): ${identity}`);
     this.callbacks.onScreenShareSubscribed(identity, null as unknown as MediaStream);
+  }
+
+  private handleScreenShareAudioAvailable(identity: string): void {
+    if (this.activeShares.has(identity)) {
+      return;
+    }
+    if (this.remoteShareTypes.get(identity) !== 'audio_only') {
+      this.applyRemoteShareType(identity, 'audio_only', true);
+    }
+  }
+
+  private handleScreenShareAudioEnded(identity: string): void {
+    if (
+      this.inferredAudioOnlySharers.has(identity) ||
+      this.remoteShareTypes.get(identity) === 'audio_only'
+    ) {
+      this.clearRemoteShareType(identity);
+    }
   }
 
   /** Handle screen_share_ended event — clean up and notify. */


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
