### PR TITLE
fix

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/SharePicker.tsx
+++ b/clients/wavis-gui/src/features/screen-share/SharePicker.tsx
@@ -38,7 +38,8 @@ export interface OccupiedSlots {
  * When omitted, falls back to URL hash + Tauri event relay (Linux path).
  */
 export interface SharePickerProps {
-  enumResult?: EnumerationResult;
+  inline?: boolean;
+  enumResult?: EnumerationResult | null;
   occupied?: OccupiedSlots;
   modeScope?: 'all' | 'video_only';
   initialWithAudio?: boolean;
@@ -48,16 +49,18 @@ export interface SharePickerProps {
 }
 
 /** Parse the picker data from the URL hash (standalone window mode). */
-function parseHashData(): { enumResult: EnumerationResult; occupied: OccupiedSlots } | null {
+function parseHashData(): { enumResult: EnumerationResult | null; occupied: OccupiedSlots } | null {
   try {
     const raw = decodeURIComponent(window.location.hash.slice(1));
     if (!raw) return null;
     const data = JSON.parse(raw);
-    const result: EnumerationResult = {
-      sources: Array.isArray(data.enumResult?.sources) ? data.enumResult.sources : [],
-      warnings: Array.isArray(data.enumResult?.warnings) ? data.enumResult.warnings : [],
-      fallback_reason: data.enumResult?.fallback_reason ?? null,
-    };
+    const result: EnumerationResult | null = data.enumResult
+      ? {
+        sources: Array.isArray(data.enumResult.sources) ? data.enumResult.sources : [],
+        warnings: Array.isArray(data.enumResult.warnings) ? data.enumResult.warnings : [],
+        fallback_reason: data.enumResult.fallback_reason ?? null,
+      }
+      : null;
     const occupied: OccupiedSlots = {
       videoOccupied: data.occupied?.videoOccupied ?? false,
       audioOccupied: data.occupied?.audioOccupied ?? false,
@@ -303,10 +306,10 @@ function SourceItem({
 
 export default function SharePicker(props: SharePickerProps) {
   // ── Mode detection: inline modal (props) vs standalone window (hash) ──
-  const isInline = props.enumResult !== undefined;
+  const isInline = props.inline === true || props.enumResult !== undefined;
 
   /* ── State ── */
-  const [parsed] = useState(() => (isInline ? null : parseHashData()));
+  const [parsed, setParsed] = useState(() => (isInline ? null : parseHashData()));
 
   const enumResult = isInline
     ? (props.enumResult ?? null)
@@ -337,6 +340,35 @@ export default function SharePicker(props: SharePickerProps) {
 
   const listboxRef = useRef<HTMLDivElement>(null);
   const activeIndexRef = useRef<number>(-1);
+
+  /* ── Standalone source loading ── */
+  useEffect(() => {
+    if (isInline || enumResult !== null) return;
+    let cancelled = false;
+
+    invoke<EnumerationResult>('list_share_sources')
+      .then((result) => {
+        if (!cancelled) {
+          setParsed((current) => ({
+            enumResult: result,
+            occupied: current?.occupied ?? { videoOccupied: false, audioOccupied: false },
+          }));
+        }
+      })
+      .catch((err: unknown) => {
+        if (DEBUG_SCREEN_CAPTURE) console.error(LOG, 'source enumeration failed', err);
+        if (!cancelled) {
+          setParsed((current) => ({
+            enumResult: { sources: [], warnings: [String(err)], fallback_reason: null },
+            occupied: current?.occupied ?? { videoOccupied: false, audioOccupied: false },
+          }));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enumResult, isInline]);
 
   /* ── Lazy thumbnail loading ── */
   useEffect(() => {

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -773,7 +773,7 @@ export default function ActiveRoom() {
   const [shareStarting, setShareStarting] = useState(false);
   // Windows: inline share picker data (replaces getDisplayMedia to suppress WebView2 capture indicator)
   const [winSharePicker, setWinSharePicker] = useState<{
-    enumResult: EnumerationResult;
+    enumResult: EnumerationResult | null;
     occupied: OccupiedSlots;
     isChangingSource?: boolean;
     initialWithAudio?: boolean;
@@ -1129,15 +1129,24 @@ export default function ActiveRoom() {
     cleanups.push(
       listen('screen-share:change-source', async () => {
         if (isWindowsPlatform) {
+          const occupied = {
+            videoOccupied: false,
+            audioOccupied: roomStateRef.current?.activeAudioShare !== null,
+          };
+          const initialWithAudio = roomStateRef.current?.activeVideoShare?.withAudio ?? false;
+          setWinSharePicker({
+            enumResult: null,
+            occupied,
+            isChangingSource: true,
+            initialWithAudio,
+          });
           try {
             const enumResult = await invoke<EnumerationResult>('list_share_sources');
-            setWinSharePicker({
-              enumResult,
-              occupied: { videoOccupied: false, audioOccupied: roomStateRef.current?.activeAudioShare !== null },
-              isChangingSource: true,
-              initialWithAudio: roomStateRef.current?.activeVideoShare?.withAudio ?? false,
-            });
+            setWinSharePicker((current) => (
+              current ? { ...current, enumResult } : current
+            ));
           } catch (err) {
+            setWinSharePicker(null);
             const detail = err instanceof Error ? err.message : String(err);
             toast.error(`Screen sharing failed: ${detail}`);
           }
@@ -2132,14 +2141,19 @@ export default function ActiveRoom() {
         // Windows: use native Rust source picker to avoid getDisplayMedia() and
         // the WebView2 capture indicator bar it triggers.
         if (isWindowsPlatform) {
+          const occupied: OccupiedSlots = {
+            videoOccupied: roomState?.activeVideoShare !== null,
+            audioOccupied: roomState?.activeAudioShare !== null,
+          };
+          setWinSharePicker({ enumResult: null, occupied });
+          setSharePickerLoading(false);
           try {
             const enumResult = await invoke<EnumerationResult>('list_share_sources');
-            const occupied: OccupiedSlots = {
-              videoOccupied: roomState?.activeVideoShare !== null,
-              audioOccupied: roomState?.activeAudioShare !== null,
-            };
-            setWinSharePicker({ enumResult, occupied });
+            setWinSharePicker((current) => (
+              current ? { ...current, enumResult } : current
+            ));
           } catch (err) {
+            setWinSharePicker(null);
             const detail = err instanceof Error ? err.message : String(err);
             showTransientScreenShareError(`Screen sharing failed: ${detail}`);
             toast.error(`Screen sharing failed: ${detail}`);
@@ -2180,35 +2194,27 @@ export default function ActiveRoom() {
       }
 
       // Linux: custom picker path — getDisplayMedia() doesn't work in WebKitGTK.
-      const result = await invoke<EnumerationResult>('list_share_sources');
-
-      if (result.sources.length > 0 || result.fallback_reason === 'portal') {
-        const occupied: OccupiedSlots = {
-          videoOccupied: roomState?.activeVideoShare !== null,
-          audioOccupied: roomState?.activeAudioShare !== null,
-        };
-
-        // Linux: standalone OS window — PostMessage works fine on WebKitGTK.
-        setPendingSharePickerData({ enumResult: result, occupied });
-        const pickerPayload = encodeURIComponent(
-          JSON.stringify({ enumResult: result, occupied }),
-        );
-        new WebviewWindow('share-picker', {
-          url: `/share-picker#${pickerPayload}`,
-          title: 'Wavis — Share Picker',
-          width: 640,
-          height: 480,
-          minWidth: 360,
-          minHeight: 320,
-          resizable: true,
-          decorations: false,
-          center: true,
-        });
-      } else if (result.fallback_reason === 'get_display_media' && roomState?.connectionMode === 'livekit') {
-        await startFallbackShare();
-      } else {
-        toast.error('No shareable sources found');
-      }
+      // Open the picker before source enumeration so slow PipeWire/PulseAudio
+      // discovery does not block the OS window from appearing.
+      const occupied: OccupiedSlots = {
+        videoOccupied: roomState?.activeVideoShare !== null,
+        audioOccupied: roomState?.activeAudioShare !== null,
+      };
+      setPendingSharePickerData({ enumResult: { sources: [], warnings: [], fallback_reason: null }, occupied });
+      const pickerPayload = encodeURIComponent(
+        JSON.stringify({ enumResult: null, occupied }),
+      );
+      new WebviewWindow('share-picker', {
+        url: `/share-picker#${pickerPayload}`,
+        title: 'Wavis — Share Picker',
+        width: 640,
+        height: 480,
+        minWidth: 360,
+        minHeight: 320,
+        resizable: true,
+        decorations: false,
+        center: true,
+      });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       showTransientScreenShareError(msg);
@@ -3070,15 +3076,24 @@ export default function ActiveRoom() {
                             onClick={() => {
                               if (isWindowsPlatform) {
                                 void (async () => {
+                                  const occupied = {
+                                    videoOccupied: false,
+                                    audioOccupied: roomState.activeAudioShare !== null,
+                                  };
+                                  const initialWithAudio = roomState.activeVideoShare?.withAudio ?? false;
+                                  setWinSharePicker({
+                                    enumResult: null,
+                                    occupied,
+                                    isChangingSource: true,
+                                    initialWithAudio,
+                                  });
                                   try {
                                     const enumResult = await invoke<EnumerationResult>('list_share_sources');
-                                    setWinSharePicker({
-                                      enumResult,
-                                      occupied: { videoOccupied: false, audioOccupied: roomState.activeAudioShare !== null },
-                                      isChangingSource: true,
-                                      initialWithAudio: roomState.activeVideoShare?.withAudio ?? false,
-                                    });
+                                    setWinSharePicker((current) => (
+                                      current ? { ...current, enumResult } : current
+                                    ));
                                   } catch (err) {
+                                    setWinSharePicker(null);
                                     const detail = err instanceof Error ? err.message : String(err);
                                     toast.error(`Screen sharing failed: ${detail}`);
                                   }
@@ -3586,6 +3601,7 @@ export default function ActiveRoom() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-wavis-bg/80 px-4">
           <div className="w-[640px] max-w-[90vw] h-[480px] max-h-[80vh] border border-wavis-text-secondary shadow-xl overflow-hidden flex flex-col">
             <SharePicker
+              inline
               enumResult={winSharePicker.enumResult}
               occupied={winSharePicker.occupied}
               modeScope={winSharePicker.isChangingSource ? 'video_only' : 'all'}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
