### PR TITLE
fix

### DIFF
--- a/clients/wavis-gui/src/features/voice/native-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/native-media.test.ts
@@ -24,6 +24,11 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const mockSettings = vi.hoisted(() => ({
+  inputDeviceId: null as string | null,
+  outputDeviceId: null as string | null,
+}));
+
 /* ─── Mock Tauri IPC layer ──────────────────────────────────────── */
 
 // Mock @tauri-apps/api/core — invoke must exist for NativeMediaModule to load
@@ -36,9 +41,22 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn().mockResolvedValue(() => {}),
 }));
 
+vi.mock('@features/settings/settings-store', () => ({
+  getAudioInputDevice: vi.fn(async () => mockSettings.inputDeviceId),
+  getAudioOutputDevice: vi.fn(async () => mockSettings.outputDeviceId),
+  getDenoiseEnabled: vi.fn(async () => false),
+  inputVolumeToGain: vi.fn((volume: number) => volume / 100),
+  setStoreValue: vi.fn(async () => {}),
+  STORE_KEYS: {
+    audioInputDevice: 'wavis_audio_input_device',
+    audioOutputDevice: 'wavis_audio_output_device',
+  },
+}));
+
 import { invoke } from '@tauri-apps/api/core';
 import { NativeMediaModule } from './native-media';
 import type { MediaCallbacks } from './livekit-media';
+import { setStoreValue, STORE_KEYS } from '@features/settings/settings-store';
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
@@ -68,6 +86,8 @@ describe('Property 1: Fault Condition — Linux Screen Share Stubbed Out', () =>
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSettings.inputDeviceId = null;
+    mockSettings.outputDeviceId = null;
     callbacks = makeCallbacks();
     mod_ = new NativeMediaModule(callbacks);
   });
@@ -182,6 +202,31 @@ describe('Property 1: Fault Condition — Linux Screen Share Stubbed Out', () =>
     vi.mocked(invoke).mockRejectedValueOnce(new Error(errorMsg));
 
     await expect(mod_.startScreenShare()).rejects.toThrow(errorMsg);
+  });
+
+  it('connect() ignores a stale saved output sink and continues with system default', async () => {
+    mockSettings.outputDeviceId = 'output:wavis_capture';
+    vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+      if (cmd === 'set_audio_device') {
+        throw new Error('pactl set-default-sink failed with status exit status: 1: Failure: No such entity');
+      }
+      return undefined;
+    });
+
+    await mod_.connect('wss://sfu.test', 'token');
+
+    expect(invoke).toHaveBeenCalledWith('set_audio_device', {
+      deviceId: 'output:wavis_capture',
+      kind: 'output',
+    });
+    expect(invoke).toHaveBeenCalledWith('media_connect', {
+      url: 'wss://sfu.test',
+      token: 'token',
+      denoiseEnabled: false,
+    });
+    expect(setStoreValue).toHaveBeenCalledWith(STORE_KEYS.audioOutputDevice, '');
+    expect(callbacks.onSystemEvent).toHaveBeenCalledWith('output device unavailable, using system default');
+    expect(callbacks.onMediaFailed).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/wavis-gui/src/features/voice/native-media.ts
+++ b/clients/wavis-gui/src/features/voice/native-media.ts
@@ -16,10 +16,13 @@ import {
   getAudioOutputDevice,
   getDenoiseEnabled,
   inputVolumeToGain,
+  setStoreValue,
+  STORE_KEYS,
 } from '@features/settings/settings-store';
 
 const LOG = '[wavis:native-media]';
 type RemoteShareType = 'screen_audio' | 'window' | 'audio_only' | 'browser';
+type AudioDeviceKind = 'input' | 'output';
 
 /* ─── Tauri Event Payload Types ─────────────────────────────────── */
 
@@ -154,6 +157,24 @@ export class NativeMediaModule {
     console.log(LOG, 'created (native Rust path)');
   }
 
+  private async applySavedAudioDevice(deviceId: string | null, kind: AudioDeviceKind): Promise<void> {
+    if (!deviceId) return;
+
+    try {
+      await invoke('set_audio_device', { deviceId, kind });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      console.warn(LOG, `saved ${kind} device unavailable; falling back to system default:`, reason);
+      this.callbacks.onSystemEvent?.(
+        `${kind} device unavailable, using system default`,
+      );
+      await setStoreValue(
+        kind === 'input' ? STORE_KEYS.audioInputDevice : STORE_KEYS.audioOutputDevice,
+        '',
+      ).catch(() => {});
+    }
+  }
+
   /** Connect to LiveKit SFU via the Rust-side RealLiveKitConnection. */
   async connect(sfuUrl: string, token: string): Promise<void> {
     // 1. Subscribe to Rust-side media events before connecting
@@ -275,12 +296,8 @@ export class NativeMediaModule {
         getAudioInputDevice().catch(() => null),
         getAudioOutputDevice().catch(() => null),
       ]);
-      if (inputDeviceId) {
-        await invoke('set_audio_device', { deviceId: inputDeviceId, kind: 'input' });
-      }
-      if (outputDeviceId) {
-        await invoke('set_audio_device', { deviceId: outputDeviceId, kind: 'output' });
-      }
+      await this.applySavedAudioDevice(inputDeviceId, 'input');
+      await this.applySavedAudioDevice(outputDeviceId, 'output');
       await invoke('media_connect', { url: sfuUrl, token, denoiseEnabled });
     } catch (err) {
       this.callbacks.onMediaFailed(


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
