### PR TITLE
fix: track video-type and audio-only shares as independent slots

### DIFF
--- a/clients/shared/src/room_session/screen_share.rs
+++ b/clients/shared/src/room_session/screen_share.rs
@@ -61,6 +61,7 @@ where
         self.signaling
             .send(&SignalingMessage::StopShare(StopSharePayload {
                 target_participant_id: target.map(|participant_id| participant_id.to_string()),
+                share_type: None,
             }))
             .map_err(|e| RoomError::Signaling(e.to_string()))
     }

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
@@ -1,0 +1,125 @@
+// Live-backend regression test: a participant running an independent
+// video-type share (no companion audio) AND a standalone audio-only share at
+// the same time used to have the second share silently overwrite the first
+// in the backend's per-participant share state. Another participant who left
+// and rejoined the room would then see only whichever share was started
+// last in the ShareState snapshot — not both.
+//
+// Uses the same raw ws-sfu-test peer pattern as screen-share.spec.mjs
+// (Direction B): the peer never publishes real media, so the GUI's video
+// badge renders as "waiting for stream..." rather than "watch share" — that
+// is expected and does not affect this test, which is only about whether
+// the video-share and audio-share badges render independently, both while
+// connected and after the observing window rejoins the room.
+import { test, expect } from './fixtures.mjs';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  seedChannelWithInvite,
+  registerViaUi,
+  joinChannelViaUi,
+  enterChannelRoom,
+  leaveRoomIfActive,
+  joinDefaultSubRoomViaUi,
+  joinDefaultSubRoomAsPeer,
+  visibleTitle,
+  spawnPeer,
+  joinVoiceAsPeer,
+} from './live-backend-helpers.mjs';
+
+/** Same "get back to the channels list" fallback joinChannelViaUi uses internally. */
+async function goToChannelsList(page) {
+  if (
+    !(await page
+      .getByRole('heading', { name: 'channels' })
+      .isVisible()
+      .catch(() => false))
+  ) {
+    const back = page.getByText('← /channels', { exact: true });
+    if (await back.isVisible().catch(() => false)) await back.click();
+  }
+  await page.getByRole('heading', { name: 'channels' }).waitFor({ state: 'visible' });
+}
+
+test('rejoining participant sees both video-share and audio-share badges for a concurrent sharer', async ({
+  app,
+}) => {
+  await waitForBackendHealth();
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-share-rejoin-${suffix}`;
+  const { owner, channel, invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  await leaveRoomIfActive(main);
+  const pathname = new URL(main.url()).pathname;
+
+  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+    await registerViaUi(main, {
+      username: `e2e-share-rejoin-gui-${suffix}`,
+      password: `e2e-password-${suffix}`,
+      serverUrl: SERVER_URL,
+    });
+  }
+
+  await joinChannelViaUi(main, invite.code);
+  await enterChannelRoom(main, channelName);
+  await joinDefaultSubRoomViaUi(main);
+
+  const peer = spawnPeer();
+  try {
+    await joinVoiceAsPeer(peer, {
+      accessToken: owner.access_token,
+      channelId: channel.channel_id,
+      displayName: 'SharerBot',
+    });
+    // Participant rows only render for sub-room members.
+    await joinDefaultSubRoomAsPeer(peer);
+    // Role-based, not visibleText: the room's event log also renders a
+    // "SharerBot joined" line, which a plain text match ambiguously matches
+    // too. The participant row itself is the only `role="button"` element
+    // with this name (see ParticipantRow.tsx).
+    await expect(
+      main.getByRole('button', { name: /SharerBot/ }).and(main.locator(':visible')),
+    ).toBeVisible({ timeout: 10_000 });
+
+    /* ── Peer starts a video-type share (no companion audio) ──────────── */
+    peer.send({ type: 'start_share', shareType: 'window' });
+    await peer.waitForOutput(/"type":"share_started"/, 15_000);
+    await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
+
+    /* ── Peer ALSO starts an independent standalone audio-only share ──── */
+    peer.send({ type: 'start_share', shareType: 'audio_only' });
+    // Lookaheads, not an ordered pattern: ws-sfu-test's print_text roundtrips
+    // through serde_json::Value (no preserve_order feature), which sorts
+    // object keys alphabetically — "shareType" ends up before "type" on the
+    // wire line, same phenomenon chatMessageReceivedPattern works around above.
+    await peer.waitForOutput(/(?=.*"type":"share_started")(?=.*"shareType":"audio_only")/, 15_000);
+
+    // Both badges must render at once: the audio-only start must not hide
+    // the still-active video share, and vice versa.
+    await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
+    await expect(visibleTitle(main, 'mute audio share')).toBeVisible({ timeout: 10_000 });
+
+    /* ── Regression: leave and rejoin — only the ShareState snapshot ──── */
+    // now describes the sharer's state to the rejoining client. Both slots
+    // must still be reflected, not just whichever share started last.
+    await leaveRoomIfActive(main);
+    await goToChannelsList(main);
+    await enterChannelRoom(main, channelName);
+    await joinDefaultSubRoomViaUi(main);
+    // Role-based, not visibleText: the room's event log also renders a
+    // "SharerBot joined" line, which a plain text match ambiguously matches
+    // too. The participant row itself is the only `role="button"` element
+    // with this name (see ParticipantRow.tsx).
+    await expect(
+      main.getByRole('button', { name: /SharerBot/ }).and(main.locator(':visible')),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
+    await expect(visibleTitle(main, 'mute audio share')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await peer.close();
+    await leaveRoomIfActive(main);
+  }
+});

--- a/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
+++ b/clients/wavis-gui/src/features/voice/ActiveRoom.tsx
@@ -1016,6 +1016,11 @@ export default function ActiveRoom() {
 
   const participantsViewModel: ParticipantRowViewModel[] = roomState.participants.map((p) => {
     const videoTile = roomState.videoTilesById[p.id];
+    // A legacy/untyped signaling-only sharer (no shareType metadata at all)
+    // is assumed to be video, matching prior behavior — see voice-room.ts's
+    // share_started/share_state handlers for how shareType/audioOnlySharers
+    // are kept independent for participants running both slots at once.
+    const isAudioOnlySharer = roomState.audioOnlySharers.has(p.id);
     return {
       id: p.id,
       userId: p.userId,
@@ -1033,7 +1038,8 @@ export default function ActiveRoom() {
       // genuinely undefined.
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       cameraOn: !!videoTile && !videoTile.isMuted && !videoTile.hasError,
-      isAudioOnlySharer: roomState.audioOnlySharers.has(p.id),
+      isAudioOnlySharer,
+      hasVideoShare: p.shareType !== undefined || !isAudioOnlySharer,
       hasScreenShareStream: roomState.screenShareStreams.has(p.id),
     };
   });

--- a/clients/wavis-gui/src/features/voice/ParticipantRow.tsx
+++ b/clients/wavis-gui/src/features/voice/ParticipantRow.tsx
@@ -20,6 +20,13 @@ export interface ParticipantRowViewModel {
   volume: number;
   cameraOn: boolean;
   isAudioOnlySharer: boolean;
+  /**
+   * True when this participant has an active video-type share, independent
+   * of isAudioOnlySharer — a participant can run a video share and a
+   * standalone audio-only share at the same time, so both badges must be
+   * able to render together instead of one hiding the other.
+   */
+  hasVideoShare: boolean;
   hasScreenShareStream: boolean;
 }
 
@@ -183,53 +190,56 @@ export function ParticipantRow({
               )}
             </>
           )}
-          {!isSelf &&
-            p.isSharing &&
-            (p.isAudioOnlySharer ? (
-              <button
-                className="text-sm leading-none hover:opacity-70 transition-opacity"
-                style={{
-                  color: shareMuted ? 'var(--wavis-danger)' : 'transparent',
-                  WebkitTextStroke: shareMuted ? undefined : '1px var(--wavis-danger)',
-                  animation: shareMuted ? 'watchPulse 2s ease-in-out infinite' : undefined,
-                }}
-                title={shareMuted ? 'unmute audio share' : 'mute audio share'}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSyncShareMuted(!shareMuted);
-                }}
-              >
-                {'♪'}
-              </button>
-            ) : (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (!p.hasScreenShareStream) return;
-                  onToggleWatchShare();
-                }}
-                className="text-sm leading-none"
-                style={
-                  isWatchingShare
-                    ? { color: 'var(--wavis-danger)' }
-                    : p.hasScreenShareStream
-                      ? {
-                          color: 'var(--wavis-danger)',
-                          animation: 'watchPulse 2s ease-in-out infinite',
-                        }
-                      : { color: 'var(--wavis-text-secondary)', opacity: 0.4 }
-                }
-                title={
-                  isWatchingShare
-                    ? 'close share'
-                    : p.hasScreenShareStream
-                      ? 'watch share'
-                      : 'waiting for stream...'
-                }
-              >
-                {isWatchingShare ? '◎' : '◉'}
-              </button>
-            ))}
+          {!isSelf && p.isSharing && (
+            <>
+              {p.isAudioOnlySharer && (
+                <button
+                  className="text-sm leading-none hover:opacity-70 transition-opacity"
+                  style={{
+                    color: shareMuted ? 'var(--wavis-danger)' : 'transparent',
+                    WebkitTextStroke: shareMuted ? undefined : '1px var(--wavis-danger)',
+                    animation: shareMuted ? 'watchPulse 2s ease-in-out infinite' : undefined,
+                  }}
+                  title={shareMuted ? 'unmute audio share' : 'mute audio share'}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSyncShareMuted(!shareMuted);
+                  }}
+                >
+                  {'♪'}
+                </button>
+              )}
+              {p.hasVideoShare && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!p.hasScreenShareStream) return;
+                    onToggleWatchShare();
+                  }}
+                  className="text-sm leading-none"
+                  style={
+                    isWatchingShare
+                      ? { color: 'var(--wavis-danger)' }
+                      : p.hasScreenShareStream
+                        ? {
+                            color: 'var(--wavis-danger)',
+                            animation: 'watchPulse 2s ease-in-out infinite',
+                          }
+                        : { color: 'var(--wavis-text-secondary)', opacity: 0.4 }
+                  }
+                  title={
+                    isWatchingShare
+                      ? 'close share'
+                      : p.hasScreenShareStream
+                        ? 'watch share'
+                        : 'waiting for stream...'
+                  }
+                >
+                  {isWatchingShare ? '◎' : '◉'}
+                </button>
+              )}
+            </>
+          )}
         </div>
       </div>
       {isExpanded && !isSelf && (

--- a/clients/wavis-gui/src/features/voice/ParticipantsPanel.tsx
+++ b/clients/wavis-gui/src/features/voice/ParticipantsPanel.tsx
@@ -85,6 +85,7 @@ function areParticipantsPanelPropsEqual(
       a.volume !== b.volume ||
       a.cameraOn !== b.cameraOn ||
       a.isAudioOnlySharer !== b.isAudioOnlySharer ||
+      a.hasVideoShare !== b.hasVideoShare ||
       a.hasScreenShareStream !== b.hasScreenShareStream
     )
       return false;

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-camera.property.test.ts
@@ -91,6 +91,7 @@ function makeState(overrides?: Partial<VoiceRoomState>): VoiceRoomState {
     roomPanelManualOverride: null,
     roomPanelTab: 'logs',
     audioOnlySharers: new Set(),
+    confirmedAudioOnlySharers: new Set(),
     ...overrides,
   };
 }

--- a/clients/wavis-gui/src/features/voice/signaling/messages.ts
+++ b/clients/wavis-gui/src/features/voice/signaling/messages.ts
@@ -177,6 +177,8 @@ export interface ShareStoppedMessage {
   type: 'share_stopped';
   participantId: string;
   displayName?: string;
+  /** Which slot stopped (video-type or 'audio_only'); undefined means every slot stopped. */
+  shareType?: unknown;
 }
 
 export interface WireActiveShare {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -328,6 +328,16 @@ export interface VoiceRoomState {
   roomPanelTab: 'logs' | 'video';
   /** Identities of remote participants currently in audio-only share mode. */
   audioOnlySharers: Set<string>;
+  /**
+   * Subset of audioOnlySharers whose membership came from an explicit
+   * audio_only share_started/share_state entry (a real, independent
+   * standalone-audio slot), as opposed to LiveKit's TrackSubscribed-based
+   * guess (onAudioOnlySharerAdded) made before any signaling confirms it.
+   * A later video-type share_started must not clear a confirmed entry (the
+   * two slots are independent), but should still correct an unconfirmed
+   * LiveKit guess once real signaling arrives.
+   */
+  confirmedAudioOnlySharers: Set<string>;
 }
 
 /* ─── Constants ─────────────────────────────────────────────────── */
@@ -890,6 +900,7 @@ const DEFAULT_STATE: VoiceRoomState = {
   roomPanelManualOverride: null,
   roomPanelTab: 'logs',
   audioOnlySharers: new Set(),
+  confirmedAudioOnlySharers: new Set(),
 };
 
 let state: VoiceRoomState = {
@@ -2776,8 +2787,11 @@ function connectMedia(
       notify();
     },
     onAudioOnlySharerRemoved: (identity) => {
+      const participantId = participantIdForLiveKitIdentity(identity);
       state.audioOnlySharers = new Set(state.audioOnlySharers);
-      state.audioOnlySharers.delete(participantIdForLiveKitIdentity(identity));
+      state.audioOnlySharers.delete(participantId);
+      state.confirmedAudioOnlySharers = new Set(state.confirmedAudioOnlySharers);
+      state.confirmedAudioOnlySharers.delete(participantId);
       notify();
     },
   };
@@ -3675,17 +3689,36 @@ function dispatchMessage(raw: unknown): void {
       const sp = state.participants.find((pp) => pp.id === shareStartId);
       if (sp) {
         sp.isSharing = true;
-        sp.shareType = remoteShareType;
+        // Video-type share and audio-only share are independent slots — a
+        // participant may run both concurrently. Only overwrite the video
+        // slot when this event is itself for a video-type share (or a
+        // legacy untyped restart); an audio_only start must never clobber
+        // an already-recorded video type.
+        if (remoteShareType !== 'audio_only') {
+          sp.shareType = remoteShareType;
+        }
       }
       // Keep audioOnlySharers in sync directly — updateRemoteShareType is a no-op
       // when lkModule is not yet initialized, which would leave the UI stuck on ◉.
-      if (remoteShareType === 'audio_only' && !state.audioOnlySharers.has(shareStartId)) {
-        state.audioOnlySharers = new Set(state.audioOnlySharers);
-        state.audioOnlySharers.add(shareStartId);
+      // A video share starting must never clear a CONFIRMED audio-only flag
+      // (and vice versa) — the two slots are independent, only an explicit
+      // share_stopped for that slot does. An UNCONFIRMED flag (LiveKit's
+      // TrackSubscribed-based onAudioOnlySharerAdded guess, made before any
+      // signaling arrives) is a different case: the first real video-type
+      // share_started is authoritative and must correct that guess.
+      if (remoteShareType === 'audio_only') {
+        if (!state.audioOnlySharers.has(shareStartId)) {
+          state.audioOnlySharers = new Set(state.audioOnlySharers);
+          state.audioOnlySharers.add(shareStartId);
+        }
+        if (!state.confirmedAudioOnlySharers.has(shareStartId)) {
+          state.confirmedAudioOnlySharers = new Set(state.confirmedAudioOnlySharers);
+          state.confirmedAudioOnlySharers.add(shareStartId);
+        }
       } else if (
         remoteShareType !== undefined &&
-        remoteShareType !== 'audio_only' &&
-        state.audioOnlySharers.has(shareStartId)
+        state.audioOnlySharers.has(shareStartId) &&
+        !state.confirmedAudioOnlySharers.has(shareStartId)
       ) {
         state.audioOnlySharers = new Set(state.audioOnlySharers);
         state.audioOnlySharers.delete(shareStartId);
@@ -3731,24 +3764,38 @@ function dispatchMessage(raw: unknown): void {
     case 'share_stopped': {
       const shareStopId = msg.participantId;
       const shareStopName = msg.displayName;
+      // share_type is set when only one slot stopped (the other, if any,
+      // keeps running); undefined means every slot for this participant
+      // stopped (legacy behavior / host-directed stop-all).
+      const stoppedType = parseRemoteShareType(msg.shareType);
+      const stopsVideoSlot = stoppedType !== 'audio_only';
+      const stopsAudioSlot = stoppedType === undefined || stoppedType === 'audio_only';
       const ssp = state.participants.find((pp) => pp.id === shareStopId);
-      if (ssp) {
-        ssp.isSharing = false;
+      if (ssp && stopsVideoSlot) {
         ssp.shareType = undefined;
       }
-      if (state.audioOnlySharers.has(shareStopId)) {
+      if (stopsAudioSlot && state.audioOnlySharers.has(shareStopId)) {
         state.audioOnlySharers = new Set(state.audioOnlySharers);
         state.audioOnlySharers.delete(shareStopId);
+        if (state.confirmedAudioOnlySharers.has(shareStopId)) {
+          state.confirmedAudioOnlySharers = new Set(state.confirmedAudioOnlySharers);
+          state.confirmedAudioOnlySharers.delete(shareStopId);
+        }
       }
-      clearRemoteShareType(shareStopId);
-      refreshRetryGenerations.delete(shareStopId);
-      // Clear the stream reference immediately on signaling. The LiveKit
-      // TrackUnsubscribed event may lag by the SFU's disconnect timeout when
-      // the sharer closes the app abruptly; without this the viewer's UI shows
-      // a stale frozen frame until the SFU eventually fires the event.
-      if (state.screenShareStreams.has(shareStopId)) {
-        state.screenShareStreams = new Map(state.screenShareStreams);
-        state.screenShareStreams.delete(shareStopId);
+      if (ssp) {
+        ssp.isSharing = ssp.shareType !== undefined || state.audioOnlySharers.has(shareStopId);
+      }
+      if (stopsVideoSlot) {
+        clearRemoteShareType(shareStopId);
+        refreshRetryGenerations.delete(shareStopId);
+        // Clear the stream reference immediately on signaling. The LiveKit
+        // TrackUnsubscribed event may lag by the SFU's disconnect timeout when
+        // the sharer closes the app abruptly; without this the viewer's UI shows
+        // a stale frozen frame until the SFU eventually fires the event.
+        if (state.screenShareStreams.has(shareStopId)) {
+          state.screenShareStreams = new Map(state.screenShareStreams);
+          state.screenShareStreams.delete(shareStopId);
+        }
       }
       // Cache the display name from the server payload
       if (shareStopName) {
@@ -3774,17 +3821,23 @@ function dispatchMessage(raw: unknown): void {
     }
 
     case 'share_state': {
-      // share_state is an authoritative snapshot — reconcile all participants
+      // share_state is an authoritative snapshot — reconcile all participants.
+      // A participant may have up to two entries in activeShares (one video-type
+      // slot, one audio-only slot) — collect them per participant rather than
+      // collapsing to a single type, or a late joiner only ever learns about
+      // whichever slot happened to be listed last.
       const shareIds = new Set(msg.participantIds || []);
-      const typedShares = new Map<string, RemoteShareType | undefined>(
-        (msg.activeShares || []).map(
-          (share) =>
-            [share.participantId, parseRemoteShareType(share.shareType)] as [
-              string,
-              RemoteShareType | undefined,
-            ],
-        ),
-      );
+      const typedShares = new Map<string, Set<RemoteShareType>>();
+      for (const share of msg.activeShares || []) {
+        const t = parseRemoteShareType(share.shareType);
+        if (t === undefined) continue;
+        const existing = typedShares.get(share.participantId);
+        if (existing) {
+          existing.add(t);
+        } else {
+          typedShares.set(share.participantId, new Set([t]));
+        }
+      }
       for (const p of state.participants) {
         const shouldBeSharing = shareIds.has(p.id);
         if (p.isSharing && !shouldBeSharing) {
@@ -3795,6 +3848,10 @@ function dispatchMessage(raw: unknown): void {
             state.audioOnlySharers = new Set(state.audioOnlySharers);
             state.audioOnlySharers.delete(p.id);
           }
+          if (state.confirmedAudioOnlySharers.has(p.id)) {
+            state.confirmedAudioOnlySharers = new Set(state.confirmedAudioOnlySharers);
+            state.confirmedAudioOnlySharers.delete(p.id);
+          }
           clearRemoteShareType(p.id);
           if (state.screenShareStreams.has(p.id)) {
             state.screenShareStreams = new Map(state.screenShareStreams);
@@ -3804,26 +3861,39 @@ function dispatchMessage(raw: unknown): void {
           p.isSharing = true;
         }
         if (shouldBeSharing) {
-          p.shareType = typedShares.get(p.id);
-          const resolvedType = p.shareType as RemoteShareType | undefined;
-          if (resolvedType === 'audio_only' && !state.audioOnlySharers.has(p.id)) {
-            state.audioOnlySharers = new Set(state.audioOnlySharers);
-            state.audioOnlySharers.add(p.id);
-          } else if (
-            resolvedType !== undefined &&
-            resolvedType !== 'audio_only' &&
-            state.audioOnlySharers.has(p.id)
-          ) {
+          const types = typedShares.get(p.id);
+          const videoType = types ? [...types].find((t) => t !== 'audio_only') : undefined;
+          const hasAudioOnly = types ? types.has('audio_only') : false;
+          p.shareType = videoType;
+          if (hasAudioOnly) {
+            if (!state.audioOnlySharers.has(p.id)) {
+              state.audioOnlySharers = new Set(state.audioOnlySharers);
+              state.audioOnlySharers.add(p.id);
+            }
+            if (!state.confirmedAudioOnlySharers.has(p.id)) {
+              state.confirmedAudioOnlySharers = new Set(state.confirmedAudioOnlySharers);
+              state.confirmedAudioOnlySharers.add(p.id);
+            }
+          } else if (types !== undefined && state.audioOnlySharers.has(p.id)) {
+            // Typed snapshot explicitly has no audio-only entry for this
+            // participant (it was stopped while we were away) — clear it.
             state.audioOnlySharers = new Set(state.audioOnlySharers);
             state.audioOnlySharers.delete(p.id);
+            if (state.confirmedAudioOnlySharers.has(p.id)) {
+              state.confirmedAudioOnlySharers = new Set(state.confirmedAudioOnlySharers);
+              state.confirmedAudioOnlySharers.delete(p.id);
+            }
           }
-          if (resolvedType !== undefined || !state.audioOnlySharers.has(p.id)) {
-            updateRemoteShareType(p.id, resolvedType);
+          // else: no typed entry at all (legacy/untyped sender) — keep
+          // whatever audioOnlySharers already holds for this participant.
+          if (videoType !== undefined || !state.audioOnlySharers.has(p.id)) {
+            updateRemoteShareType(p.id, videoType);
           }
-          const isAudioOnlyShare =
-            resolvedType === 'audio_only' ||
-            (resolvedType === undefined && state.audioOnlySharers.has(p.id));
-          if (!isAudioOnlyShare) {
+          const isPureAudioOnlyShare =
+            types !== undefined
+              ? videoType === undefined && hasAudioOnly
+              : state.audioOnlySharers.has(p.id);
+          if (!isPureAudioOnlyShare) {
             refreshRemoteScreenShare(p.id);
             // Schedule retries for late joiners or post-reconnect cases where
             // the stream isn't available yet. share_state doesn't schedule
@@ -5224,18 +5294,16 @@ export async function stopCustomShare(
     }
   }
 
-  // 4. Send stop_share signaling — only when the entire share session ends.
-  // If the other slot is still active the participant remains "sharing" on the backend.
-  const willStillBeSharing =
-    (target === 'video' && state.activeAudioShare !== null) ||
-    (target === 'audio' && state.activeVideoShare !== null);
+  // 4. Send stop-share signaling for the slot(s) that stopped. A slot-scoped
+  // shareType tells the backend to clear only that slot and leave the other
+  // slot (if still active) running — the participant stays "sharing" there.
   if (client && !options.suppressSignaling) {
-    if (!willStillBeSharing) {
+    if (target === 'all') {
       client.send({ type: 'stop-share' });
-    } else if (target === 'video' && state.activeAudioShare !== null) {
-      client.send({ type: 'start_share', shareType: 'audio_only' });
-    } else if (target === 'audio' && state.activeVideoShare !== null) {
-      client.send({ type: 'start_share', shareType: state.activeVideoShare.mode });
+    } else if (target === 'video' && state.activeVideoShare) {
+      client.send({ type: 'stop-share', shareType: state.activeVideoShare.mode });
+    } else if (target === 'audio') {
+      client.send({ type: 'stop-share', shareType: 'audio_only' });
     }
   }
 

--- a/shared/src/signaling/mod.rs
+++ b/shared/src/signaling/mod.rs
@@ -75,13 +75,21 @@ pub enum WireSharePermission {
 }
 
 /// Wire-format screen share type.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum WireShareType {
     ScreenAudio,
     Window,
     AudioOnly,
     Browser,
+}
+
+impl WireShareType {
+    /// True for the standalone system-audio-only share type. All other
+    /// variants carry video and may optionally have companion audio.
+    pub fn is_audio_only(self) -> bool {
+        matches!(self, Self::AudioOnly)
+    }
 }
 
 impl WireSharePermission {
@@ -693,14 +701,21 @@ pub struct ShareStartedPayload {
 }
 
 /// Client requests to stop a screen share (optionally targeting another participant's share).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct StopSharePayload {
     /// If set, a host is stopping another participant's share.
     #[serde(
         rename = "targetParticipantId",
+        default,
         skip_serializing_if = "Option::is_none"
     )]
     pub target_participant_id: Option<String>,
+    /// Which concurrent share slot to stop (a participant may have an
+    /// independent video-type share and audio-only share active at once).
+    /// `None` stops every slot the target has active — preserves legacy
+    /// single-slot behavior for older clients.
+    #[serde(rename = "shareType", default, skip_serializing_if = "Option::is_none")]
+    pub share_type: Option<WireShareType>,
 }
 
 /// Broadcast to all participants when a screen share stops.
@@ -712,6 +727,10 @@ pub struct ShareStoppedPayload {
     /// Display name for the sharer whose presentation stopped.
     #[serde(rename = "displayName")]
     pub display_name: String,
+    /// Which slot stopped. `None` means every slot for this participant
+    /// stopped (legacy behavior / host-directed stop-all).
+    #[serde(rename = "shareType", default, skip_serializing_if = "Option::is_none")]
+    pub share_type: Option<WireShareType>,
 }
 
 /// Snapshot of all active screen sharers in a room. Sent to late joiners.

--- a/shared/src/signaling/proptest_support.rs
+++ b/shared/src/signaling/proptest_support.rs
@@ -539,9 +539,13 @@ impl Arbitrary for StopSharePayload {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        prop::option::of(any::<String>())
-            .prop_map(|target_participant_id| StopSharePayload {
+        (
+            prop::option::of(any::<String>()),
+            prop::option::of(any::<WireShareType>()),
+        )
+            .prop_map(|(target_participant_id, share_type)| StopSharePayload {
                 target_participant_id,
+                share_type,
             })
             .boxed()
     }
@@ -552,11 +556,18 @@ impl Arbitrary for ShareStoppedPayload {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        (any::<String>(), any::<String>())
-            .prop_map(|(participant_id, display_name)| ShareStoppedPayload {
-                participant_id,
-                display_name,
-            })
+        (
+            any::<String>(),
+            any::<String>(),
+            prop::option::of(any::<WireShareType>()),
+        )
+            .prop_map(
+                |(participant_id, display_name, share_type)| ShareStoppedPayload {
+                    participant_id,
+                    display_name,
+                    share_type,
+                },
+            )
             .boxed()
     }
 }

--- a/shared/src/signaling/validation.rs
+++ b/shared/src/signaling/validation.rs
@@ -531,6 +531,7 @@ mod tests {
 
         let msg2 = SignalingMessage::StopShare(StopSharePayload {
             target_participant_id: Some(long_str(MAX_PEER_ID_LEN + 1)),
+            share_type: None,
         });
         let err2 = validate_field_lengths(&msg2).unwrap_err();
         assert_eq!(err2.field, "target_participant_id");

--- a/wavis-backend/src/state.rs
+++ b/wavis-backend/src/state.rs
@@ -143,7 +143,10 @@ pub struct RoomInfo {
     /// Participant IDs currently sharing their screen. SFU rooms only.
     pub active_shares: HashSet<String>,
     /// Authoritative share types for active shares that supplied metadata.
-    pub active_share_types: HashMap<String, shared::signaling::WireShareType>,
+    /// A participant may have at most one video-type share (`ScreenAudio`,
+    /// `Window`, `Browser`) and one `AudioOnly` share active concurrently —
+    /// those are independent slots, so the value is a set, not a single type.
+    pub active_share_types: HashMap<String, HashSet<shared::signaling::WireShareType>>,
     /// Screen share permission policy (default: AllParticipants).
     pub share_permission: SharePermission,
     /// Optional synchronized sub-room state for channel-based voice sessions.

--- a/wavis-backend/src/voice/screen_share.rs
+++ b/wavis-backend/src/voice/screen_share.rs
@@ -117,19 +117,34 @@ pub fn handle_start_share_with_type(
             }));
         }
 
-        // Check sender not already sharing
+        // Check sender not already sharing this specific slot. A participant
+        // may run one video-type share (ScreenAudio/Window/Browser) and one
+        // AudioOnly share concurrently — those are independent slots keyed
+        // by WireShareType::is_audio_only(), so starting the second kind
+        // must add alongside the first, not replace it.
         if members.info.active_shares.contains(sender_id) {
-            if members.info.active_share_types.get(sender_id).copied() == share_type {
-                return ShareResult::Noop;
-            }
+            let existing_types = members
+                .info
+                .active_share_types
+                .entry(sender_id.to_string())
+                .or_default();
+
             if let Some(share_type) = share_type {
-                members
-                    .info
-                    .active_share_types
-                    .insert(sender_id.to_string(), share_type);
+                if existing_types.contains(&share_type) {
+                    return ShareResult::Noop;
+                }
+                // Replace any existing slot in the same category; keep the
+                // other category's slot (if any) untouched.
+                existing_types.retain(|t| t.is_audio_only() != share_type.is_audio_only());
+                existing_types.insert(share_type);
+            } else if existing_types.is_empty() {
+                return ShareResult::Noop;
             } else {
-                members.info.active_share_types.remove(sender_id);
+                // Legacy client with no type metadata restarting its share —
+                // can't reason about slots, so clear all recorded types.
+                existing_types.clear();
             }
+
             let display_name = lookup_display_name(&members.info.participants, sender_id);
             return ShareResult::Ok(vec![OutboundSignal::broadcast_all(
                 SignalingMessage::ShareStarted(ShareStartedPayload {
@@ -146,7 +161,9 @@ pub fn handle_start_share_with_type(
             members
                 .info
                 .active_share_types
-                .insert(sender_id.to_string(), share_type);
+                .entry(sender_id.to_string())
+                .or_default()
+                .insert(share_type);
         }
 
         let display_name = lookup_display_name(&members.info.participants, sender_id);
@@ -186,12 +203,17 @@ pub fn handle_start_share_with_type(
 /// - Target is in `active_shares`
 ///
 /// On success, removes target from `active_shares` and returns a `BroadcastAll` `ShareStopped` signal.
+///
+/// `share_type_to_stop`: when set, only that slot (video-type or AudioOnly)
+/// is stopped — the target keeps sharing if the other slot is still active.
+/// `None` stops every slot the target has (legacy behavior).
 pub fn handle_stop_share(
     state: &InMemoryRoomState,
     room_id: &str,
     peer_id: &str,
     target_participant_id: Option<&str>,
     role: ParticipantRole,
+    share_type_to_stop: Option<WireShareType>,
 ) -> ShareResult {
     let effective_target = target_participant_id.unwrap_or(peer_id);
 
@@ -221,7 +243,30 @@ pub fn handle_stop_share(
             return ShareResult::Noop;
         }
 
-        // All preconditions pass — atomically remove from active_shares
+        // If a specific slot was requested, try to remove just that one and
+        // leave the target sharing if another slot remains active.
+        if let Some(stop_type) = share_type_to_stop
+            && let Some(types) = members.info.active_share_types.get_mut(effective_target)
+        {
+            if !types.remove(&stop_type) {
+                // Wasn't sharing that slot — nothing to do.
+                return ShareResult::Noop;
+            }
+            if !types.is_empty() {
+                let display_name =
+                    lookup_display_name(&members.info.participants, effective_target);
+                return ShareResult::Ok(vec![OutboundSignal::broadcast_all(
+                    SignalingMessage::ShareStopped(ShareStoppedPayload {
+                        participant_id: effective_target.to_string(),
+                        display_name,
+                        share_type: Some(stop_type),
+                    }),
+                )]);
+            }
+        }
+
+        // Either no specific slot was requested, or the removed slot was the
+        // last one active — fully stop the target.
         members.info.active_shares.remove(effective_target);
         members.info.active_share_types.remove(effective_target);
 
@@ -230,6 +275,7 @@ pub fn handle_stop_share(
             OutboundSignal::broadcast_all(SignalingMessage::ShareStopped(ShareStoppedPayload {
                 participant_id: effective_target.to_string(),
                 display_name,
+                share_type: None,
             }));
         ShareResult::Ok(vec![signal])
     });
@@ -284,6 +330,7 @@ pub fn handle_stop_all_shares(
                 OutboundSignal::broadcast_all(SignalingMessage::ShareStopped(ShareStoppedPayload {
                     participant_id,
                     display_name,
+                    share_type: None,
                 }))
             })
             .collect();
@@ -311,12 +358,26 @@ pub fn share_state_snapshot(
         .get_room_info(room_id)
         .map(|info| {
             let participant_ids: Vec<String> = info.active_shares.iter().cloned().collect();
+            // One entry per active slot, so a participant with both a
+            // video-type share and an AudioOnly share concurrently produces
+            // two entries — a fresh joiner must see both, not just one.
             let active_shares = participant_ids
                 .iter()
-                .map(|participant_id| ActiveSharePayload {
-                    participant_id: participant_id.clone(),
-                    share_type: info.active_share_types.get(participant_id).copied(),
-                })
+                .flat_map(
+                    |participant_id| match info.active_share_types.get(participant_id) {
+                        Some(types) if !types.is_empty() => types
+                            .iter()
+                            .map(|&share_type| ActiveSharePayload {
+                                participant_id: participant_id.clone(),
+                                share_type: Some(share_type),
+                            })
+                            .collect::<Vec<_>>(),
+                        _ => vec![ActiveSharePayload {
+                            participant_id: participant_id.clone(),
+                            share_type: None,
+                        }],
+                    },
+                )
                 .collect();
             (participant_ids, active_shares)
         })
@@ -351,6 +412,7 @@ pub fn cleanup_share_on_disconnect(
             OutboundSignal::broadcast_all(SignalingMessage::ShareStopped(ShareStoppedPayload {
                 participant_id: peer_id.to_string(),
                 display_name,
+                share_type: None,
             }));
         Some(vec![signal])
     });
@@ -417,6 +479,7 @@ mod tests {
     use crate::state::RoomInfo;
     use crate::voice::sfu_bridge::SfuRoomHandle;
     use proptest::prelude::*;
+    use std::collections::HashSet;
 
     // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -572,7 +635,14 @@ mod tests {
         make_sfu_room(&state, "room-1", &["peer-a"]);
         set_active_share(&state, "room-1", "peer-a");
 
-        let result = handle_stop_share(&state, "room-1", "peer-a", None, ParticipantRole::Guest);
+        let result = handle_stop_share(
+            &state,
+            "room-1",
+            "peer-a",
+            None,
+            ParticipantRole::Guest,
+            None,
+        );
         assert!(matches!(result, ShareResult::Ok(_)));
         assert_eq!(get_active_share(&state, "room-1"), None);
     }
@@ -589,6 +659,7 @@ mod tests {
             "host",
             Some("sharer"),
             ParticipantRole::Host,
+            None,
         );
         assert!(matches!(result, ShareResult::Ok(_)));
         assert_eq!(get_active_share(&state, "room-1"), None);
@@ -599,7 +670,14 @@ mod tests {
         let state = InMemoryRoomState::new();
         make_sfu_room(&state, "room-1", &["peer-a"]);
 
-        let result = handle_stop_share(&state, "room-1", "peer-a", None, ParticipantRole::Guest);
+        let result = handle_stop_share(
+            &state,
+            "room-1",
+            "peer-a",
+            None,
+            ParticipantRole::Guest,
+            None,
+        );
         assert!(matches!(result, ShareResult::Noop));
     }
 
@@ -609,7 +687,14 @@ mod tests {
         make_sfu_room(&state, "room-1", &["peer-a", "peer-b"]);
         set_active_share(&state, "room-1", "peer-a");
 
-        let result = handle_stop_share(&state, "room-1", "peer-b", None, ParticipantRole::Guest);
+        let result = handle_stop_share(
+            &state,
+            "room-1",
+            "peer-b",
+            None,
+            ParticipantRole::Guest,
+            None,
+        );
         assert!(matches!(result, ShareResult::Noop));
         // State unchanged
         assert_eq!(
@@ -676,6 +761,7 @@ mod tests {
             "peer-b",
             Some("peer-a"),
             ParticipantRole::Guest,
+            None,
         );
         assert!(matches!(result, ShareResult::Error(_)));
         // Share still active
@@ -696,6 +782,7 @@ mod tests {
             "host",
             Some("sharer-a"),
             ParticipantRole::Host,
+            None,
         );
         assert!(
             matches!(result, ShareResult::Ok(ref sigs) if signals_contain_share_stopped(sigs, "sharer-a"))
@@ -771,6 +858,107 @@ mod tests {
             }
             _ => panic!("expected ShareState message"),
         }
+    }
+
+    #[test]
+    fn concurrent_video_and_audio_only_shares_both_survive_to_late_joiner_snapshot() {
+        // Regression test: a participant sharing video (no companion audio)
+        // who then ALSO starts a standalone audio-only share used to have the
+        // audio-only start silently overwrite the recorded video share type
+        // server-side. A client joining afterward would see only one of the
+        // two active shares in its ShareState snapshot.
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["sharer", "late-joiner"]);
+
+        let video_result = handle_start_share_with_type(
+            &state,
+            "room-1",
+            "sharer",
+            ParticipantRole::Guest,
+            Some(WireShareType::Window),
+        );
+        assert!(matches!(video_result, ShareResult::Ok(_)));
+
+        let audio_result = handle_start_share_with_type(
+            &state,
+            "room-1",
+            "sharer",
+            ParticipantRole::Guest,
+            Some(WireShareType::AudioOnly),
+        );
+        assert!(matches!(audio_result, ShareResult::Ok(_)));
+
+        let signal = share_state_snapshot(&state, "room-1", "late-joiner");
+        match signal.msg {
+            SignalingMessage::ShareState(payload) => {
+                let types: HashSet<WireShareType> = payload
+                    .active_shares
+                    .iter()
+                    .filter(|s| s.participant_id == "sharer")
+                    .filter_map(|s| s.share_type)
+                    .collect();
+                assert_eq!(
+                    types,
+                    HashSet::from([WireShareType::Window, WireShareType::AudioOnly]),
+                    "late joiner must see both the video-type share and the audio-only share"
+                );
+            }
+            _ => panic!("expected ShareState message"),
+        }
+    }
+
+    #[test]
+    fn stopping_one_slot_leaves_the_other_slot_active() {
+        let state = InMemoryRoomState::new();
+        make_sfu_room(&state, "room-1", &["sharer"]);
+
+        handle_start_share_with_type(
+            &state,
+            "room-1",
+            "sharer",
+            ParticipantRole::Guest,
+            Some(WireShareType::Window),
+        );
+        handle_start_share_with_type(
+            &state,
+            "room-1",
+            "sharer",
+            ParticipantRole::Guest,
+            Some(WireShareType::AudioOnly),
+        );
+
+        // Stop only the audio-only slot.
+        let result = handle_stop_share(
+            &state,
+            "room-1",
+            "sharer",
+            None,
+            ParticipantRole::Guest,
+            Some(WireShareType::AudioOnly),
+        );
+        assert!(matches!(result, ShareResult::Ok(_)));
+
+        // Sharer must still be sharing (video slot untouched).
+        assert!(get_active_shares(&state, "room-1").contains("sharer"));
+        let info = state.get_room_info("room-1").unwrap();
+        let remaining = info
+            .active_share_types
+            .get("sharer")
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(remaining, HashSet::from([WireShareType::Window]));
+
+        // Stopping the remaining video slot now fully clears the sharer.
+        let result2 = handle_stop_share(
+            &state,
+            "room-1",
+            "sharer",
+            None,
+            ParticipantRole::Guest,
+            Some(WireShareType::Window),
+        );
+        assert!(matches!(result2, ShareResult::Ok(_)));
+        assert!(!get_active_shares(&state, "room-1").contains("sharer"));
     }
 
     #[test]
@@ -997,7 +1185,7 @@ mod tests {
             make_sfu_room(&state, &room_id, &[&owner_id]);
             set_active_share(&state, &room_id, &owner_id);
 
-            let result = handle_stop_share(&state, &room_id, &owner_id, None, ParticipantRole::Guest);
+            let result = handle_stop_share(&state, &room_id, &owner_id, None, ParticipantRole::Guest, None);
 
             prop_assert!(
                 matches!(result, ShareResult::Ok(_)),
@@ -1029,7 +1217,7 @@ mod tests {
             make_sfu_room(&state, &room_id, &[&host_id, &sharer_id]);
             set_active_share(&state, &room_id, &sharer_id);
 
-            let result = handle_stop_share(&state, &room_id, &host_id, Some(sharer_id.as_str()), ParticipantRole::Host);
+            let result = handle_stop_share(&state, &room_id, &host_id, Some(sharer_id.as_str()), ParticipantRole::Host, None);
 
             prop_assert!(
                 matches!(result, ShareResult::Ok(_)),
@@ -1064,7 +1252,7 @@ mod tests {
             make_sfu_room(&state, &room_id, &[&sender_id]);
             // No active share
 
-            let result = handle_stop_share(&state, &room_id, &sender_id, None, ParticipantRole::Guest);
+            let result = handle_stop_share(&state, &room_id, &sender_id, None, ParticipantRole::Guest, None);
             prop_assert!(
                 matches!(result, ShareResult::Noop),
                 "no active share must return Noop"
@@ -1084,7 +1272,7 @@ mod tests {
             make_sfu_room(&state, &room_id, &[&owner_id, &other_id]);
             set_active_share(&state, &room_id, &owner_id);
 
-            let result = handle_stop_share(&state, &room_id, &other_id, None, ParticipantRole::Guest);
+            let result = handle_stop_share(&state, &room_id, &other_id, None, ParticipantRole::Guest, None);
             prop_assert!(
                 matches!(result, ShareResult::Noop),
                 "non-owner guest must return Noop"
@@ -1106,11 +1294,11 @@ mod tests {
             set_active_share(&state, &room_id, &owner_id);
 
             // First stop — should succeed
-            let r1 = handle_stop_share(&state, &room_id, &owner_id, None, ParticipantRole::Guest);
+            let r1 = handle_stop_share(&state, &room_id, &owner_id, None, ParticipantRole::Guest, None);
             prop_assert!(matches!(r1, ShareResult::Ok(_)));
 
             // Second stop — should be Noop
-            let r2 = handle_stop_share(&state, &room_id, &owner_id, None, ParticipantRole::Guest);
+            let r2 = handle_stop_share(&state, &room_id, &owner_id, None, ParticipantRole::Guest, None);
             prop_assert!(
                 matches!(r2, ShareResult::Noop),
                 "second stop must be Noop (idempotent)"

--- a/wavis-backend/src/voice/voice_orchestrator.rs
+++ b/wavis-backend/src/voice/voice_orchestrator.rs
@@ -710,6 +710,7 @@ pub fn leave_sub_room(
                         &members.info.participants,
                         participant_id,
                     ),
+                    share_type: None,
                 }));
             }
             Ok::<(), String>(())

--- a/wavis-backend/src/ws/ws_dispatch.rs
+++ b/wavis-backend/src/ws/ws_dispatch.rs
@@ -1866,7 +1866,7 @@ pub(crate) async fn dispatch_message(
             }
             DispatchOutcome::Continue
         }
-        SignalingMessage::StopShare(_payload) => {
+        SignalingMessage::StopShare(payload) => {
             // Session is guaranteed Some here (pre-join gate already handled above)
             let session_ref = ctx.session.as_ref().unwrap();
             let sender_id = session_ref.participant_id.as_str();
@@ -1889,8 +1889,9 @@ pub(crate) async fn dispatch_message(
                 ctx.app_state.room_state.as_ref(),
                 &room_id,
                 sender_id,
-                _payload.target_participant_id.as_deref(),
+                payload.target_participant_id.as_deref(),
                 sender_role,
+                payload.share_type,
             ) {
                 ShareResult::Ok(signals) => {
                     dispatch_signals(

--- a/wavis-backend/tests/screen_share_integration.rs
+++ b/wavis-backend/tests/screen_share_integration.rs
@@ -198,7 +198,7 @@ proptest! {
 
         let shares_before = get_active_shares(&state, "room-1");
 
-        let result = handle_stop_share(&state, "room-1", target, None, ParticipantRole::Guest);
+        let result = handle_stop_share(&state, "room-1", target, None, ParticipantRole::Guest, None);
 
         let shares_after = get_active_shares(&state, "room-1");
 
@@ -326,7 +326,7 @@ proptest! {
 
         // Test 1: Non-host targeted stop → permission error
         let result = handle_stop_share(
-            &state, "room-1", guest, Some(target), ParticipantRole::Guest,
+            &state, "room-1", guest, Some(target), ParticipantRole::Guest, None,
         );
         match &result {
             ShareResult::Error(SignalingMessage::Error(e)) => {
@@ -571,7 +571,7 @@ proptest! {
                 RoomOp::StopShare(peer) => {
                     if participants.contains(peer) {
                         let _ = handle_stop_share(
-                            &state, "room-1", peer, None, ParticipantRole::Guest,
+                            &state, "room-1", peer, None, ParticipantRole::Guest, None,
                         );
                     }
                 }
@@ -637,7 +637,14 @@ fn integration_full_share_lifecycle() {
     assert_eq!(shares.len(), 2);
 
     // peer-0 stops sharing
-    let r2 = handle_stop_share(&state, "room-1", "peer-0", None, ParticipantRole::Guest);
+    let r2 = handle_stop_share(
+        &state,
+        "room-1",
+        "peer-0",
+        None,
+        ParticipantRole::Guest,
+        None,
+    );
     match r2 {
         ShareResult::Ok(signals) => {
             assert_eq!(signals.len(), 1);


### PR DESCRIPTION
## Summary
- A participant running an independent video-type share (no companion audio) plus a separate standalone audio-only share had the second silently overwrite the first: `active_share_types` was a `HashMap<participant, WireShareType>` (one type per participant), not per concurrent slot. A late-joining/rejoining client's `ShareState` snapshot inherited the same collapse, so it could only ever learn about whichever share was started last — the other participant's badge silently vanished.
- Backend: `active_share_types` is now `HashMap<participant, HashSet<WireShareType>>`, keyed by category (`WireShareType::is_audio_only()`) so a video-type share and an audio-only share coexist per participant. `StopSharePayload`/`ShareStoppedPayload` gain an optional `share_type` so a client can stop one slot without clearing the other; `share_state` snapshot emits one entry per active slot.
- Frontend: `voice-room.ts`'s `share_started`/`share_stopped`/`share_state` handlers track the two slots independently (mirroring the two-slot model the self row already had). `ParticipantRow.tsx` renders both remote badges independently instead of if/else. A `confirmedAudioOnlySharers` set distinguishes LiveKit's track-inference guess (unconfirmed) from a real signaling-confirmed audio-only slot, since a later video-type event must correct the former but never clobber the latter.

## Test plan
- [x] Backend unit tests reproducing the collapse (`concurrent_video_and_audio_only_shares_both_survive_to_late_joiner_snapshot`, `stopping_one_slot_leaves_the_other_slot_active`) plus full existing suite — all pass
- [x] Frontend vitest suite — 1381 tests pass
- [x] `cargo fmt --check` / `clippy -D warnings` / `arch-check.mjs` / `eslint` (0 errors) / `depcruise` — all clean
- [x] New Playwright e2e regression test (`screen-share-rejoin-badges.spec.mjs`) verified red against the pre-fix backend (via a temporary revert) and green against the fix, run against a real backend + built app
- [x] Full existing live-backend Playwright suite (room-join/login/participants/chat/screen-share) re-verified green

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01JkTaxqBwGXQej9NHyEuETF