### PR TITLE
refactor(lint): VideoPopoutPage.tsx 9 -> 4

### DIFF
--- a/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
+++ b/clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx
@@ -27,7 +27,7 @@ function parseHashParams(): VideoPopoutParams | null {
   try {
     const hash = window.location.hash.slice(1);
     if (!hash) return null;
-    return JSON.parse(decodeURIComponent(hash));
+    return JSON.parse(decodeURIComponent(hash)) as VideoPopoutParams;
   } catch {
     return null;
   }
@@ -226,6 +226,9 @@ export default function VideoPopoutPage() {
     if (!el) return;
     const ro = new ResizeObserver((entries) => {
       const entry = entries[0];
+      // Without noUncheckedIndexedAccess, TS types entries[0] as always-defined even
+      // though the ResizeObserverEntry array could theoretically be empty.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!entry) return;
       setGridSize({ width: entry.contentRect.width, height: entry.contentRect.height });
     });
@@ -264,7 +267,7 @@ export default function VideoPopoutPage() {
 
     return () => {
       for (const cleanup of cleanups) {
-        cleanup.then((fn) => fn());
+        void cleanup.then((fn) => fn());
       }
     };
   }, []);
@@ -275,7 +278,7 @@ export default function VideoPopoutPage() {
       await emit('camera-popout:closed', {});
     });
     return () => {
-      unlisten.then((fn) => fn());
+      void unlisten.then((fn) => fn());
     };
   }, []);
 
@@ -288,7 +291,7 @@ export default function VideoPopoutPage() {
       ? computeGridLayout(tiles.length, gridSize.width, gridSize.height)
       : null;
   const handleClose = () => {
-    getCurrentWindow().close();
+    void getCurrentWindow().close();
   };
 
   return (


### PR DESCRIPTION
## Summary
- Picked `clients/wavis-gui/src/features/voice/VideoPopoutPage.tsx` from the fresh ESLint warn-tier survey (717 total warnings repo-wide) — it had 3 purely mechanical `no-floating-promises` sites, one `no-unsafe-return` from an untyped `JSON.parse` boundary, and one `no-unnecessary-condition`, all matching idioms already established elsewhere in this codebase (`ScreenSharePage.tsx`, `WatchAllPage.tsx`). No dedicated test suite exists for this file.
- Fixed (5 sites):
  - `@typescript-eslint/no-unsafe-return`: added an audited `as VideoPopoutParams` cast at the `JSON.parse(decodeURIComponent(hash))` hash-parsing boundary — the exact pattern already used in `ScreenSharePage.tsx:60` and `WatchAllPage.tsx:54`.
  - `@typescript-eslint/no-floating-promises` (x3): `void`'d the fire-and-forget `cleanup.then(...)`, `unlisten.then(...)`, and `getCurrentWindow().close()` calls — matching the `void x.then((fn) => fn())` / `void getCurrentWindow().close()` idiom used throughout `ScreenSharePage.tsx`.
  - `@typescript-eslint/no-unnecessary-condition`: kept the `entries[0]`/`!entry` guard in the `ResizeObserver` callback and documented + suppressed it inline — without `noUncheckedIndexedAccess` in tsconfig, TS types `entries[0]` as always-defined even though the array could theoretically be empty. Same reasoning and near-identical comment as the existing suppression at `WatchAllPage.tsx:152`.
- Deliberately skipped (out of scope for a mechanical pass, left untouched): 2x `max-lines-per-function`, 1x `complexity`, 1x `react-hooks/set-state-in-effect` on this file — these need real decomposition or careful effect-dependency review, not a mechanical async-ownership fix.

## Validation
- `npx tsc --noEmit` — clean
- Lint breakdown on the file: 9 -> 4 warnings (exactly the 5 fixed sites, no unused-disable directives)
- `npx prettier --write` on the touched file — clean
- Full GUI gate suite from `clients/wavis-gui`: `npm run lint` (717 -> 712, 0 errors), `npm run lint:deps` (clean), `npm test` (76 files / 1381 tests passed)
- `npm run format:check` was **not** run as the pass/fail signal — it currently reports pre-existing formatting issues across ~314 unrelated files in this worktree checkout, caused by git auto-converting LF -> CRLF on checkout (Windows). This is a pre-existing local-checkout artifact, not a regression from this change (CI runs on Linux and is green on `pre-dev`); the touched file passes its own `prettier --check` individually.
- No dedicated test suite exists for `VideoPopoutPage.tsx`.

## Test plan
- [x] Typecheck clean
- [x] Lint delta matches sites fixed exactly
- [x] Full `npm test` suite green
- [ ] Manual smoke test of the camera popout window (not done — no UI changes, pure async-ownership/type annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fEdHqnL7KPHXcBPz3tyhy