### PR TITLE
 Fixed the audio-only watcher state mismatch

### DIFF
--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -914,6 +914,11 @@ export default function ActiveRoom() {
       return next;
     });
     persistStreamMuted(participantId, muted);
+    if (muted) {
+      detachScreenShareAudio(participantId);
+    } else {
+      attachScreenShareAudio(participantId);
+    }
     setScreenShareAudioVolume(participantId, muted ? 0 : restoredVolume);
     emit('watch-all:restore-volume', { participantId, volume: restoredVolume, muted });
     emit('screen-share:restore-volume', { participantId, volume: restoredVolume, muted });
@@ -935,6 +940,11 @@ export default function ActiveRoom() {
       next.set(participantId, muted);
       return next;
     });
+    if (muted) {
+      detachScreenShareAudio(participantId);
+    } else {
+      attachScreenShareAudio(participantId);
+    }
     setScreenShareAudioVolume(participantId, muted ? 0 : volume);
     persistStreamVolume(participantId, volume);
     persistStreamMuted(participantId, muted);
@@ -1358,7 +1368,7 @@ export default function ActiveRoom() {
 
   // Watch All: sync audio-only sharer additions/removals
   useEffect(() => {
-    if (!roomState || !watchAllOpen || !watchAllReadyRef.current) return;
+    if (!roomState) return;
     const curr = roomState.audioOnlySharers;
     const prev = prevAudioOnlySharersRef.current;
     for (const identity of curr) {
@@ -1374,11 +1384,17 @@ export default function ActiveRoom() {
         next.set(identity, true);
         return next;
       });
-      void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted: true });
+      detachScreenShareAudio(identity);
+      setScreenShareAudioVolume(identity, 0);
+      if (watchAllOpen && watchAllReadyRef.current) {
+        void emit('watch-all:audio-share-added', { participantId: identity, displayName: participant.displayName, color: participant.color, volume: vol, muted: true });
+      }
     }
     for (const identity of prev) {
       if (curr.has(identity)) continue;
-      void emit('watch-all:audio-share-removed', { participantId: identity });
+      if (watchAllOpen && watchAllReadyRef.current) {
+        void emit('watch-all:audio-share-removed', { participantId: identity });
+      }
     }
     prevAudioOnlySharersRef.current = new Set(curr);
   }, [getSavedShareVolume, watchAllOpen, roomState?.audioOnlySharers, roomState?.participants]);

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -3038,7 +3038,7 @@ describe('Screen share and device selection', () => {
         { identity: 'alice' },
       );
 
-      // Subscribe alice's sys-audio track (audio-only share — auto-attaches immediately)
+      // Subscribe alice's sys-audio track, then simulate the user opting in to listen.
       emitRoomEvent(
         'trackSubscribed',
         { kind: 'audio', mediaStreamTrack: { id: 'ssa-alice' } },

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -2588,7 +2588,7 @@ describe('Screen share and device selection', () => {
       mod.disconnect();
     });
 
-    it('infers legacy ScreenShareAudio without video as audio-only and autoplays it', async () => {
+    it('infers legacy ScreenShareAudio without video as audio-only without autoplaying it', async () => {
       resetAll();
       const cbs = createMockCallbacks();
       const mod = new LiveKitModule(cbs);
@@ -2603,8 +2603,8 @@ describe('Screen share and device selection', () => {
       );
 
       const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
-      expect(setSubscribed).toHaveBeenCalledWith(true);
-      expect(audioElementMap.has('alice:screen-share')).toBe(true);
+      expect(setSubscribed).toHaveBeenCalledWith(false);
+      expect(audioElementMap.has('alice:screen-share')).toBe(false);
       expect(cbs.calls).toContainEqual({ method: 'onAudioOnlySharerAdded', args: ['alice'] });
 
       mod.disconnect();
@@ -2626,14 +2626,14 @@ describe('Screen share and device selection', () => {
       await driveToConnected(mod);
 
       const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
-      expect(setSubscribed).toHaveBeenCalledWith(true);
-      expect(audioElementMap.has('alice:screen-share')).toBe(true);
+      expect(setSubscribed).toHaveBeenCalledWith(false);
+      expect(audioElementMap.has('alice:screen-share')).toBe(false);
       expect(cbs.calls).toContainEqual({ method: 'onAudioOnlySharerAdded', args: ['alice'] });
 
       mod.disconnect();
     });
 
-    it('autoplays confirmed audio-only shares and detaches autoplay when promoted to video', async () => {
+    it('keeps confirmed audio-only shares detached until the user unmutes', async () => {
       resetAll();
       const cbs = createMockCallbacks();
       const mod = new LiveKitModule(cbs);
@@ -2649,12 +2649,17 @@ describe('Screen share and device selection', () => {
       );
 
       const audioElementMap = (mod as unknown as { audioElementMap: Map<string, unknown> }).audioElementMap;
+      expect(setSubscribed).toHaveBeenLastCalledWith(false);
+      expect(audioElementMap.has('alice:screen-share')).toBe(false);
+
+      mod.attachScreenShareAudio('alice');
+
+      expect(setSubscribed).toHaveBeenLastCalledWith(true);
       expect(audioElementMap.has('alice:screen-share')).toBe(true);
 
       mod.setRemoteShareType('alice', 'screen_audio');
 
-      expect(setSubscribed).toHaveBeenLastCalledWith(false);
-      expect(audioElementMap.has('alice:screen-share')).toBe(false);
+      expect(audioElementMap.has('alice:screen-share')).toBe(true);
 
       mod.disconnect();
     });

--- a/clients/wavis-gui/src/features/voice/__tests__/preservation.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/preservation.test.ts
@@ -243,7 +243,7 @@ describe('Property 2: Preservation — NativeMediaModule audio IPC baseline', ()
     expect(invoke).toHaveBeenCalledWith('media_set_mic_enabled', { enabled: false });
   });
 
-  it('setRemoteShareType(audio_only) marks native audio-only shares and enables share audio', () => {
+  it('setRemoteShareType(audio_only) marks native audio-only shares without enabling share audio', () => {
     vi.mocked(invoke).mockResolvedValue(undefined);
 
     mod_.setRemoteShareType('peer-a', 'audio_only');
@@ -251,7 +251,7 @@ describe('Property 2: Preservation — NativeMediaModule audio IPC baseline', ()
 
     expect(callbacks.onAudioOnlySharerAdded).toHaveBeenCalledTimes(1);
     expect(callbacks.onAudioOnlySharerAdded).toHaveBeenCalledWith('peer-a');
-    expect(invoke).toHaveBeenCalledWith('media_attach_screen_share_audio', { id: 'peer-a' });
+    expect(invoke).not.toHaveBeenCalledWith('media_attach_screen_share_audio', { id: 'peer-a' });
   });
 
   it('setRemoteShareType(non-audio) removes native audio-only shares and disables share audio', () => {

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -5683,8 +5683,7 @@ export class LiveKitModule {
   }
 
   private shouldPlayScreenShareAudio(participantIdentity: string): boolean {
-    return this.screenShareAudioViewerOwners.has(participantIdentity)
-      || this.remoteShareTypes.get(participantIdentity) === 'audio_only';
+    return this.screenShareAudioViewerOwners.has(participantIdentity);
   }
 
   private syncScreenShareAudioPolicy(participantIdentity: string): void {

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -5641,7 +5641,9 @@ export class LiveKitModule {
           track: screenShareAudioTrack as RemoteTrack,
           participant,
         });
-        this.syncScreenShareAudioPolicy(participant.identity);
+        if (this.shouldPlayScreenShareAudio(participant.identity)) {
+          this.syncScreenShareAudioPolicy(participant.identity);
+        }
       }
     }
 
@@ -5669,6 +5671,13 @@ export class LiveKitModule {
       this.callbacks.onAudioOnlySharerAdded?.(participantIdentity);
     } else if (!isAudioOnly && this.audioOnlySharers.delete(participantIdentity)) {
       this.callbacks.onAudioOnlySharerRemoved?.(participantIdentity);
+    }
+    if (isAudioOnly && !this.screenShareAudioViewerOwners.has(participantIdentity)) {
+      const publication = this.screenShareAudioPublications.get(participantIdentity);
+      if (publication && typeof publication.setSubscribed === 'function') {
+        publication.setSubscribed(false);
+      }
+      return;
     }
     this.syncScreenShareAudioPolicy(participantIdentity);
   }

--- a/clients/wavis-gui/src/features/voice/native-media.ts
+++ b/clients/wavis-gui/src/features/voice/native-media.ts
@@ -404,7 +404,6 @@ export class NativeMediaModule {
         this.audioOnlySharers.add(participantIdentity);
         this.callbacks.onAudioOnlySharerAdded?.(participantIdentity);
       }
-      this.attachScreenShareAudio(participantIdentity);
       return;
     }
 


### PR DESCRIPTION

  - Audio-only share metadata no longer auto-attaches/plays share audio in livekit-media.ts or native-media.ts.
  - New audio-only shares are forced into a local muted/detached state in ActiveRoom.tsx, so the UI starts as “not
    listening”.

  - Unmuting or raising volume now explicitly attaches playback; muting detaches it.
  - Updated the focused expectations in livekit-media.test.ts and preservation.test.ts.
