### PR TITLE
fixing for clippy and cargo tests

### DIFF
--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -5,6 +5,8 @@
 //! JS SDK. The interface mirrors LiveKitModule's shape so voice-room.ts can
 //! swap transparently.
 
+#[cfg(target_os = "windows")]
+use serde::Deserialize;
 use serde::Serialize;
 #[cfg(target_os = "windows")]
 use std::os::windows::process::CommandExt;
@@ -42,6 +44,19 @@ use crate::screen_capture;
 const LOG: &str = "[wavis:native-media]";
 #[cfg(target_os = "windows")]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+#[cfg(target_os = "windows")]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WindowsScreenShareStartSourceRequest {
+    source_id: String,
+    share_session_id: Option<String>,
+    source_kind: Option<String>,
+    capture_backend: Option<String>,
+    compatibility_mode: Option<bool>,
+    previous_backend: Option<String>,
+    retry_reason: Option<String>,
+}
 
 #[cfg(target_os = "windows")]
 fn unix_now_ms() -> u64 {
@@ -2644,13 +2659,7 @@ pub fn screen_share_start_source(
 #[tauri::command]
 #[cfg(target_os = "windows")]
 pub fn screen_share_start_source(
-    source_id: String,
-    share_session_id: Option<String>,
-    source_kind: Option<String>,
-    capture_backend: Option<String>,
-    compatibility_mode: Option<bool>,
-    previous_backend: Option<String>,
-    retry_reason: Option<String>,
+    request: WindowsScreenShareStartSourceRequest,
     state: State<'_, MediaState>,
     app: AppHandle,
 ) -> Result<bool, String> {
@@ -2660,6 +2669,16 @@ pub fn screen_share_start_source(
         WinCapture, WinCaptureConfig, WinCaptureSourceKind, WindowsNativeCaptureDiagnostics,
     };
     use screen_capture::ScreenCapture;
+
+    let WindowsScreenShareStartSourceRequest {
+        source_id,
+        share_session_id,
+        source_kind,
+        capture_backend,
+        compatibility_mode,
+        previous_backend,
+        retry_reason,
+    } = request;
 
     let source_kind = parse_windows_source_kind(source_kind.as_deref())?;
     let capture_backend = select_windows_capture_backend(
@@ -2939,13 +2958,15 @@ pub fn screen_share_start_source(
                 let raw_to_pollable_frame_ms = raw_to_pollable_start.elapsed().as_millis() as u64;
                 if let Ok(mut diag_guard) = diagnostics_for_frames.lock() {
                     diag_guard.record_pollable_frame_timing(
-                        cap_downscale_ms,
-                        i420_convert_ms,
-                        0,
-                        0,
-                        0,
-                        i420_write_ms,
-                        raw_to_pollable_frame_ms,
+                        screen_capture::win_capture::PollableFrameTiming {
+                            cap_downscale_ms,
+                            i420_convert_ms,
+                            rgba_to_rgb_ms: 0,
+                            jpeg_encode_ms: 0,
+                            base64_encode_ms: 0,
+                            latest_frame_write_ms: i420_write_ms,
+                            raw_to_pollable_frame_ms,
+                        },
                     );
                 }
                 if let Ok(mut leak_guard) = native_share_leak_session.lock() {
@@ -3069,13 +3090,15 @@ pub fn screen_share_start_source(
             let raw_to_pollable_frame_ms = raw_to_pollable_start.elapsed().as_millis() as u64;
             if let Ok(mut diag_guard) = diagnostics_for_frames.lock() {
                 diag_guard.record_pollable_frame_timing(
-                    cap_downscale_ms,
-                    i420_convert_ms,
-                    rgba_to_rgb_ms,
-                    jpeg_encode_ms,
-                    base64_encode_ms,
-                    latest_frame_write_ms,
-                    raw_to_pollable_frame_ms,
+                    screen_capture::win_capture::PollableFrameTiming {
+                        cap_downscale_ms,
+                        i420_convert_ms,
+                        rgba_to_rgb_ms,
+                        jpeg_encode_ms,
+                        base64_encode_ms,
+                        latest_frame_write_ms,
+                        raw_to_pollable_frame_ms,
+                    },
                 );
             }
             let mut first_pollable_elapsed_ms = raw_to_pollable_frame_ms;
@@ -4057,6 +4080,11 @@ mod windows_capture_routing_tests {
         let diagnostics = Arc::new(Mutex::new(WindowsNativeCaptureDiagnostics::new(
             "wgc", "screen", 1920, 1080,
         )));
+        {
+            let mut diag = diagnostics.lock().unwrap();
+            diag.record_startup_stage("first_frame_arrived", "FrameArrived callback", 10);
+            diag.frame_arrived_callbacks = 1;
+        }
         let latest_i420_for_thread = latest_i420_frame.clone();
         let writer = thread::spawn(move || {
             thread::sleep(Duration::from_millis(15));

--- a/clients/wavis-gui/src-tauri/src/screen_capture/win_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture/win_capture.rs
@@ -135,6 +135,16 @@ pub struct WindowsNativeCaptureTiming {
     pub first_raw_to_pollable_frame_ms: Option<u64>,
 }
 
+pub struct PollableFrameTiming {
+    pub cap_downscale_ms: u64,
+    pub i420_convert_ms: u64,
+    pub rgba_to_rgb_ms: u64,
+    pub jpeg_encode_ms: u64,
+    pub base64_encode_ms: u64,
+    pub latest_frame_write_ms: u64,
+    pub raw_to_pollable_frame_ms: u64,
+}
+
 impl WindowsNativeCaptureDiagnostics {
     pub fn new(backend: &str, source_kind: &str, item_width: u32, item_height: u32) -> Self {
         Self {
@@ -240,30 +250,24 @@ impl WindowsNativeCaptureDiagnostics {
         self.refresh_interval_rates();
     }
 
-    pub fn record_pollable_frame_timing(
-        &mut self,
-        cap_downscale_ms: u64,
-        i420_convert_ms: u64,
-        rgba_to_rgb_ms: u64,
-        jpeg_encode_ms: u64,
-        base64_encode_ms: u64,
-        latest_frame_write_ms: u64,
-        raw_to_pollable_frame_ms: u64,
-    ) {
+    pub fn record_pollable_frame_timing(&mut self, timing: PollableFrameTiming) {
         self.emitted_pollable_frames = self.emitted_pollable_frames.saturating_add(1);
         let n = self.emitted_pollable_frames as f64;
         let update = |avg: &mut f64, value: u64| {
             *avg = ((*avg * (n - 1.0)) + value as f64) / n;
         };
-        update(&mut self.cap_downscale_avg_ms, cap_downscale_ms);
-        update(&mut self.i420_convert_avg_ms, i420_convert_ms);
-        update(&mut self.rgba_to_rgb_avg_ms, rgba_to_rgb_ms);
-        update(&mut self.jpeg_encode_avg_ms, jpeg_encode_ms);
-        update(&mut self.base64_encode_avg_ms, base64_encode_ms);
-        update(&mut self.latest_frame_write_avg_ms, latest_frame_write_ms);
+        update(&mut self.cap_downscale_avg_ms, timing.cap_downscale_ms);
+        update(&mut self.i420_convert_avg_ms, timing.i420_convert_ms);
+        update(&mut self.rgba_to_rgb_avg_ms, timing.rgba_to_rgb_ms);
+        update(&mut self.jpeg_encode_avg_ms, timing.jpeg_encode_ms);
+        update(&mut self.base64_encode_avg_ms, timing.base64_encode_ms);
+        update(
+            &mut self.latest_frame_write_avg_ms,
+            timing.latest_frame_write_ms,
+        );
         update(
             &mut self.raw_to_pollable_frame_avg_ms,
-            raw_to_pollable_frame_ms,
+            timing.raw_to_pollable_frame_ms,
         );
         self.refresh_interval_rates();
     }
@@ -1586,7 +1590,7 @@ impl Drop for WinCapture {
 
 #[cfg(test)]
 mod tests {
-    use super::{staging_texture_matches, WindowsNativeCaptureDiagnostics};
+    use super::{staging_texture_matches, PollableFrameTiming, WindowsNativeCaptureDiagnostics};
 
     #[test]
     fn staging_texture_is_reused_only_for_matching_dimensions_and_format() {
@@ -1681,8 +1685,24 @@ mod tests {
         diag.record_backend_callback();
         diag.record_backend_callback();
         diag.record_throttle_drop();
-        diag.record_pollable_frame_timing(1, 2, 3, 4, 5, 6, 7);
-        diag.record_pollable_frame_timing(3, 4, 5, 6, 7, 8, 9);
+        diag.record_pollable_frame_timing(PollableFrameTiming {
+            cap_downscale_ms: 1,
+            i420_convert_ms: 2,
+            rgba_to_rgb_ms: 3,
+            jpeg_encode_ms: 4,
+            base64_encode_ms: 5,
+            latest_frame_write_ms: 6,
+            raw_to_pollable_frame_ms: 7,
+        });
+        diag.record_pollable_frame_timing(PollableFrameTiming {
+            cap_downscale_ms: 3,
+            i420_convert_ms: 4,
+            rgba_to_rgb_ms: 5,
+            jpeg_encode_ms: 6,
+            base64_encode_ms: 7,
+            latest_frame_write_ms: 8,
+            raw_to_pollable_frame_ms: 9,
+        });
 
         assert_eq!(diag.frame_arrived_callbacks, 2);
         assert_eq!(diag.throttle_drop_count, 1);

--- a/clients/wavis-gui/src-tauri/src/taskbar_toolbar.rs
+++ b/clients/wavis-gui/src-tauri/src/taskbar_toolbar.rs
@@ -7,8 +7,6 @@
 //!
 //! Reuses `tray-event` and `tray-state-update` events — no frontend changes needed.
 
-#![cfg(target_os = "windows")]
-
 use std::sync::{
     atomic::{AtomicIsize, Ordering},
     Mutex,

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-audio-share.test.ts
@@ -33,7 +33,10 @@ let sentMessages: Array<Record<string, unknown>>;
 let messageHandler: ((msg: unknown) => void) | null;
 
 /** Tracks invoke calls — key is command name, value is array of arg objects. */
-let invokeCalls: Array<{ command: string; args?: Record<string, unknown> }>;
+type MockInvokeArgs = Record<string, unknown> & {
+  request?: Record<string, unknown>;
+};
+let invokeCalls: Array<{ command: string; args?: MockInvokeArgs }>;
 let tauriListeners: Map<string, Set<(event: { payload: unknown }) => void>>;
 
 /** When set, invoke('audio_share_start') will reject with this error. */
@@ -613,11 +616,13 @@ describe('Audio share error propagation and toast display (Task 4.4)', () => {
     expect(invokeCalls.filter((call) => call.command === 'screen_share_start_source')).toEqual([
       {
         command: 'screen_share_start_source',
-        args: expect.objectContaining({
-          sourceId: 'screen-1',
-          sourceKind: 'screen',
-          captureBackend: 'wgc',
-        }),
+        args: {
+          request: expect.objectContaining({
+            sourceId: 'screen-1',
+            sourceKind: 'screen',
+            captureBackend: 'wgc',
+          }),
+        },
       },
     ]);
     expect(invokeCalls).toContainEqual({
@@ -747,10 +752,11 @@ describe('Audio share error propagation and toast display (Task 4.4)', () => {
     expect(
       invokeCalls
         .filter((call) => call.command === 'screen_share_start_source')
-        .map((call) => call.args?.captureBackend),
+        .map((call) => call.args?.request?.captureBackend),
     ).toEqual(['wgc', 'gdi_poll']);
     expect(
-      invokeCalls.filter((call) => call.command === 'screen_share_start_source').at(-1)?.args,
+      invokeCalls.filter((call) => call.command === 'screen_share_start_source').at(-1)?.args
+        ?.request,
     ).toEqual(
       expect.objectContaining({
         previousBackend: 'wgc',
@@ -813,7 +819,7 @@ describe('Audio share error propagation and toast display (Task 4.4)', () => {
     expect(
       invokeCalls
         .filter((call) => call.command === 'screen_share_start_source')
-        .map((call) => call.args?.captureBackend),
+        .map((call) => call.args?.request?.captureBackend),
     ).toEqual(['wgc', 'wgc', 'wgc']);
   });
 
@@ -839,7 +845,9 @@ describe('Audio share error propagation and toast display (Task 4.4)', () => {
     expect(invokeCalls.filter((call) => call.command === 'screen_share_start_source')).toEqual([
       {
         command: 'screen_share_start_source',
-        args: expect.objectContaining({ sourceKind: 'window', captureBackend: 'gdi_poll' }),
+        args: {
+          request: expect.objectContaining({ sourceKind: 'window', captureBackend: 'gdi_poll' }),
+        },
       },
     ]);
   });

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -5374,13 +5374,15 @@ export async function startCustomShare(
         try {
           await syncNativeScreenShareQualityBeforeCapture(`windows_${captureBackend}`);
           await invoke('screen_share_start_source', {
-            sourceId: selection.sourceId,
-            shareSessionId,
-            sourceKind,
-            captureBackend,
-            compatibilityMode: selection.compatibilityMode ?? false,
-            previousBackend: retryMetadata?.previousBackend ?? null,
-            retryReason: retryMetadata?.retryReason ?? null,
+            request: {
+              sourceId: selection.sourceId,
+              shareSessionId,
+              sourceKind,
+              captureBackend,
+              compatibilityMode: selection.compatibilityMode ?? false,
+              previousBackend: retryMetadata?.previousBackend ?? null,
+              retryReason: retryMetadata?.retryReason ?? null,
+            },
           });
           rustCaptureStarted = true;
           if (options.isSourceChange) {

--- a/wavis-backend/Cargo.toml
+++ b/wavis-backend/Cargo.toml
@@ -28,8 +28,6 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 async-trait = "0.1"
 thiserror = "1"
 anyhow = "1"
-aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 jsonwebtoken = "9"
 livekit-api = { version = "0.4", features = ["native-tls"] }
 uuid = { version = "1", features = ["v4", "serde"] }
@@ -47,6 +45,10 @@ aes-gcm = "0.10"
 reqwest = { version = "0.12", features = ["json"] }
 zeroize = { version = "1", features = ["derive"] }
 dotenvy = "0.15"
+
+[target.'cfg(not(windows))'.dependencies]
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-ec2 = { version = "1", default-features = false, features = ["default-https-client", "rt-tokio"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/wavis-backend/src/app_state.rs
+++ b/wavis-backend/src/app_state.rs
@@ -243,6 +243,14 @@ impl AppState {
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(50);
 
+        #[cfg(not(windows))]
+        let ec2_controller = std::env::var("LIVEKIT_EC2_INSTANCE_ID")
+            .ok()
+            .map(|id| Arc::new(Ec2InstanceController::new(id)));
+
+        #[cfg(windows)]
+        let ec2_controller = None;
+
         Self {
             room_state: Arc::new(InMemoryRoomState::new()),
             connections: Arc::new(LiveConnections::new()),
@@ -253,9 +261,7 @@ impl AppState {
             sfu_room_manager,
             sfu_signaling_proxy,
             sfu_url,
-            ec2_controller: std::env::var("LIVEKIT_EC2_INSTANCE_ID")
-                .ok()
-                .map(|id| Arc::new(Ec2InstanceController::new(id))),
+            ec2_controller,
             pending_shutdown: Arc::new(AtomicBool::new(false)),
             invite_store,
             join_rate_limiter,

--- a/wavis-backend/src/ec2_control.rs
+++ b/wavis-backend/src/ec2_control.rs
@@ -1,14 +1,27 @@
-use anyhow::{Context, anyhow};
+#[cfg(not(windows))]
+use anyhow::Context;
+use anyhow::anyhow;
+#[cfg(not(windows))]
 use aws_config::BehaviorVersion;
+#[cfg(not(windows))]
 use aws_sdk_ec2::Client;
+#[cfg(not(windows))]
 use aws_sdk_ec2::config::Region;
+#[cfg(not(windows))]
 use aws_sdk_ec2::types::InstanceStateName;
+#[cfg(not(windows))]
 use tokio::sync::OnceCell;
 
+#[cfg(not(windows))]
 pub struct Ec2InstanceController {
     client: OnceCell<Client>,
     instance_id: String,
     region: Option<String>,
+}
+
+#[cfg(windows)]
+pub struct Ec2InstanceController {
+    instance_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,6 +34,7 @@ pub enum Ec2InstanceState {
 }
 
 impl Ec2InstanceController {
+    #[cfg(not(windows))]
     pub fn new(instance_id: String) -> Self {
         Self {
             client: OnceCell::new(),
@@ -29,6 +43,12 @@ impl Ec2InstanceController {
         }
     }
 
+    #[cfg(windows)]
+    pub fn new(instance_id: String) -> Self {
+        Self { instance_id }
+    }
+
+    #[cfg(not(windows))]
     async fn client(&self) -> &Client {
         self.client
             .get_or_init(|| async {
@@ -42,6 +62,7 @@ impl Ec2InstanceController {
             .await
     }
 
+    #[cfg(not(windows))]
     pub async fn start_instance(&self) -> Result<(), anyhow::Error> {
         self.client()
             .await
@@ -54,6 +75,15 @@ impl Ec2InstanceController {
         Ok(())
     }
 
+    #[cfg(windows)]
+    pub async fn start_instance(&self) -> Result<(), anyhow::Error> {
+        Err(anyhow!(
+            "EC2 control is not available on Windows builds for instance {}",
+            self.instance_id
+        ))
+    }
+
+    #[cfg(not(windows))]
     pub async fn stop_instance(&self) -> Result<(), anyhow::Error> {
         self.client()
             .await
@@ -66,6 +96,15 @@ impl Ec2InstanceController {
         Ok(())
     }
 
+    #[cfg(windows)]
+    pub async fn stop_instance(&self) -> Result<(), anyhow::Error> {
+        Err(anyhow!(
+            "EC2 control is not available on Windows builds for instance {}",
+            self.instance_id
+        ))
+    }
+
+    #[cfg(not(windows))]
     pub async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
         let output = self
             .client()
@@ -95,6 +134,14 @@ impl Ec2InstanceController {
             InstanceStateName::Stopping => Ec2InstanceState::Stopping,
             other => Ec2InstanceState::Other(format!("{other:?}")),
         })
+    }
+
+    #[cfg(windows)]
+    pub async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
+        Err(anyhow!(
+            "EC2 control is not available on Windows builds for instance {}",
+            self.instance_id
+        ))
     }
 }
 


### PR DESCRIPTION
Single-page landing site in website/, matching the app's Catppuccin
Mocha palette and JetBrains Mono. Sections: hero with an app-window
mock, features, downloads, open source, mailing list, footer.

- Downloads resolve real per-platform assets from the GitHub Releases
  API at runtime (filenames embed the version), with OS auto-detection
  and a fallback to the releases page; links work without JS.
- Mailing list posts to a Google Form (env-configured), validated
  client-side with an optimistic confirmation.
- Static export (output: export) for SEO; sitemap, robots, OG metadata.
- Infra: S3 + dedicated CloudFront distribution (infrastructure/
  environments/dev/website.tf) and a deploy workflow that builds, syncs
  to S3, and invalidates CloudFront on pushes to main touching website/.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
