### PR TITLE
fix: repair desktop updater and Linux audio output

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -49,4 +49,10 @@ ignore = [
 
     # fxhash unmaintained — transitive dep. Consider rustc-hash when upstream migrates.
     "RUSTSEC-2025-0057",
+
+    # quick-xml quadratic/runtime DoS advisories — the remaining instance is
+    # quick-xml 0.39.4 via wayland-scanner 0.31.10, a proc-macro/codegen path.
+    # wayland-scanner has no published release using quick-xml >= 0.41 yet.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1761,12 +1761,6 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
@@ -1790,24 +1784,6 @@ name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
-
-[[package]]
-name = "cookie_store"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "log",
- "publicsuffix",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
-]
 
 [[package]]
 name = "cookie_store"
@@ -1858,6 +1834,19 @@ name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
@@ -2026,19 +2015,15 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.29.6"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "matches",
- "phf 0.10.1",
- "proc-macro2",
- "quote",
+ "phf",
  "smallvec",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2053,13 +2038,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
 dependencies = [
- "quote",
- "syn 2.0.116",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctr"
@@ -2108,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+checksum = "00424da159cc5adcb4eeea7e7b5cb1d96df41f5fa695ec596922181bdc36232a"
 dependencies = [
  "cc",
  "cxx-build",
@@ -2123,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+checksum = "43e05269dbed4dab7072ae0f04ef31799ad189d52ce2ac12710c2997b754f86a"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -2138,9 +2129,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+checksum = "e2f017b07e0da7f425642339faff0edc9f0de6459a18180183d086d1f3381e89"
 dependencies = [
  "clap 4.5.60",
  "codespan-reporting",
@@ -2152,15 +2143,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+checksum = "293d267f43a5778bf3b89fff2a658f081166e7f152d9640e2ee3d917d065a5fc"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.194"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+checksum = "72dd233dc128223fe85d2afa5c617c79743c0f47fb495b69234b5da680d4986a"
 dependencies = [
  "indexmap 2.13.0",
  "proc-macro2",
@@ -2370,6 +2361,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,11 +2432,19 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.20"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "convert_case 0.4.0",
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -2483,14 +2493,8 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "dispatch"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -2499,6 +2503,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
 ]
 
@@ -2552,6 +2558,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
+]
+
+[[package]]
+name = "dom_query"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+dependencies = [
+ "bit-set",
+ "cssparser",
+ "foldhash 0.2.0",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
 ]
 
 [[package]]
@@ -2629,6 +2650,21 @@ checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
 dependencies = [
  "dtoa",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -2836,7 +2872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3116,16 +3152,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,15 +3261,6 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -3403,17 +3420,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -3421,7 +3427,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -3504,7 +3510,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3606,9 +3612,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "global-hotkey"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
 dependencies = [
  "crossbeam-channel",
  "keyboard-types",
@@ -3876,14 +3882,12 @@ checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "html5ever"
-version = "0.29.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -4036,7 +4040,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4056,7 +4060,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4518,18 +4522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kuchikiki"
-version = "0.8.8-speedreader"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
-dependencies = [
- "cssparser",
- "html5ever",
- "indexmap 2.13.0",
- "selectors",
-]
-
-[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4582,6 +4574,15 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -4676,7 +4677,7 @@ checksum = "b6b8cfa2a7656627b4c92c6b9ef929433acd673d5ab3708cda1b18478ac00df4"
 dependencies = [
  "bitflags 2.11.0",
  "cc",
- "convert_case 0.8.0",
+ "convert_case",
  "cookie-factory",
  "libc",
  "libspa-sys",
@@ -4911,21 +4912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "mac-notification-sys"
-version = "0.6.9"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fd3f75411f4725061682ed91f131946e912859d0044d39c4ec0aac818d7621"
+checksum = "fd604973958ddcc11b561193c0fb96ba146506ef2f231ef2e7c35fd2cbc9beca"
 dependencies = [
  "cc",
+ "log",
  "objc2",
  "objc2-foundation",
  "time",
+ "uuid",
 ]
 
 [[package]]
@@ -4948,27 +4945,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.14.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
  "tendril",
-]
-
-[[package]]
-name = "match_token"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.116",
+ "web_atoms",
 ]
 
 [[package]]
@@ -4979,12 +4962,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -5061,7 +5038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -5077,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.17.1"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01c1738382f66ed56b3b9c8119e794a2e23148ac8ea214eda86622d4cb9d415a"
+checksum = "1dd04e60bc0b07438a6771710ee1698f98f6ebbc7f89b61264af1563b8aeb878"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -5090,7 +5067,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -5220,12 +5197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,9 +5217,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.12.0"
+version = "4.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+checksum = "c5b4c1b4f2aa9f25f63a7a49d3dd0ed567b3670da15330a66b29434be899b891"
 dependencies = [
  "futures-lite",
  "log",
@@ -5273,7 +5244,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5375,7 +5346,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -5417,17 +5388,10 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "libc",
  "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
- "objc2-core-text",
- "objc2-core-video",
  "objc2-foundation",
- "objc2-quartz-core",
 ]
 
 [[package]]
@@ -5479,7 +5443,6 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -5609,16 +5572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-javascript-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a1e6550c4caed348956ce3370c9ffeca70bb1dbed4fa96112e7c6170e074586"
-dependencies = [
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5659,17 +5612,6 @@ dependencies = [
  "objc2-core-media",
  "objc2-foundation",
  "objc2-uniform-type-identifiers",
-]
-
-[[package]]
-name = "objc2-security"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
 ]
 
 [[package]]
@@ -5725,8 +5667,6 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
- "objc2-javascript-core",
- "objc2-security",
 ]
 
 [[package]]
@@ -6106,106 +6046,43 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
+ "phf_macros",
+ "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.8.0",
- "phf_shared 0.8.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_shared 0.8.0",
- "rand 0.7.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.5",
+ "fastrand",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -6213,29 +6090,11 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.8.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher 0.3.11",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher 1.0.2",
+ "siphasher",
 ]
 
 [[package]]
@@ -6318,13 +6177,13 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -6508,12 +6367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6653,18 +6506,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -6682,7 +6535,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6719,9 +6572,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6747,20 +6600,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -6778,16 +6617,6 @@ checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6812,15 +6641,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -6835,24 +6655,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -6995,7 +6797,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "cookie",
- "cookie_store 0.22.1",
+ "cookie_store",
  "encoding_rs",
  "futures-channel",
  "futures-core",
@@ -7254,7 +7056,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7267,7 +7069,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7325,7 +7127,7 @@ dependencies = [
  "security-framework 3.6.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7377,15 +7179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
 ]
 
 [[package]]
@@ -7467,12 +7260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
 name = "sdp"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7542,18 +7329,19 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.24.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "cssparser",
  "derive_more",
- "fxhash",
  "log",
- "phf 0.8.0",
- "phf_codegen 0.8.0",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
@@ -7719,24 +7507,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
  "log",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7767,11 +7554,10 @@ dependencies = [
 
 [[package]]
 name = "servo_arc"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
- "nodrop",
  "stable_deref_trait",
 ]
 
@@ -7907,12 +7693,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
@@ -8273,25 +8053,24 @@ dependencies = [
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.11.3",
+ "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -8480,35 +8259,35 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.34.5"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
+checksum = "d1c93047acf68669466a34690ac58cca7010bd1b201e1ec86f1fd0a75d3dd4a9"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.25.0",
  "crossbeam-channel",
- "dispatch",
+ "dbus",
+ "dispatch2",
  "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
  "jni",
- "lazy_static",
  "libc",
  "log",
  "ndk 0.9.0",
- "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
+ "objc2-ui-kit",
  "once_cell",
  "parking_lot",
+ "percent-encoding",
  "raw-window-handle",
- "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
@@ -8560,9 +8339,9 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tauri"
-version = "2.10.2"
+version = "2.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463ae8677aa6d0f063a900b9c41ecd4ac2b7ca82f0b058cc4491540e55b20129"
+checksum = "667b20e2726d572dea2de7370da16e188eb06008faf9a92fab7cdc46791190b5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -8611,9 +8390,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.5.5"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca7bd893329425df750813e95bd2b643d5369d929438da96d5bbb7cc2c918f74"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -8627,15 +8406,14 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "tauri-winres",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-codegen"
-version = "2.5.4"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac423e5859d9f9ccdd32e3cf6a5866a15bedbf25aa6630bcb2acde9468f6ae3"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -8660,9 +8438,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.5.4"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a1bd2861ff0c8766b1d38b32a6a410f6dc6532d4ef534c47cfb2236092f59"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -8674,9 +8452,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin"
-version = "2.5.3"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692a77abd8b8773e107a42ec0e05b767b8d2b7ece76ab36c6c3947e34df9f53f"
+checksum = "74be5dd4bed9afbd145e5716b5fa2ec28cbc29c34ffa61c258c9273d896c8020"
 dependencies = [
  "anyhow",
  "glob",
@@ -8685,7 +8463,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "toml 0.9.12+spec-1.1.0",
  "walkdir",
 ]
 
@@ -8706,13 +8483,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.5"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -8722,15 +8501,15 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "url",
 ]
 
 [[package]]
 name = "tauri-plugin-global-shortcut"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424af23c7e88d05e4a1a6fc2c7be077912f8c76bd7900fd50aa2b7cbf5a2c405"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
 dependencies = [
  "global-hotkey",
  "log",
@@ -8743,12 +8522,12 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-http"
-version = "2.5.7"
+version = "2.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f069451c4e87e7e2636b7f065a4c52866c4ce5e60e2d53fa1038edb6d184dc"
+checksum = "b5bd512048e1985b7ec78f96d99083e2ddaf7e0d906b2b63c44ce5bb8b894067"
 dependencies = [
  "bytes",
- "cookie_store 0.21.1",
+ "cookie_store",
  "data-url",
  "http 1.4.0",
  "regex",
@@ -8839,9 +8618,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-store"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca1a8ff83c269b115e98726ffc13f9e548a10161544a92ad121d6d0a96e16ea"
+checksum = "6c72dda16786eb4a3f903e43a17b64d8d78dc0f00fe2aa4b757c28f617a8630b"
 dependencies = [
  "dunce",
  "serde",
@@ -8888,9 +8667,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.10.0"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b885ffeac82b00f1f6fd292b6e5aabfa7435d537cef57d11e38a489956535651"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -8913,9 +8692,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5204682391625e867d16584fedc83fc292fb998814c9f7918605c789cd876314"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http 1.4.0",
@@ -8923,7 +8702,6 @@ dependencies = [
  "log",
  "objc2",
  "objc2-app-kit",
- "objc2-foundation",
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
@@ -8940,24 +8718,24 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.8.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd169fccdff05eff2c1033210b9b94acd07a47e6fa9a3431cf09cfd4f01c87e"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
  "cargo_metadata",
  "ctor",
+ "dom_query",
  "dunce",
  "glob",
- "html5ever",
  "http 1.4.0",
  "infer",
  "json-patch",
- "kuchikiki",
  "log",
  "memchr",
- "phf 0.11.3",
+ "phf",
+ "plist",
  "proc-macro2",
  "quote",
  "regex",
@@ -8989,11 +8767,10 @@ dependencies = [
 
 [[package]]
 name = "tauri-winrt-notification"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+checksum = "9ed071c670382e85fc2f48ae706492d8c338f4f89bf72520d32f8abfe880aade"
 dependencies = [
- "quick-xml 0.37.5",
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-version",
@@ -9009,18 +8786,16 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
 dependencies = [
- "futf",
- "mac",
- "utf-8",
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -9301,6 +9076,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9314,6 +9104,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -9489,9 +9288,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.21.3"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e85aa143ceb072062fc4d6356c1b520a51d636e7bc8e77ec94be3608e5e80c"
+checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -9503,7 +9302,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation",
  "once_cell",
- "png 0.17.16",
+ "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
@@ -9897,12 +9696,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -10144,7 +9937,7 @@ dependencies = [
  "base64 0.22.1",
  "block2",
  "core-foundation 0.10.1",
- "core-graphics",
+ "core-graphics 0.24.0",
  "cpal",
  "dotenvy",
  "drm-fourcc",
@@ -10189,9 +9982,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee64194ccd96bf648f42a65a7e589547096dfa702f7cadef84347b66ad164f9"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -10203,9 +9996,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.12"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e6faa537fbb6c186cb9f1d41f2f811a4120d1b57ec61f50da451a0c5122bec"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
  "bitflags 2.11.0",
  "rustix 1.1.3",
@@ -10215,9 +10008,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.10"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baeda9ffbcfc8cd6ddaade385eaf2393bd2115a69523c735f12242353c3df4f3"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -10227,9 +10020,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9597cdf02cf0c34cd5823786dce6b5ae8598f05c2daf5621b6e178d4f7345f3"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -10240,20 +10033,20 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.8"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5423e94b6a63e68e439803a3e153a9252d5ead12fd853334e2ad33997e3889e3"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
 [[package]]
 name = "wayland-server"
-version = "0.31.11"
+version = "0.31.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9297ab90f8d1f597711d36455c5b1b2290eca59b8134485e377a296b80b118c9"
+checksum = "cc1846eb04c49182e04f4a099e2a830a2b745610bbc1d61246e206f29c7000a0"
 dependencies = [
  "bitflags 2.11.0",
  "downcast-rs",
@@ -10264,9 +10057,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.8"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "libc",
@@ -10293,6 +10086,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]
@@ -10679,7 +10484,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11390,24 +11195,23 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "wry"
-version = "0.54.2"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb26159b420aa77684589a744ae9a9461a95395b848764ad12290a14d960a11a"
+checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
  "block2",
  "cookie",
  "crossbeam-channel",
  "dirs",
+ "dom_query",
  "dpi",
  "dunce",
  "gdkx11",
  "gtk",
- "html5ever",
  "http 1.4.0",
  "javascriptcore-rs",
  "jni",
- "kuchikiki",
  "libc",
  "ndk 0.9.0",
  "objc2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10138,7 +10138,7 @@ dependencies = [
 
 [[package]]
 name = "wavis-gui"
-version = "0.1.3"
+version = "0.2.2"
 dependencies = [
  "ashpd",
  "base64 0.22.1",

--- a/clients/wavis-gui/package.json
+++ b/clients/wavis-gui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wavis-gui",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "patch:livekit": "node ./scripts/apply-livekit-transceiver-reuse-fix.mjs",

--- a/clients/wavis-gui/src-tauri/Cargo.toml
+++ b/clients/wavis-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavis-gui"
-version = "0.1.3"
+version = "0.2.2"
 description = "Wavis native voice client"
 authors = ["Wavis"]
 edition = "2021"

--- a/clients/wavis-gui/src-tauri/src/linux_mic.rs
+++ b/clients/wavis-gui/src-tauri/src/linux_mic.rs
@@ -1,8 +1,8 @@
-//! Linux microphone capture via PulseAudio pa_simple.
+//! Linux audio I/O via PulseAudio pa_simple.
 //!
 //! Replaces CPAL/ALSA mic capture on Linux to avoid the bundled libasound.so.2
 //! issue in AppImage builds where snd_pcm_open("default") returns ENXIO.
-//! The pa_simple API is already proven to work in AppImage via screen audio capture.
+//! Speaker playback uses the same path for the same reason.
 
 use psimple::Simple;
 use pulse::def::BufferAttr;
@@ -30,6 +30,18 @@ impl LinuxMicHandle {
     }
 }
 
+pub(crate) struct LinuxPlaybackHandle {
+    stop_flag: Arc<AtomicBool>,
+    thread: std::thread::JoinHandle<()>,
+}
+
+impl LinuxPlaybackHandle {
+    pub(crate) fn stop(self) {
+        self.stop_flag.store(true, Ordering::Relaxed);
+        let _ = self.thread.join();
+    }
+}
+
 pub(crate) fn start_linux_mic_capture(
     capture_buffer: AudioBuffer,
     input_gain: Arc<Mutex<f32>>,
@@ -45,12 +57,26 @@ pub(crate) fn start_linux_mic_capture(
     Ok(LinuxMicHandle { stop_flag, thread })
 }
 
-fn mic_capture_loop(
-    stop_flag: &AtomicBool,
-    capture_buffer: &AudioBuffer,
-    input_gain: &Mutex<f32>,
-) {
-    let spec = Spec { format: Format::S16le, channels: 1, rate: SAMPLE_RATE };
+pub(crate) fn start_linux_playback(
+    playback_buffer: AudioBuffer,
+) -> Result<LinuxPlaybackHandle, String> {
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let stop_flag_thread = Arc::clone(&stop_flag);
+
+    let thread = std::thread::Builder::new()
+        .name("pa-speaker-playback".into())
+        .spawn(move || playback_loop(&stop_flag_thread, &playback_buffer))
+        .map_err(|e| format!("failed to spawn pa_simple playback thread: {e}"))?;
+
+    Ok(LinuxPlaybackHandle { stop_flag, thread })
+}
+
+fn mic_capture_loop(stop_flag: &AtomicBool, capture_buffer: &AudioBuffer, input_gain: &Mutex<f32>) {
+    let spec = Spec {
+        format: Format::S16le,
+        channels: 1,
+        rate: SAMPLE_RATE,
+    };
     assert!(spec.is_valid());
 
     let buffer_attr = BufferAttr {
@@ -133,4 +159,96 @@ fn mic_capture_loop(
     }
 
     log::info!("[linux_mic] mic capture stopped");
+}
+
+fn playback_loop(stop_flag: &AtomicBool, playback_buffer: &AudioBuffer) {
+    let spec = Spec {
+        format: Format::S16le,
+        channels: 1,
+        rate: SAMPLE_RATE,
+    };
+    assert!(spec.is_valid());
+
+    let buffer_attr = BufferAttr {
+        maxlength: FRAME_BYTES * 4,
+        tlength: FRAME_BYTES * 2,
+        prebuf: 0,
+        minreq: FRAME_BYTES,
+        fragsize: u32::MAX,
+    };
+
+    let simple = {
+        let mut last_err = None;
+        let mut opened = None;
+        for attempt in 1..=PA_OPEN_ATTEMPTS {
+            match Simple::new(
+                None,
+                "wavis-speaker",
+                Direction::Playback,
+                None, // default PA sink — PipeWire routes to current output
+                "speaker-playback",
+                &spec,
+                None,
+                Some(&buffer_attr),
+            ) {
+                Ok(s) => {
+                    opened = Some(s);
+                    break;
+                }
+                Err(e) => {
+                    log::warn!(
+                        "[linux_mic] pa_simple playback open attempt {attempt}/{PA_OPEN_ATTEMPTS}: {e}"
+                    );
+                    last_err = Some(format!("{e}"));
+                    if attempt < PA_OPEN_ATTEMPTS {
+                        std::thread::sleep(PA_OPEN_BACKOFF);
+                    }
+                }
+            }
+        }
+        match opened {
+            Some(s) => s,
+            None => {
+                log::error!(
+                    "[linux_mic] pa_simple playback open failed: {}",
+                    last_err.unwrap_or_default()
+                );
+                return;
+            }
+        }
+    };
+
+    log::info!("[linux_mic] speaker playback started (default PA sink, 48kHz mono S16le)");
+
+    let mut f32_buf = vec![0.0f32; FRAME_SAMPLES];
+    let mut i16_buf = vec![0i16; FRAME_SAMPLES];
+
+    loop {
+        if stop_flag.load(Ordering::Relaxed) {
+            break;
+        }
+
+        let read = playback_buffer.read(&mut f32_buf);
+        if read < f32_buf.len() {
+            f32_buf[read..].fill(0.0);
+        }
+
+        for (dst, &sample) in i16_buf.iter_mut().zip(f32_buf.iter()) {
+            *dst = (sample.clamp(-0.98, 0.98) * 32767.0) as i16;
+        }
+
+        let byte_buf = unsafe {
+            std::slice::from_raw_parts(
+                i16_buf.as_ptr() as *const u8,
+                FRAME_SAMPLES * std::mem::size_of::<i16>(),
+            )
+        };
+
+        if let Err(e) = simple.write(byte_buf) {
+            log::error!("[linux_mic] pa_simple playback write error: {e}");
+            break;
+        }
+    }
+
+    log::info!("[linux_mic] speaker playback stopped");
 }

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -21,12 +21,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod audio_capture;
-#[cfg(target_os = "windows")]
-mod taskbar_toolbar;
 #[cfg(target_os = "linux")]
 mod external_share_helper;
 #[cfg(target_os = "linux")]
 mod linux_mic;
+#[cfg(target_os = "windows")]
+mod taskbar_toolbar;
 #[cfg(not(target_os = "linux"))]
 mod external_share_helper {
     pub struct ExternalShareHelperState;
@@ -387,6 +387,45 @@ use std::process::Command;
 use std::sync::atomic::Ordering;
 use tauri::{Emitter, Manager};
 
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateInstallContext {
+    version: String,
+    current_binary: Option<UpdateBinaryInfo>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateBinaryInfo {
+    path: String,
+    size: Option<u64>,
+    modified_ms: Option<u128>,
+}
+
+#[tauri::command]
+fn get_update_install_context(app: tauri::AppHandle) -> UpdateInstallContext {
+    let version = app.package_info().version.to_string();
+    let current_binary = tauri::process::current_binary(&app.env()).ok().map(|path| {
+        let metadata = std::fs::metadata(&path).ok();
+        let modified_ms = metadata
+            .as_ref()
+            .and_then(|meta| meta.modified().ok())
+            .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+            .map(|duration| duration.as_millis());
+
+        UpdateBinaryInfo {
+            path: path.display().to_string(),
+            size: metadata.as_ref().map(|meta| meta.len()),
+            modified_ms,
+        }
+    });
+
+    UpdateInstallContext {
+        version,
+        current_binary,
+    }
+}
+
 fn main() {
     // Load .env in debug builds so WAVIS_* vars work without manually exporting them.
     // dotenvy searches from CWD upward, so it finds clients/wavis-gui/.env from src-tauri/.
@@ -425,13 +464,12 @@ fn main() {
                 .level(log::LevelFilter::Info)
                 .clear_targets()
                 .target(
-                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout)
-                        .filter({
-                            let min = debug_env::tauri_log_level()
-                                .to_level()
-                                .unwrap_or(log::Level::Warn);
-                            move |metadata| metadata.level() <= min
-                        }),
+                    tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout).filter({
+                        let min = debug_env::tauri_log_level()
+                            .to_level()
+                            .unwrap_or(log::Level::Warn);
+                        move |metadata| metadata.level() <= min
+                    }),
                 )
                 .target(tauri_plugin_log::Target::new(
                     tauri_plugin_log::TargetKind::Dispatch(log_layer),
@@ -568,6 +606,7 @@ fn main() {
             get_linux_desktop_context,
             bug_report::get_rust_log_buffer,
             bug_report::capture_window_screenshot,
+            get_update_install_context,
             media::media_connect,
             media::media_disconnect,
             media::media_set_mic_enabled,

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -8,6 +8,8 @@
 use serde::Serialize;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
+#[cfg(target_os = "linux")]
+use std::process::{Child, Command, Stdio};
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(target_os = "linux")]
@@ -20,10 +22,6 @@ use std::{
     io::{Read, Write},
     net::{TcpListener, TcpStream},
     time::Duration,
-};
-#[cfg(target_os = "linux")]
-use std::{
-    process::{Child, Command, Stdio},
 };
 use tauri::{AppHandle, Emitter, State};
 use tokio::runtime::{Builder, Runtime};
@@ -1029,14 +1027,11 @@ fn wait_for_first_pollable_frame(
                     || diag.timing.first_raw_to_pollable_frame_ms.is_some()
                     || diag.first_raw_frame_latency_ms.is_some()
                     || diag.first_buffered_jpeg_latency_ms.is_some()
-                    || diag
-                        .startup_step_timings
-                        .iter()
-                        .any(|timing| {
-                            timing.stage == "first_frame_arrived"
-                                || timing.stage == "first_buffered_jpeg"
-                                || timing.stage == "first_pollable_frame_written"
-                        })
+                    || diag.startup_step_timings.iter().any(|timing| {
+                        timing.stage == "first_frame_arrived"
+                            || timing.stage == "first_buffered_jpeg"
+                            || timing.stage == "first_pollable_frame_written"
+                    })
             })
             .unwrap_or(false);
         if first_frame_processing_started && first_frame_processing_started_at.is_none() {
@@ -1147,6 +1142,8 @@ pub struct MediaState {
     #[cfg(target_os = "linux")]
     linux_mic_handle: Mutex<Option<crate::linux_mic::LinuxMicHandle>>,
     #[cfg(target_os = "linux")]
+    linux_playback_handle: Mutex<Option<crate::linux_mic::LinuxPlaybackHandle>>,
+    #[cfg(target_os = "linux")]
     remote_screen_share_stream_port: u16,
     #[cfg(target_os = "linux")]
     native_screen_share_viewers: Arc<Mutex<std::collections::HashMap<String, std::process::Child>>>,
@@ -1254,6 +1251,8 @@ impl MediaState {
             #[cfg(target_os = "linux")]
             linux_mic_handle: Mutex::new(None),
             #[cfg(target_os = "linux")]
+            linux_playback_handle: Mutex::new(None),
+            #[cfg(target_os = "linux")]
             remote_screen_share_stream_port,
             #[cfg(target_os = "linux")]
             native_screen_share_viewers: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -1314,6 +1313,11 @@ impl MediaState {
                     handle.stop();
                 }
             }
+            if let Ok(mut guard) = self.linux_playback_handle.lock() {
+                if let Some(handle) = guard.take() {
+                    handle.stop();
+                }
+            }
         }
 
         self.audio
@@ -1339,11 +1343,21 @@ impl MediaState {
             }
         }
 
+        #[cfg(not(target_os = "linux"))]
         self.audio
             .play_remote(AudioTrack {
                 id: "native-playback".to_string(),
             })
             .map_err(|err| format!("failed to start output device: {err}"))?;
+
+        #[cfg(target_os = "linux")]
+        {
+            let handle = crate::linux_mic::start_linux_playback(self.audio.playback_buffer.clone())
+                .map_err(|err| format!("failed to start output device: {err}"))?;
+            if let Ok(mut guard) = self.linux_playback_handle.lock() {
+                *guard = Some(handle);
+            }
+        }
 
         let mut capture_guard = self
             .capture_buffer
@@ -1905,6 +1919,11 @@ pub fn media_disconnect(state: State<'_, MediaState>, app: AppHandle) -> Result<
     #[cfg(target_os = "linux")]
     {
         if let Ok(mut guard) = state.linux_mic_handle.lock() {
+            if let Some(handle) = guard.take() {
+                handle.stop();
+            }
+        }
+        if let Ok(mut guard) = state.linux_playback_handle.lock() {
             if let Some(handle) = guard.take() {
                 handle.stop();
             }
@@ -3790,9 +3809,10 @@ pub fn screen_share_start() -> Result<bool, String> {
 #[cfg(all(test, target_os = "windows"))]
 mod windows_capture_routing_tests {
     use super::{
-        is_windows_capture_setup_error, parse_windows_source_kind, select_windows_capture_backend,
-        rgba_to_i420, wait_for_first_pollable_frame, windows_bridge_transport_fps, LatestFrame,
-        windows_i420_stream_frame_header, LatestI420Frame, WindowsCaptureBackend, WindowsSourceKind,
+        is_windows_capture_setup_error, parse_windows_source_kind, rgba_to_i420,
+        select_windows_capture_backend, wait_for_first_pollable_frame,
+        windows_bridge_transport_fps, windows_i420_stream_frame_header, LatestFrame,
+        LatestI420Frame, WindowsCaptureBackend, WindowsSourceKind,
     };
     use crate::screen_capture::frame_processor::ScreenShareConfig;
     use crate::screen_capture::win_capture::WindowsNativeCaptureDiagnostics;
@@ -3838,7 +3858,10 @@ mod windows_capture_routing_tests {
         assert_eq!(u32::from_le_bytes(header[0..4].try_into().unwrap()), 4);
         assert_eq!(u32::from_le_bytes(header[4..8].try_into().unwrap()), 2);
         assert_eq!(u64::from_le_bytes(header[8..16].try_into().unwrap()), 9);
-        assert_eq!(u64::from_le_bytes(header[16..24].try_into().unwrap()), 123_456);
+        assert_eq!(
+            u64::from_le_bytes(header[16..24].try_into().unwrap()),
+            123_456
+        );
         assert_eq!(u32::from_le_bytes(header[24..28].try_into().unwrap()), 12);
     }
 
@@ -3957,16 +3980,23 @@ mod windows_capture_routing_tests {
     #[test]
     fn startup_setup_error_classification_ignores_nonfatal_configuration_errors() {
         assert!(is_windows_capture_setup_error("capture_item_create_error"));
-        assert!(is_windows_capture_setup_error("capture_session_create_error"));
-        assert!(!is_windows_capture_setup_error("cursor_border_config_error"));
-        assert!(!is_windows_capture_setup_error("closed_handler_register_error"));
-        assert!(!is_windows_capture_setup_error("first_pollable_frame_timeout"));
+        assert!(is_windows_capture_setup_error(
+            "capture_session_create_error"
+        ));
+        assert!(!is_windows_capture_setup_error(
+            "cursor_border_config_error"
+        ));
+        assert!(!is_windows_capture_setup_error(
+            "closed_handler_register_error"
+        ));
+        assert!(!is_windows_capture_setup_error(
+            "first_pollable_frame_timeout"
+        ));
     }
 
     #[test]
     fn cursor_border_unsupported_error_does_not_become_primary_first_error() {
-        let mut diagnostics =
-            WindowsNativeCaptureDiagnostics::new("wgc", "screen", 1920, 1080);
+        let mut diagnostics = WindowsNativeCaptureDiagnostics::new("wgc", "screen", 1920, 1080);
 
         diagnostics.record_nonfatal_startup_error(
             "cursor_border_config_error",

--- a/clients/wavis-gui/src-tauri/tauri.conf.json
+++ b/clients/wavis-gui/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Wavis",
-  "version": "0.1.8",
+  "version": "0.2.2",
   "identifier": "com.wavis.desktop",
   "build": {
     "frontendDist": "../dist",

--- a/clients/wavis-gui/src/shared/update-service.ts
+++ b/clients/wavis-gui/src/shared/update-service.ts
@@ -1,5 +1,6 @@
 import { check, type DownloadEvent, type Update } from '@tauri-apps/plugin-updater';
 import { relaunch } from '@tauri-apps/plugin-process';
+import { invoke } from '@tauri-apps/api/core';
 
 export type UpdateCheckResult =
   | { kind: 'none' }
@@ -10,6 +11,40 @@ export type UpdateProgress = {
   downloadedBytes: number;
   totalBytes: number | null;
 };
+
+type UpdateBinaryInfo = {
+  path: string;
+  size: number | null;
+  modifiedMs: number | null;
+};
+
+type UpdateInstallContext = {
+  version: string;
+  currentBinary: UpdateBinaryInfo | null;
+};
+
+function isAppImage(binary: UpdateBinaryInfo | null): boolean {
+  return binary?.path.endsWith('.AppImage') ?? false;
+}
+
+function sameBinaryFile(before: UpdateBinaryInfo | null, after: UpdateBinaryInfo | null): boolean {
+  return (
+    before !== null &&
+    after !== null &&
+    before.path === after.path &&
+    before.size === after.size &&
+    before.modifiedMs === after.modifiedMs
+  );
+}
+
+async function getUpdateInstallContext(): Promise<UpdateInstallContext | null> {
+  try {
+    return await invoke<UpdateInstallContext>('get_update_install_context');
+  } catch (err) {
+    console.warn('[wavis:update] install context unavailable:', err);
+    return null;
+  }
+}
 
 export async function checkForUpdate(): Promise<UpdateCheckResult> {
   try {
@@ -29,6 +64,13 @@ export async function installUpdateAndRelaunch(
 ): Promise<void> {
   let downloadedBytes = 0;
   let totalBytes: number | null = null;
+  const before = await getUpdateInstallContext();
+
+  console.info('[wavis:update] installing update', {
+    currentVersion: before?.version ?? null,
+    updateVersion: update.version,
+    currentBinary: before?.currentBinary ?? null,
+  });
 
   await update.downloadAndInstall((event: DownloadEvent) => {
     switch (event.event) {
@@ -46,6 +88,24 @@ export async function installUpdateAndRelaunch(
         break;
     }
   });
+
+  const after = await getUpdateInstallContext();
+  console.info('[wavis:update] install command completed', {
+    currentVersion: after?.version ?? null,
+    updateVersion: update.version,
+    currentBinaryBefore: before?.currentBinary ?? null,
+    currentBinaryAfter: after?.currentBinary ?? null,
+  });
+
+  if (
+    isAppImage(before?.currentBinary ?? null) &&
+    sameBinaryFile(before?.currentBinary ?? null, after?.currentBinary ?? null)
+  ) {
+    throw new Error(
+      `Update install finished but did not modify ${before?.currentBinary?.path}. ` +
+        'Move the AppImage to a writable local folder and try again.',
+    );
+  }
 
   await relaunch();
 }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -127,23 +127,6 @@ workflows:
             echo "No artifacts found to upload."
             exit 1
           fi
-      - name: Update latest.json for updater
-        script: |
-          if [ -z "$CM_TAG" ]; then exit 0; fi
-          export GH_TOKEN="$GITHUB_TOKEN"
-          sudo apt-get install -y jq || true
-          VERSION="${CM_TAG#desktop-v}"
-          REPO="TommasoRibaudo/wavis-public"
-          shopt -s nullglob
-          sig_files=(target/release/bundle/appimage/*.AppImage.sig)
-          if [ ${#sig_files[@]} -eq 0 ]; then
-            echo "No .sig file found, skipping latest.json update."
-            exit 0
-          fi
-          appimage_files=(target/release/bundle/appimage/*.AppImage)
-          ARTIFACT_NAME=$(basename "${appimage_files[0]}")
-          ARTIFACT_URL="https://github.com/${REPO}/releases/download/${CM_TAG}/${ARTIFACT_NAME}"
-          bash scripts/update-latest-json.sh "$CM_TAG" "$VERSION" "linux-x86_64" "$ARTIFACT_URL" "${sig_files[0]}"
     artifacts:
       - target/release/bundle/appimage/*.AppImage
       - target/release/bundle/appimage/*.AppImage.sig
@@ -231,44 +214,6 @@ workflows:
           if ($artifacts) {
             gh release upload $env:CM_TAG $artifacts --clobber
           }
-      - name: Update latest.json for updater
-        script: |
-          if (-not $env:CM_TAG) { exit 0 }
-          $env:GH_TOKEN = $env:GITHUB_TOKEN
-          $version = $env:CM_TAG -replace '^desktop-v', ''
-          $repo = "TommasoRibaudo/wavis-public"
-
-          $sigFiles = Get-ChildItem target/release/bundle/nsis/*-setup.exe.sig -ErrorAction SilentlyContinue
-          if (-not $sigFiles) {
-            Write-Host "No .sig file found, skipping latest.json update."
-            exit 0
-          }
-          $signature = Get-Content $sigFiles[0].FullName -Raw
-          $exeName = ($sigFiles[0].Name -replace '\.sig$', '')
-          $url = "https://github.com/$repo/releases/download/$($env:CM_TAG)/$exeName"
-          $pubDate = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-
-          # Try to download existing latest.json
-          $existing = '{}'
-          try {
-            gh release download $env:CM_TAG --pattern "latest.json" --dir $env:TEMP --repo $repo --clobber 2>$null
-            if (Test-Path "$env:TEMP/latest.json") {
-              $existing = Get-Content "$env:TEMP/latest.json" -Raw
-            }
-          } catch {}
-
-          $json = $existing | ConvertFrom-Json
-          if (-not $json.platforms) { $json | Add-Member -NotePropertyName platforms -NotePropertyValue @{} -Force }
-          $json.version = $version
-          $json.pub_date = $pubDate
-          if (-not $json.notes) { $json | Add-Member -NotePropertyName notes -NotePropertyValue "" -Force }
-          $json.platforms | Add-Member -NotePropertyName "windows-x86_64" -NotePropertyValue @{url=$url; signature=$signature.Trim()} -Force
-
-          $jsonStr = $json | ConvertTo-Json -Depth 10
-          [System.IO.File]::WriteAllText("$env:TEMP/latest.json", $jsonStr, [System.Text.UTF8Encoding]::new($false))
-          Write-Host "Generated latest.json with platform windows-x86_64"
-          Get-Content "$env:TEMP/latest.json"
-          gh release upload $env:CM_TAG "$env:TEMP/latest.json" --repo $repo --clobber
     artifacts:
       - target/release/bundle/nsis/*.exe
       - target/release/bundle/nsis/*.exe.sig
@@ -358,32 +303,6 @@ workflows:
             echo "No artifacts found to upload."
             exit 1
           fi
-      - name: Update latest.json for updater
-        script: |
-          if [ -z "$CM_TAG" ]; then exit 0; fi
-          export GH_TOKEN="$GITHUB_TOKEN"
-          VERSION="${CM_TAG#desktop-v}"
-          REPO="TommasoRibaudo/wavis-public"
-          shopt -s nullglob
-          sig_files=(target/release/bundle/macos/*.app.tar.gz.sig)
-          if [ ${#sig_files[@]} -eq 0 ]; then
-            # Fallback: check for dmg sig if tar.gz sig doesn't exist
-            sig_files=(target/release/bundle/dmg/*.dmg.sig)
-          fi
-          if [ ${#sig_files[@]} -eq 0 ]; then
-            echo "No .sig file found, skipping latest.json update."
-            exit 0
-          fi
-          # Find the corresponding updater artifact (prefer .app.tar.gz, fallback to .dmg)
-          tar_files=(target/release/bundle/macos/*.app.tar.gz)
-          if [ ${#tar_files[@]} -gt 0 ]; then
-            ARTIFACT_NAME=$(basename "${tar_files[0]}")
-          else
-            dmg_files=(target/release/bundle/dmg/*.dmg)
-            ARTIFACT_NAME=$(basename "${dmg_files[0]}")
-          fi
-          ARTIFACT_URL="https://github.com/${REPO}/releases/download/${CM_TAG}/${ARTIFACT_NAME}"
-          bash scripts/update-latest-json.sh "$CM_TAG" "$VERSION" "darwin-aarch64" "$ARTIFACT_URL" "${sig_files[0]}"
     artifacts:
       - target/release/bundle/dmg/*.dmg
       - target/release/bundle/macos/*.app.tar.gz

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 // Usage: node scripts/bump-version.js <version>
 //
-// Updates the version field in both:
+// Updates the version field in:
 //   clients/wavis-gui/src-tauri/tauri.conf.json
+//   clients/wavis-gui/src-tauri/Cargo.toml
 //   clients/wavis-gui/package.json
+//   clients/wavis-gui/package-lock.json
 //
 // Run this before committing and tagging a release:
 //   node scripts/bump-version.js 0.2.0
-//   git add clients/wavis-gui/src-tauri/tauri.conf.json clients/wavis-gui/package.json
+//   git add clients/wavis-gui/src-tauri/tauri.conf.json clients/wavis-gui/src-tauri/Cargo.toml clients/wavis-gui/package.json clients/wavis-gui/package-lock.json
 //   git commit -m "chore: bump version to 0.2.0"
 //   git tag desktop-v0.2.0
 //   git push && git push --tags
@@ -36,9 +38,33 @@ function bump(filePath, mutate) {
 
 bump(join(root, 'clients/wavis-gui/src-tauri/tauri.conf.json'), o => { o.version = version; });
 bump(join(root, 'clients/wavis-gui/package.json'),              o => { o.version = version; });
+bump(join(root, 'clients/wavis-gui/package-lock.json'),         o => {
+  o.version = version;
+  if (o.packages?.['']) {
+    o.packages[''].version = version;
+  }
+});
+
+function bumpCargoToml(filePath) {
+  const raw = readFileSync(filePath, 'utf8');
+  const next = raw.replace(
+    /^(\[package\]\s*\nname = "wavis-gui"\s*\nversion = )"[^"]+"/m,
+    `$1"${version}"`,
+  );
+
+  if (next === raw) {
+    console.error(`Could not update package version in ${filePath}`);
+    process.exit(1);
+  }
+
+  writeFileSync(filePath, next);
+  console.log(`${filePath.replace(root + '/', '')}:  version -> ${version}`);
+}
+
+bumpCargoToml(join(root, 'clients/wavis-gui/src-tauri/Cargo.toml'));
 
 console.log(`\nNext steps:`);
-console.log(`  git add clients/wavis-gui/src-tauri/tauri.conf.json clients/wavis-gui/package.json`);
+console.log(`  git add clients/wavis-gui/src-tauri/tauri.conf.json clients/wavis-gui/src-tauri/Cargo.toml clients/wavis-gui/package.json clients/wavis-gui/package-lock.json`);
 console.log(`  git commit -m "chore: bump version to ${version}"`);
 console.log(`  git tag desktop-v${version}`);
 console.log(`  git push && git push --tags`);


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
