### PR TITLE
perf: split livekit-client chunk and lazy load voice-room to optimize build size

### DIFF
--- a/clients/wavis-gui/src/App.tsx
+++ b/clients/wavis-gui/src/App.tsx
@@ -7,9 +7,10 @@ import { initNotificationBridge } from '@shared/notification-bridge';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { emit } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { getState } from '@features/voice/voice-room';
 import AppUpdatePrompt from '@shared/AppUpdatePrompt';
 import type { AppDimensions } from '@features/diagnostics/diagnostics';
+
+type VoiceRoomGetState = typeof import('@features/voice/voice-room').getState;
 
 /* ─── Helpers ───────────────────────────────────────────────────── */
 
@@ -92,7 +93,22 @@ export default function App() {
     if (import.meta.env.VITE_DIAGNOSTICS !== 'true') return;
     if (isChromelessWindow()) return;
 
+    let cancelled = false;
+    let getVoiceRoomState: VoiceRoomGetState | null = null;
+
+    void import('@features/voice/voice-room')
+      .then((mod) => {
+        if (!cancelled) {
+          getVoiceRoomState = mod.getState;
+        }
+      })
+      .catch((err) => {
+        console.warn('[wavis:diagnostics] voice stats unavailable:', err);
+      });
+
     const intervalId = setInterval(() => {
+      if (!getVoiceRoomState) return;
+
       const {
         networkStats,
         shareStats,
@@ -100,7 +116,7 @@ export default function App() {
         participants,
         selfParticipantId,
         activeVideoShare,
-      } = getState();
+      } = getVoiceRoomState();
       const self = participants.find((p) => p.id === selfParticipantId);
       const fallbackShareActive = self?.isSharing === true && self.shareType !== 'audio_only';
       const isSharing = activeVideoShare !== null || fallbackShareActive;
@@ -122,7 +138,10 @@ export default function App() {
       });
     }, 1000);
 
-    return () => clearInterval(intervalId);
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+    };
   }, []);
 
   // Diagnostics app-size bridge. Sends the main Wavis native window and webview

--- a/clients/wavis-gui/src/features/diagnostics/BugReportButton.tsx
+++ b/clients/wavis-gui/src/features/diagnostics/BugReportButton.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, type ComponentType } from 'react';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { invoke } from '@tauri-apps/api/core';
 import { getStoreValue, setStoreValue, STORE_KEYS } from '@features/settings/settings-store';
-import BugReportFlow from './BugReportFlow';
 
 /* ─── Constants ─────────────────────────────────────────────────── */
 
@@ -12,6 +11,11 @@ const BUTTON_HEIGHT = 40;
 const EXPANDED_WIDTH = 140;
 const DRAG_THRESHOLD = 4;
 export const TITLE_BAR_HEIGHT = 32; // h-8, keeps button out of the OS drag region
+
+type BugReportFlowComponent = ComponentType<{
+  onClose: () => void;
+  preScreenshot?: Uint8Array | null;
+}>;
 
 /* ─── Snap Logic (exported for testing) ─────────────────────────── */
 
@@ -89,6 +93,7 @@ function useBugReportLauncher({ captureScreenshot = true }: { captureScreenshot?
   const [showFlow, setShowFlow] = useState(false);
   const [isCapturing, setIsCapturing] = useState(false);
   const [preScreenshot, setPreScreenshot] = useState<Uint8Array | null>(null);
+  const [FlowComponent, setFlowComponent] = useState<BugReportFlowComponent | null>(null);
 
   const handleClick = useCallback(async () => {
     if (isCapturing) return;
@@ -98,6 +103,7 @@ function useBugReportLauncher({ captureScreenshot = true }: { captureScreenshot?
     if (showFlow) {
       setShowFlow(false);
       setPreScreenshot(null);
+      setFlowComponent(null);
       return;
     }
 
@@ -114,15 +120,26 @@ function useBugReportLauncher({ captureScreenshot = true }: { captureScreenshot?
         console.warn('[bug-report] capture_window_screenshot failed:', err);
       }
     }
-    setPreScreenshot(screenshot);
-    setIsCapturing(false);
-    setShowFlow(true);
+    try {
+      const { default: BugReportFlow } = await import('./BugReportFlow');
+      setPreScreenshot(screenshot);
+      setFlowComponent(() => BugReportFlow);
+      setShowFlow(true);
+    } catch (err) {
+      console.warn('[bug-report] failed to load bug report flow:', err);
+    } finally {
+      setIsCapturing(false);
+    }
   }, [captureScreenshot, isCapturing, showFlow]);
 
-  const flow = showFlow ? (
-    <BugReportFlow
+  const flow = showFlow && FlowComponent ? (
+    <FlowComponent
       preScreenshot={preScreenshot}
-      onClose={() => { setShowFlow(false); setPreScreenshot(null); }}
+      onClose={() => {
+        setShowFlow(false);
+        setPreScreenshot(null);
+        setFlowComponent(null);
+      }}
     />
   ) : null;
 

--- a/clients/wavis-gui/src/shared/AppUpdatePrompt.tsx
+++ b/clients/wavis-gui/src/shared/AppUpdatePrompt.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import type { Update } from '@tauri-apps/plugin-updater';
-import { getState, leaveRoom } from '@features/voice/voice-room';
 import {
   checkForUpdate,
   installUpdateAndRelaunch,
@@ -13,13 +12,16 @@ type PromptState =
   | { kind: 'installing'; update: Update; progress: UpdateProgress }
   | { kind: 'error'; message: string };
 
-function isVoiceRoomActive(): boolean {
+async function leaveActiveVoiceRoom(): Promise<void> {
+  const { getState, leaveRoom } = await import('@features/voice/voice-room');
   const state = getState();
-  return (
+  const isActive =
     state.machineState === 'active' ||
     state.mediaState === 'connecting' ||
-    state.mediaState === 'connected'
-  );
+    state.mediaState === 'connected';
+  if (isActive) {
+    leaveRoom();
+  }
 }
 
 function progressLabel(progress: UpdateProgress): string {
@@ -62,9 +64,6 @@ export default function AppUpdatePrompt() {
 
   const install = () => {
     if (!update) return;
-    if (isVoiceRoomActive()) {
-      leaveRoom();
-    }
 
     setPromptState({
       kind: 'installing',
@@ -72,9 +71,12 @@ export default function AppUpdatePrompt() {
       progress: { downloadedBytes: 0, totalBytes: null },
     });
 
-    void installUpdateAndRelaunch(update, (progress) => {
-      setPromptState({ kind: 'installing', update, progress });
-    }).catch((err) => {
+    void (async () => {
+      await leaveActiveVoiceRoom();
+      await installUpdateAndRelaunch(update, (progress) => {
+        setPromptState({ kind: 'installing', update, progress });
+      });
+    })().catch((err) => {
       setPromptState({
         kind: 'error',
         message: err instanceof Error ? err.message : String(err),

--- a/clients/wavis-gui/vite.config.ts
+++ b/clients/wavis-gui/vite.config.ts
@@ -2,9 +2,11 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
+import { fileURLToPath } from 'node:url';
 
 const host = process.env.TAURI_DEV_HOST;
 const WINDOWS_SHARE_PATH_OVERRIDE_KEY = 'VITE_WAVIS_WINDOWS_SHARE_PATH';
+const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
 export default defineConfig(({ command, mode }) => {
   if (
@@ -19,11 +21,23 @@ export default defineConfig(({ command, mode }) => {
     plugins: [react(), tailwindcss()],
     build: {
       target: ['safari15'],
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (
+              id.includes('/node_modules/livekit-client/') ||
+              id.includes('\\node_modules\\livekit-client\\')
+            ) {
+              return 'livekit-client';
+            }
+          },
+        },
+      },
     },
     resolve: {
       alias: {
-        '@shared': path.resolve(__dirname, './src/shared'),
-        '@features': path.resolve(__dirname, './src/features'),
+        '@shared': path.resolve(rootDir, './src/shared'),
+        '@features': path.resolve(rootDir, './src/features'),
       },
     },
     clearScreen: false,


### PR DESCRIPTION
This PR optimizes the production build size of the Tauri GUI application by:
- Splitting the \livekit-client\ dependency into its own Rollup chunk using \manualChunks\.
- Lazy-loading the voice room features (\getState\, \leaveRoom\, \BugReportFlow\) to reduce the initial main bundle size and improve app load times.
- Updating \ite.config.ts\ resolve path mappings to use \ileURLToPath\ instead of \__dirname\ for standardized ESM compatibility.