### PR TITLE
fix: replace CPAL/ALSA mic capture with pa_simple on Linux

### DIFF
--- a/clients/shared/src/cpal_audio.rs
+++ b/clients/shared/src/cpal_audio.rs
@@ -112,6 +112,10 @@ impl CpalAudioBackend {
     pub fn set_input_gain(&self, gain: f32) {
         *recover_lock(&self.input_gain) = gain.clamp(0.0, 1.0);
     }
+
+    pub fn input_gain_arc(&self) -> Arc<Mutex<f32>> {
+        Arc::clone(&self.input_gain)
+    }
 }
 
 impl AudioBackend for CpalAudioBackend {

--- a/clients/wavis-gui/src-tauri/src/linux_mic.rs
+++ b/clients/wavis-gui/src-tauri/src/linux_mic.rs
@@ -1,0 +1,136 @@
+//! Linux microphone capture via PulseAudio pa_simple.
+//!
+//! Replaces CPAL/ALSA mic capture on Linux to avoid the bundled libasound.so.2
+//! issue in AppImage builds where snd_pcm_open("default") returns ENXIO.
+//! The pa_simple API is already proven to work in AppImage via screen audio capture.
+
+use psimple::Simple;
+use pulse::def::BufferAttr;
+use pulse::sample::{Format, Spec};
+use pulse::stream::Direction;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use wavis_client_shared::cpal_audio::AudioBuffer;
+
+const SAMPLE_RATE: u32 = 48_000;
+const FRAME_SAMPLES: usize = 960; // 20ms at 48 kHz
+const FRAME_BYTES: u32 = (FRAME_SAMPLES * std::mem::size_of::<i16>()) as u32;
+const PA_OPEN_ATTEMPTS: u32 = 3;
+const PA_OPEN_BACKOFF: std::time::Duration = std::time::Duration::from_millis(150);
+
+pub(crate) struct LinuxMicHandle {
+    stop_flag: Arc<AtomicBool>,
+    thread: std::thread::JoinHandle<()>,
+}
+
+impl LinuxMicHandle {
+    pub(crate) fn stop(self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        let _ = self.thread.join();
+    }
+}
+
+pub(crate) fn start_linux_mic_capture(
+    capture_buffer: AudioBuffer,
+    input_gain: Arc<Mutex<f32>>,
+) -> Result<LinuxMicHandle, String> {
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let stop_flag_thread = Arc::clone(&stop_flag);
+
+    let thread = std::thread::Builder::new()
+        .name("pa-mic-capture".into())
+        .spawn(move || mic_capture_loop(&stop_flag_thread, &capture_buffer, &input_gain))
+        .map_err(|e| format!("failed to spawn pa_simple mic thread: {e}"))?;
+
+    Ok(LinuxMicHandle { stop_flag, thread })
+}
+
+fn mic_capture_loop(
+    stop_flag: &AtomicBool,
+    capture_buffer: &AudioBuffer,
+    input_gain: &Mutex<f32>,
+) {
+    let spec = Spec { format: Format::S16le, channels: 1, rate: SAMPLE_RATE };
+    assert!(spec.is_valid());
+
+    let buffer_attr = BufferAttr {
+        maxlength: FRAME_BYTES * 4,
+        tlength: u32::MAX,
+        prebuf: u32::MAX,
+        minreq: u32::MAX,
+        fragsize: FRAME_BYTES,
+    };
+
+    let simple = {
+        let mut last_err = None;
+        let mut opened = None;
+        for attempt in 1..=PA_OPEN_ATTEMPTS {
+            match Simple::new(
+                None,
+                "wavis-mic",
+                Direction::Record,
+                None, // default PA source — PipeWire routes to default mic
+                "mic-capture",
+                &spec,
+                None,
+                Some(&buffer_attr),
+            ) {
+                Ok(s) => {
+                    opened = Some(s);
+                    break;
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[linux_mic] pa_simple open attempt {attempt}/{PA_OPEN_ATTEMPTS}: {e}"
+                    );
+                    last_err = Some(format!("{e}"));
+                    if attempt < PA_OPEN_ATTEMPTS {
+                        std::thread::sleep(PA_OPEN_BACKOFF);
+                    }
+                }
+            }
+        }
+        match opened {
+            Some(s) => s,
+            None => {
+                log::error!(
+                    "[linux_mic] pa_simple mic open failed: {}",
+                    last_err.unwrap_or_default()
+                );
+                return;
+            }
+        }
+    };
+
+    log::info!("[linux_mic] mic capture started (default PA source, 48kHz mono S16le)");
+
+    let mut i16_buf = vec![0i16; FRAME_SAMPLES];
+    let mut f32_buf = vec![0.0f32; FRAME_SAMPLES];
+
+    loop {
+        if stop_flag.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let byte_buf = unsafe {
+            std::slice::from_raw_parts_mut(
+                i16_buf.as_mut_ptr() as *mut u8,
+                FRAME_SAMPLES * std::mem::size_of::<i16>(),
+            )
+        };
+
+        if let Err(e) = simple.read(byte_buf) {
+            log::error!("[linux_mic] pa_simple read error: {e}");
+            break;
+        }
+
+        let gain = *input_gain.lock().unwrap_or_else(|e| e.into_inner());
+        for (f, &s) in f32_buf.iter_mut().zip(i16_buf.iter()) {
+            *f = (s as f32 / 32768.0) * gain;
+        }
+
+        capture_buffer.write_mono(&f32_buf);
+    }
+
+    log::info!("[linux_mic] mic capture stopped");
+}

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -25,6 +25,8 @@ mod audio_capture;
 mod taskbar_toolbar;
 #[cfg(target_os = "linux")]
 mod external_share_helper;
+#[cfg(target_os = "linux")]
+mod linux_mic;
 #[cfg(not(target_os = "linux"))]
 mod external_share_helper {
     pub struct ExternalShareHelperState;

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -1145,6 +1145,8 @@ pub struct MediaState {
     #[cfg(target_os = "linux")]
     local_camera_capture: Mutex<Option<LocalCameraCapture>>,
     #[cfg(target_os = "linux")]
+    linux_mic_handle: Mutex<Option<crate::linux_mic::LinuxMicHandle>>,
+    #[cfg(target_os = "linux")]
     remote_screen_share_stream_port: u16,
     #[cfg(target_os = "linux")]
     native_screen_share_viewers: Arc<Mutex<std::collections::HashMap<String, std::process::Child>>>,
@@ -1250,6 +1252,8 @@ impl MediaState {
             #[cfg(target_os = "linux")]
             local_camera_capture: Mutex::new(None),
             #[cfg(target_os = "linux")]
+            linux_mic_handle: Mutex::new(None),
+            #[cfg(target_os = "linux")]
             remote_screen_share_stream_port,
             #[cfg(target_os = "linux")]
             native_screen_share_viewers: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -1302,13 +1306,39 @@ impl MediaState {
     }
 
     pub fn ensure_audio_streams(&self) -> Result<(), String> {
+        // Stop any existing Linux mic thread before clearing CPAL streams.
+        #[cfg(target_os = "linux")]
+        {
+            if let Ok(mut guard) = self.linux_mic_handle.lock() {
+                if let Some(handle) = guard.take() {
+                    handle.stop();
+                }
+            }
+        }
+
         self.audio
             .stop()
             .map_err(|err| format!("failed to stop audio backend: {err}"))?;
 
+        // On Linux, use pa_simple mic capture to bypass the bundled libasound.so.2
+        // in AppImage builds (which lacks the PipeWire ALSA plugin).
+        #[cfg(not(target_os = "linux"))]
         self.audio
             .capture_mic()
             .map_err(|err| format!("failed to start input device: {err}"))?;
+
+        #[cfg(target_os = "linux")]
+        {
+            let handle = crate::linux_mic::start_linux_mic_capture(
+                self.audio.capture_buffer.clone(),
+                self.audio.input_gain_arc(),
+            )
+            .map_err(|err| format!("failed to start input device: {err}"))?;
+            if let Ok(mut guard) = self.linux_mic_handle.lock() {
+                *guard = Some(handle);
+            }
+        }
+
         self.audio
             .play_remote(AudioTrack {
                 id: "native-playback".to_string(),
@@ -1870,6 +1900,14 @@ pub fn media_disconnect(state: State<'_, MediaState>, app: AppHandle) -> Result<
     if let Ok(mut task_guard) = state.local_meter_task.lock() {
         if let Some(task) = task_guard.take() {
             task.abort();
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(mut guard) = state.linux_mic_handle.lock() {
+            if let Some(handle) = guard.take() {
+                handle.stop();
+            }
         }
     }
     let _ = state.audio.stop();


### PR DESCRIPTION
AppImage builds bundle libasound.so.2 from the Ubuntu CI machine which lacks the PipeWire ALSA plugin, causing snd_pcm_open(default) to return ENXIO. This fix bypasses CPAL/ALSA on Linux entirely and uses pa_simple (already proven in screen audio capture) to read from the default PulseAudio source instead.

## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
