### PR TITLE
ci: add branch-hierarchy-check to prevent wrong-base merges

### DIFF
--- a/.github/workflows/branch-hierarchy-check.yml
+++ b/.github/workflows/branch-hierarchy-check.yml
@@ -1,0 +1,26 @@
+name: Branch Hierarchy Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+
+jobs:
+  enforce-hierarchy:
+    name: enforce-hierarchy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR follows pre-dev -> dev -> main flow
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          echo "PR: $HEAD_REF -> $BASE_REF"
+          if [ "$BASE_REF" = "main" ] && [ "$HEAD_REF" != "dev" ]; then
+            echo "::error::PRs into main must come from dev, not '$HEAD_REF'. Branch flow is pre-dev -> dev -> main. See the wavis-release-ops skill."
+            exit 1
+          fi
+          if [ "$BASE_REF" = "dev" ] && [ "$HEAD_REF" != "pre-dev" ]; then
+            echo "::error::PRs into dev must come from pre-dev, not '$HEAD_REF'. Branch flow is pre-dev -> dev -> main. See the wavis-release-ops skill."
+            exit 1
+          fi
+          echo "Hierarchy OK: $HEAD_REF -> $BASE_REF"


### PR DESCRIPTION
## Summary
- Adds a required CI check that fails any PR where head/base don't match the pre-dev -> dev -> main chain (PRs into main must come from dev; PRs into dev must come from pre-dev).
- Directly addresses how PR #271 landed on main instead of pre-dev: it was a same-repo PR that defaulted to main as base and nothing caught it.
- This PR only adds the workflow file to pre-dev. The same file needs to land on dev and main directly (small additive commit, no app code) so the check is live everywhere before branch protection is turned on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)