### PR TITLE
fix: stop screen-share aspect ratio oscillation for non-16:9 sources

### DIFF
--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -7159,11 +7159,16 @@ describe('fitPresetToSourceAspect', () => {
 
   it('returns null when source dimensions are unknown, so callers skip width/height constraints', () => {
     expect(fitPresetToSourceAspect({ width: 1920, height: 1080 }, {})).toBeNull();
-    expect(fitPresetToSourceAspect({ width: 1920, height: 1080 }, { width: 0, height: 720 })).toBeNull();
+    expect(
+      fitPresetToSourceAspect({ width: 1920, height: 1080 }, { width: 0, height: 720 }),
+    ).toBeNull();
   });
 
   it('never upscales beyond the source resolution', () => {
-    const fit = fitPresetToSourceAspect({ width: 2560, height: 1440 }, { width: 1280, height: 720 });
+    const fit = fitPresetToSourceAspect(
+      { width: 2560, height: 1440 },
+      { width: 1280, height: 720 },
+    );
     expect(fit).not.toBeNull();
     expect(fit!.width).toBe(1280);
     expect(fit!.height).toBe(720);

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -622,6 +622,7 @@ import {
   buildRtcConfiguration,
   isForceRelayEnabled,
   mapPassthroughFilterParams,
+  fitPresetToSourceAspect,
   type MediaCallbacks,
 } from '../livekit-media';
 import { CAMERA_QUALITY_HIGH } from '../camera-types';
@@ -7127,5 +7128,44 @@ describe('Feature: turn-relay-symmetric-nat-fix — buildRtcConfiguration and is
     vi.unstubAllEnvs();
     vi.stubEnv('VITE_WAVIS_FORCE_RELAY', 'true');
     expect(isForceRelayEnabled()).toBe(true);
+  });
+});
+
+describe('fitPresetToSourceAspect', () => {
+  it('preserves an ultrawide source aspect ratio instead of stamping the 16:9 preset box', () => {
+    // Santi's WGC capture: 2560x1072 (~2.39:1), fed through the DETAIL_PROFILE
+    // box (2560x1440). The 16:9 box is taller than the source, so it should
+    // fit exactly (scale=1) rather than being stretched to fill the box.
+    const detailFit = fitPresetToSourceAspect(
+      { width: 2560, height: 1440 },
+      { width: 2560, height: 1072 },
+    );
+    expect(detailFit).not.toBeNull();
+    expect(detailFit!.width).toBe(2560);
+    expect(detailFit!.height).toBe(1072);
+    expect(detailFit!.width / detailFit!.height).toBeCloseTo(2.388, 2);
+
+    // MOTION_PROFILE box (1920x1080) is narrower than the source — the fit
+    // must scale down while preserving aspect ratio, not stamp 1920x1080.
+    const motionFit = fitPresetToSourceAspect(
+      { width: 1920, height: 1080 },
+      { width: 2560, height: 1072 },
+    );
+    expect(motionFit).not.toBeNull();
+    expect(motionFit!.width).toBeLessThanOrEqual(1920);
+    expect(motionFit!.height).toBeLessThanOrEqual(1080);
+    expect(motionFit!.width / motionFit!.height).toBeCloseTo(2.388, 2);
+  });
+
+  it('returns null when source dimensions are unknown, so callers skip width/height constraints', () => {
+    expect(fitPresetToSourceAspect({ width: 1920, height: 1080 }, {})).toBeNull();
+    expect(fitPresetToSourceAspect({ width: 1920, height: 1080 }, { width: 0, height: 720 })).toBeNull();
+  });
+
+  it('never upscales beyond the source resolution', () => {
+    const fit = fitPresetToSourceAspect({ width: 2560, height: 1440 }, { width: 1280, height: 720 });
+    expect(fit).not.toBeNull();
+    expect(fit!.width).toBe(1280);
+    expect(fit!.height).toBe(720);
   });
 });

--- a/clients/wavis-gui/src/features/voice/__tests__/motion-detector.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/motion-detector.test.ts
@@ -23,12 +23,12 @@ function pushSamples(det: MotionDetector, count: number, ratio: number, startMs:
  *   - 5 samples: t=0,250,500,750,1000ms → dwell = 1000ms >= 1000ms ✓
  *   - 4 samples: t=0,...,750ms → dwell = 750ms < 1000ms ✗
  *
- * Switch-OUT (motion→detail), switchOutDwellMs=5000, starting at t=1250ms after 5 high samples:
+ * Switch-OUT (motion→detail), switchOutDwellMs=10000, starting at t=1250ms after 5 high samples:
  *   - rolling window needs 4 low samples (1s) to clear out high-ratio history
  *   - avg drops below 0.10 at the 4th low sample (t=2000ms): only low samples in window
- *   - dwell timer starts at t=2000ms; triggers at t=7000ms (20 more samples × 250ms = 5000ms)
- *   - total low samples needed: 4 (window clear) + 20 (dwell) = 24 → last at t=7000ms
- *   - 23 low samples: dwell = 6750 - 2000 = 4750ms < 5000ms ✗
+ *   - dwell timer starts at t=2000ms; triggers at t=12000ms (40 more samples × 250ms = 10000ms)
+ *   - total low samples needed: 4 (window clear) + 40 (dwell) = 44 → last at t=12000ms
+ *   - 43 low samples: dwell = 11750 - 2000 = 9750ms < 10000ms ✗
  */
 
 describe('MotionDetector', () => {
@@ -53,24 +53,24 @@ describe('MotionDetector', () => {
     expect(det.currentRecommendation()).toBe('detail');
   });
 
-  it('switches motion→detail after ≥5 s sustained <10% motion (accounting for rolling window)', () => {
+  it('switches motion→detail after ≥10 s sustained <10% motion (accounting for rolling window)', () => {
     const det = new MotionDetector();
     const t = pushSamples(det, 5, 0.5, 0);
     expect(det.currentRecommendation()).toBe('motion');
 
-    // 44 low samples: well past the 5 s dwell (triggers at t=7000ms)
-    pushSamples(det, 44, 0.05, t);
+    // 48 low samples: well past the 10 s dwell (triggers at t=12000ms)
+    pushSamples(det, 48, 0.05, t);
     expect(det.currentRecommendation()).toBe('detail');
     expect(det.lastSwitchReason()).toBe('auto_switch_out');
   });
 
-  it('does NOT switch-out before the 5 s dwell elapses', () => {
+  it('does NOT switch-out before the 10 s dwell elapses', () => {
     const det = new MotionDetector();
     const t = pushSamples(det, 5, 0.5, 0);
     expect(det.currentRecommendation()).toBe('motion');
 
-    // 23 low samples: dwell = 6750 - 2000 = 4750ms < 5000ms → no switch
-    pushSamples(det, 23, 0.05, t);
+    // 43 low samples: dwell = 11750 - 2000 = 9750ms < 10000ms → no switch
+    pushSamples(det, 43, 0.05, t);
     expect(det.currentRecommendation()).toBe('motion');
   });
 
@@ -137,8 +137,8 @@ describe('MotionDetector', () => {
     const t = pushSamples(det, 5, 0.5, 0);
     expect(det.lastSwitchReason()).toBe('auto_switch_in');
 
-    // 44 low samples to clear window and expire dwell
-    pushSamples(det, 44, 0.05, t);
+    // 48 low samples to clear window and expire dwell
+    pushSamples(det, 48, 0.05, t);
     expect(det.lastSwitchReason()).toBe('auto_switch_out');
   });
 

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -986,6 +986,29 @@ function getTrackSettingsSafe(track: MediaStreamTrack | undefined): Partial<Medi
   }
 }
 
+/**
+ * Fits a quality preset's resolution box to the source track's actual aspect
+ * ratio instead of stamping the preset's own (16:9) box directly. Non-16:9
+ * sources (e.g. ultrawide captures) would otherwise get re-adapted by the
+ * browser's video adapter on every profile switch, causing visible
+ * aspect-ratio churn for viewers. Returns null when source dimensions are
+ * unknown — callers should skip width/height constraints in that case.
+ */
+export function fitPresetToSourceAspect(
+  preset: { width: number; height: number },
+  sourceSettings: Partial<MediaTrackSettings>,
+): { width: number; height: number } | null {
+  const srcWidth = sourceSettings.width;
+  const srcHeight = sourceSettings.height;
+  if (!srcWidth || !srcHeight) return null;
+  const scale = Math.min(preset.width / srcWidth, preset.height / srcHeight, 1);
+  const evenRound = (n: number) => Math.max(2, Math.round(n / 2) * 2);
+  return {
+    width: evenRound(srcWidth * scale),
+    height: evenRound(srcHeight * scale),
+  };
+}
+
 function getTrackCapabilitiesSafe(track: MediaStreamTrack | undefined): Record<string, unknown> {
   if (!track || typeof track.getCapabilities !== 'function') return {};
   try {
@@ -4133,17 +4156,24 @@ export class LiveKitModule {
     const pub = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShare);
     if (!pub || !pub.track) return;
 
-    const preset = this.nativeCapturePublication
-      ? windowsNativeCapturePreset(quality)
-      : QUALITY_PRESETS[quality];
+    const isNativeCapture = this.nativeCapturePublication !== null;
+    const preset = isNativeCapture ? windowsNativeCapturePreset(quality) : QUALITY_PRESETS[quality];
     try {
       const track = pub.track.mediaStreamTrack;
       track.contentHint = preset.contentHint;
-      await track.applyConstraints({
-        width: { ideal: preset.resolution.width },
-        height: { ideal: preset.resolution.height },
-        frameRate: { max: preset.maxFramerate },
-      });
+      const constraints: MediaTrackConstraints = { frameRate: { max: preset.maxFramerate } };
+      // Native Rust capture already emits AR-preserving frames at a fixed size —
+      // stamping a 16:9 box here just makes Chromium's video adapter re-scale
+      // the encoder output on every switch. Only browser (getDisplayMedia)
+      // captures need the AR-fitted box.
+      if (!isNativeCapture) {
+        const fitted = fitPresetToSourceAspect(preset.resolution, getTrackSettingsSafe(track));
+        if (fitted) {
+          constraints.width = { ideal: fitted.width };
+          constraints.height = { ideal: fitted.height };
+        }
+      }
+      await track.applyConstraints(constraints);
       this.callbacks.onSystemEvent(`screen share quality: ${quality}`);
       // Re-report actual quality info so the UI updates
       const settings = getTrackSettingsSafe(track);
@@ -4670,10 +4700,17 @@ export class LiveKitModule {
     const preset = QUALITY_PRESETS[this.currentQuality];
     const idealFps = preset.maxFramerate;
     const constraints: MediaTrackConstraints = {
-      width: { ideal: preset.resolution.width },
-      height: { ideal: preset.resolution.height },
       frameRate: { min: 24, ideal: idealFps },
     };
+    // Native Rust capture already produces AR-preserving frames at a fixed
+    // size; only fit a width/height box for browser (getDisplayMedia) captures.
+    if (!this.nativeCapturePublication) {
+      const fitted = fitPresetToSourceAspect(preset.resolution, getTrackSettingsSafe(mediaTrack));
+      if (fitted) {
+        constraints.width = { ideal: fitted.width };
+        constraints.height = { ideal: fitted.height };
+      }
+    }
 
     const reportQualityInfo = () => {
       const settings = getTrackSettingsSafe(mediaTrack);

--- a/clients/wavis-gui/src/features/voice/motion-detector.ts
+++ b/clients/wavis-gui/src/features/voice/motion-detector.ts
@@ -30,7 +30,7 @@ export const DEFAULT_MOTION_DETECTOR_CONFIG: MotionDetectorConfig = {
   switchInAreaThreshold: 0.4,
   switchOutAreaThreshold: 0.1,
   switchInDwellMs: 1_000,
-  switchOutDwellMs: 5_000,
+  switchOutDwellMs: 10_000,
   sampleWindowMs: 1_000,
   sampleRateHz: 4,
 };

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -977,6 +977,11 @@ let _currentShareProfile: ShareProfileId = 'detail';
 let _stopAutoSwitchPoll: (() => void) | null = null;
 let selectedShareQuality: ShareQuality = 'high';
 
+/** Minimum time between applied auto-switches, independent of detector dwell,
+ *  to bound worst-case encoder churn regardless of content. */
+const MIN_PROFILE_SWITCH_INTERVAL_MS = 5_000;
+let _lastProfileSwitchAppliedAtMs = 0;
+
 /** Maps a ShareProfileId to the legacy ShareQuality for the existing setScreenShareQuality path. */
 function profileToQuality(profile: ShareProfileId): ShareQuality {
   return profile === 'motion' ? 'low' : 'high';
@@ -1017,6 +1022,9 @@ function startAutoSwitchPoll(): () => void {
       if (stopped || !_motionDetector) return;
       const recommendation = _motionDetector.currentRecommendation();
       if (recommendation === _currentShareProfile) return;
+      const now = Date.now();
+      if (now - _lastProfileSwitchAppliedAtMs < MIN_PROFILE_SWITCH_INTERVAL_MS) return;
+      _lastProfileSwitchAppliedAtMs = now;
       const reason: 'auto_in' | 'auto_out' = recommendation === 'motion' ? 'auto_in' : 'auto_out';
       await applyProfileSwitch(recommendation, reason).catch(() => {});
     })();
@@ -1028,6 +1036,7 @@ function startAutoSwitchPoll(): () => void {
 }
 
 async function initializeProfileSwitchAfterShareStart(): Promise<void> {
+  _lastProfileSwitchAppliedAtMs = 0;
   if (selectedShareQuality === 'max') {
     const from = _currentShareProfile;
     _currentShareProfile = 'detail';


### PR DESCRIPTION
## Summary
- Auto detail/motion profile switches stamped hard-coded 16:9 `width`/`height` constraints onto the screen-share track on every switch, forcing the browser's video adapter to re-scale non-16:9 sources (e.g. ultrawide WGC captures) mid-stream — visible to viewers as the share repeatedly zooming in and out.
- Added `fitPresetToSourceAspect()` to fit the preset box to the source's actual aspect ratio instead of stamping it directly; native Windows captures skip width/height constraints entirely since Rust already emits AR-preserving frames.
- Corrected `switchOutDwellMs` from `5_000` back to the spec value of `10_000` (`.kiro/specs/audio-video-polish/tasks-addendum.md` §A1.1), and added a 5s minimum interval between applied auto-switches as defense in depth against churn.

## Test plan
- [x] `npm run typecheck`
- [x] `npx eslint` on touched files — 0 errors (only pre-existing complexity/unsafe-any warnings)
- [x] `npm run lint:deps`
- [x] `node scripts/arch-check.mjs`
- [x] New unit tests for `fitPresetToSourceAspect` (ultrawide AR preserved, never-upscale, null-on-unknown-settings)
- [x] Updated `motion-detector.test.ts` for the corrected 10s switch-out dwell
- [x] Full `livekit-media.test.ts` + `motion-detector.test.ts` suites pass (153/153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjuaWXD2ALLoqUNJkVy6Qv