### PR TITLE
adding one time invite codes

### DIFF
--- a/.github/workflows/deploy-dev-ec2.yml
+++ b/.github/workflows/deploy-dev-ec2.yml
@@ -333,12 +333,13 @@ jobs:
         env:
           BACKEND_URL: ${{ vars.BACKEND_URL }}
           WS_URL: ${{ vars.WS_URL }}
+          ALPHA_INVITE_CODE: ${{ secrets.ALPHA_INVITE_CODE }}
         run: |
           set -euo pipefail
           missing=0
-          for name in BACKEND_URL WS_URL; do
+          for name in BACKEND_URL WS_URL ALPHA_INVITE_CODE; do
             if [ -z "${!name-}" ]; then
-              echo "::error::$name repository variable is required for deploy-dev-ec2.yml smoke tests"
+              echo "::error::$name repository variable/secret is required for deploy-dev-ec2.yml smoke tests"
               missing=1
             fi
           done
@@ -352,6 +353,7 @@ jobs:
           BACKEND_URL: ${{ vars.BACKEND_URL }}
           WS_URL: ${{ vars.WS_URL }}
           LIVEKIT_HEALTH_URL: ${{ vars.LIVEKIT_HEALTH_URL }}
+          ALPHA_INVITE_CODE: ${{ secrets.ALPHA_INVITE_CODE }}
           SMOKE_TIMEOUT_SECS: "10"
         run: python tools/smoke/smoke.py
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,16 @@ Set `REQUIRE_INVITE_CODE=false` to bypass invite validation in local development
 
 ## Identity
 
-Wavis uses credential-free device registration — no passwords, no OAuth. Each device gets a recovery phrase (Argon2id, AES-256-GCM encrypted at rest). Additional devices can be paired via QR or a short code. Recovery on a new device requires only the recovery phrase. Refresh tokens use HMAC-SHA256 hashing with reuse detection and session epoch for atomic logout-all.
+Wavis uses closed-alpha registration: `POST /auth/register` requires an
+`invite_code` / `inviteCode` value before the backend creates a user, device,
+or tokens. Alpha invite codes are stored only as HMAC-SHA256 hashes in Postgres
+and track expiry, disabled state, and redemption count. The legacy
+`POST /auth/register_device` endpoint is retired and returns `410 Gone`.
+
+Each account has a recovery phrase (Argon2id, AES-256-GCM encrypted at rest).
+Additional devices can be paired via QR or a short code. Recovery on a new
+device requires only the recovery phrase. Refresh tokens use HMAC-SHA256 hashing
+with reuse detection and session epoch for atomic logout-all.
 
 ## Voice Modes
 

--- a/clients/wavis-gui/e2e-tooling/README.md
+++ b/clients/wavis-gui/e2e-tooling/README.md
@@ -208,10 +208,10 @@ by registering a fresh, timestamp-suffixed throwaway account via the real
 registration has no email/CAPTCHA step, so this is cheap. `login.spec.mjs`
 is the one spec that exercises that UI as the thing under test; the other
 three treat it as setup. Channel/invite seeding for `room-join`/`chat`/
-`participants` uses REST (`POST /auth/register_device`,
-`POST /channels`, `POST /channels/:id/invites` — see `doc/QUICKSTART.md`
-§11) for the channel _owner_, so that identity never needs to touch the GUI
-at all.
+`participants` uses REST (`POST /auth/register`, `POST /channels`,
+`POST /channels/:id/invites`) for the channel _owner_, so that identity never
+needs to touch the GUI at all. Closed-alpha registration requires
+`ALPHA_INVITE_CODE` to point at a pre-seeded multi-use invite.
 
 **Second participant (chat/participants specs).** These need a second
 connected participant to assert anything meaningful. Two real
@@ -382,17 +382,15 @@ tests/audio-received.spec.mjs` — must connect and read a real decoded
 
 All three specs, plus the full pre-existing suite, pass now.
 
-**Rate limiting.** The backend's register/register_device rate limiter is
+**Rate limiting.** The backend's registration rate limiter is
 in-process, per-IP, and allows only **5 registrations per hour** by default
 (`AuthRateLimiterConfig` in `wavis-backend/src/auth/auth_rate_limiter.rs`) —
-and `/auth/register` (each spec's `registerViaUi`) and
-`/auth/register_device` (each spec's `seedChannelWithInvite` owner) draw
-from the **same** window. At ~2 registrations per spec, one full 7-spec run
-needs ~14, so specs past the first two or three fail setup with `429`
-(`register_device failed: 429` from `live-backend-helpers.mjs`) even on a
-freshly restarted backend. For e2e use, raise the limit when starting the
-stack — the backend reads `AUTH_REGISTER_RATE_LIMIT` and docker-compose.yml
-passes it through (default stays 5):
+and `/auth/register` calls from both `registerViaUi` and
+`seedChannelWithInvite` draw from the **same** window. At ~2 registrations per
+spec, one full 7-spec run needs ~14, so specs past the first two or three fail
+setup with `429` even on a freshly restarted backend. For e2e use, raise the
+limit when starting the stack — the backend reads `AUTH_REGISTER_RATE_LIMIT`
+and docker-compose.yml passes it through (default stays 5):
 
 ```powershell
 $env:AUTH_REGISTER_RATE_LIMIT="200"; docker compose up -d --build

--- a/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
@@ -75,14 +75,25 @@ export async function waitForBackendHealth(timeoutMs = 30_000) {
 }
 
 /**
- * POST /auth/register_device — mints a full session with no UI/phrase step.
+ * POST /auth/register — mints a full closed-alpha session with no UI step.
  * Use this for identities that never need to touch the GUI (e.g. a channel
  * owner in room-join.spec.mjs), not as a substitute for exercising the real
  * auth UI (that's what registerViaUi / login.spec.mjs are for).
  */
 export async function registerDevice() {
-  const res = await fetch(`${SERVER_URL}/auth/register_device`, { method: 'POST' });
-  if (!res.ok) throw new Error(`register_device failed: ${res.status}`);
+  const inviteCode = process.env.ALPHA_INVITE_CODE;
+  if (!inviteCode) throw new Error('ALPHA_INVITE_CODE must be set for REST auth seeding');
+  const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const res = await fetch(`${SERVER_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      phrase: `e2e-password-${suffix}`,
+      username: `E2E-${suffix}`,
+      inviteCode,
+    }),
+  });
+  if (!res.ok) throw new Error(`register failed: ${res.status}`);
   return res.json(); // { user_id, device_id, recovery_id, access_token, refresh_token }
 }
 
@@ -102,7 +113,7 @@ export async function createInvite(
   ); // { code, channel_id, ... }
 }
 
-/** REST-seeds a channel + invite owned by a fresh register_device identity. */
+/** REST-seeds a channel + invite owned by a fresh closed-alpha identity. */
 export async function seedChannelWithInvite(name) {
   const owner = await registerDevice();
   const channel = await createChannel(owner.access_token, name);

--- a/infrastructure/environments/dev-ecs/README.md
+++ b/infrastructure/environments/dev-ecs/README.md
@@ -56,6 +56,21 @@ Current automated dev deploy verification lives in:
 The smoke test runs against the current public dev entrypoint and fails the
 workflow if signaling or room join regresses after deployment.
 
+Closed-alpha registration adds one smoke prerequisite: the backend runtime must
+have `ALPHA_INVITE_CODE_PEPPER` set in SSM, the dev database must contain a
+matching alpha invite row, and GitHub Actions must expose the raw invite through
+the `ALPHA_INVITE_CODE` secret. Seed the DB with:
+
+```bash
+ALPHA_INVITE_CODE='shared-dev-ci-code' \
+ALPHA_INVITE_CODE_PEPPER='real-32-byte-minimum-pepper-value' \
+DATABASE_URL='postgres://...' \
+python3 scripts/seed-alpha-invite.py --execute
+```
+
+The seed helper defaults to `1000000` max redemptions so dev/CI smoke invites do
+not silently exhaust.
+
 The CloudWatch dashboard name is also exported from Terraform as:
 
 - `ops_dashboard_name`
@@ -90,6 +105,8 @@ terraform apply
 
 - Secret parameters are created with placeholders and `ignore_changes = [value]`.
   This matches the existing dev pattern: Terraform creates them once, operators rotate them out-of-band without Terraform trying to overwrite them later.
+- `ALPHA_INVITE_CODE_PEPPER` is security-critical. A release backend exits at
+  startup if it is missing or shorter than 32 bytes.
 - Local `terraform.tfvars` is intentionally ignored and should not be committed.
 - The ECS task builds `DATABASE_URL` at runtime from the RDS endpoint plus the
   `RDS_MASTER_PASSWORD` secret so the database password is not duplicated into a

--- a/infrastructure/environments/dev-ecs/main.tf
+++ b/infrastructure/environments/dev-ecs/main.tf
@@ -131,6 +131,7 @@ locals {
   secrets = {
     AUTH_JWT_SECRET         = "CHANGE-ME-auth-secret-32-bytes!!"
     AUTH_REFRESH_PEPPER     = "CHANGE-ME-pepper-32-bytes-min!!!"
+    ALPHA_INVITE_CODE_PEPPER = "CHANGE-ME-alpha-invite-pepper-32b"
     PHRASE_ENCRYPTION_KEY   = "CHANGE-ME-base64-32-byte-key!!!!"
     PAIRING_CODE_PEPPER     = "CHANGE-ME-pairing-pepper-32b!!!!"
     SFU_JWT_SECRET          = "CHANGE-ME-sfu-secret-32-bytes!!!"

--- a/infrastructure/environments/dev/README.md
+++ b/infrastructure/environments/dev/README.md
@@ -114,9 +114,23 @@ aws ssm put-parameter --region us-east-2 `
   --type SecureString --overwrite
 
 # Repeat for other secrets: AUTH_JWT_SECRET, AUTH_REFRESH_PEPPER,
-# PHRASE_ENCRYPTION_KEY, PAIRING_CODE_PEPPER, SFU_JWT_SECRET,
-# LIVEKIT_API_KEY, LIVEKIT_API_SECRET
+# ALPHA_INVITE_CODE_PEPPER, PHRASE_ENCRYPTION_KEY, PAIRING_CODE_PEPPER,
+# SFU_JWT_SECRET, LIVEKIT_API_KEY, LIVEKIT_API_SECRET
 ```
+
+Closed-alpha registration also requires a seeded invite row and a matching
+GitHub Actions secret before deploy smoke tests can pass:
+
+```powershell
+$env:ALPHA_INVITE_CODE = "shared-dev-ci-code"
+$env:ALPHA_INVITE_CODE_PEPPER = "real-32-byte-minimum-pepper-value"
+$env:DATABASE_URL = "postgres://..."
+python scripts/seed-alpha-invite.py --execute
+```
+
+Set the GitHub Actions secret `ALPHA_INVITE_CODE` to the raw invite code used
+above. The seed helper defaults to `1000000` max redemptions so shared dev/CI
+invites do not silently exhaust.
 
 ### 7. Verify No Placeholders Remain
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,3 +67,17 @@ Rust-based interactive WebSocket test client (async, tokio). Same idea as `ws-te
 $env:WS_URL = "ws://localhost:3000/ws"   # optional, defaults to localhost
 cargo run -p ws-sfu-test
 ```
+# Alpha Invite Seeding
+
+Closed-alpha registration stores only HMAC hashes of invite codes. Use the
+seed helper to create a dev/CI invite without hand-computing the hash:
+
+```bash
+ALPHA_INVITE_CODE='example-alpha-code' \
+ALPHA_INVITE_CODE_PEPPER='real-32-byte-minimum-pepper-value' \
+DATABASE_URL='postgres://...' \
+python3 scripts/seed-alpha-invite.py --execute
+```
+
+The default `max_redemptions` is `1000000` so shared dev/CI smoke invites do
+not silently exhaust. Use `--max-redemptions 1` for one-time invites.

--- a/scripts/seed-alpha-invite.py
+++ b/scripts/seed-alpha-invite.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Seed a closed-alpha invite row.
+
+By default this prints SQL that can be piped to psql. With --execute it invokes
+psql directly using DATABASE_URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import os
+import subprocess
+import sys
+
+HASH_DOMAIN = b"alpha-invite:v1:"
+DEFAULT_MAX_REDEMPTIONS = 1_000_000
+
+
+def normalize_invite_code(code: str) -> str:
+    normalized = "".join(
+        char.upper() for char in code.strip() if not char.isspace() and char != "-"
+    )
+    if not normalized:
+        raise ValueError("invite code is empty after normalization")
+    return normalized
+
+
+def hash_invite_code(code: str, pepper: str) -> str:
+    normalized = normalize_invite_code(code)
+    digest = hmac.new(
+        pepper.encode("utf-8"),
+        HASH_DOMAIN + normalized.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+    return digest
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def build_sql(code_hash_hex: str, max_redemptions: int, expires_at: str | None) -> str:
+    expires_sql = "NULL" if not expires_at else f"{sql_literal(expires_at)}::timestamptz"
+    return f"""\
+INSERT INTO alpha_invites (code_hash, max_redemptions, expires_at)
+VALUES (decode('{code_hash_hex}', 'hex'), {max_redemptions}, {expires_sql})
+ON CONFLICT (code_hash) DO UPDATE
+SET max_redemptions = GREATEST(alpha_invites.max_redemptions, EXCLUDED.max_redemptions),
+    expires_at = EXCLUDED.expires_at
+RETURNING invite_id, max_redemptions, redemption_count, expires_at;
+"""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--code",
+        default=os.environ.get("ALPHA_INVITE_CODE"),
+        help="Raw invite code. Defaults to ALPHA_INVITE_CODE.",
+    )
+    parser.add_argument(
+        "--pepper",
+        default=os.environ.get("ALPHA_INVITE_CODE_PEPPER"),
+        help="Invite HMAC pepper. Defaults to ALPHA_INVITE_CODE_PEPPER.",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=os.environ.get("DATABASE_URL"),
+        help="Postgres URL used with --execute. Defaults to DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--max-redemptions",
+        type=int,
+        default=DEFAULT_MAX_REDEMPTIONS,
+        help=f"Maximum redemptions to seed. Defaults to {DEFAULT_MAX_REDEMPTIONS}.",
+    )
+    parser.add_argument(
+        "--expires-at",
+        help="Optional timestamptz value, for example 2026-12-31T23:59:59Z.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the generated SQL with psql instead of printing it.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.code:
+        print("error: --code or ALPHA_INVITE_CODE is required", file=sys.stderr)
+        return 2
+    if not args.pepper:
+        print("error: --pepper or ALPHA_INVITE_CODE_PEPPER is required", file=sys.stderr)
+        return 2
+    if len(args.pepper) < 32:
+        print("error: invite pepper must be at least 32 bytes", file=sys.stderr)
+        return 2
+    if args.max_redemptions <= 0:
+        print("error: --max-redemptions must be positive", file=sys.stderr)
+        return 2
+
+    try:
+        code_hash_hex = hash_invite_code(args.code, args.pepper)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    sql = build_sql(code_hash_hex, args.max_redemptions, args.expires_at)
+
+    if not args.execute:
+        print(sql, end="")
+        return 0
+
+    if not args.database_url:
+        print("error: --database-url or DATABASE_URL is required with --execute", file=sys.stderr)
+        return 2
+
+    completed = subprocess.run(
+        ["psql", args.database_url, "-v", "ON_ERROR_STOP=1"],
+        input=sql,
+        text=True,
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gui-surface-test/src/client.rs
+++ b/tools/gui-surface-test/src/client.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 
 /// Authenticated HTTP client for surface tests.
 ///
-/// Registers a device, obtains a bearer token, and provides helpers
+/// Registers a closed-alpha user, obtains a bearer token, and provides helpers
 /// for making authenticated requests to the backend REST API.
 pub struct AuthenticatedClient {
     pub http: reqwest::Client,
@@ -22,11 +22,19 @@ struct RegisterResponse {
 }
 
 impl AuthenticatedClient {
-    /// Register a new device and return an authenticated client.
+    /// Register a new user and return an authenticated client.
     pub async fn register(base_url: &str, http: &reqwest::Client) -> Result<Self, String> {
-        let url = format!("{base_url}/auth/register_device");
+        let invite_code = std::env::var("ALPHA_INVITE_CODE")
+            .map_err(|_| "ALPHA_INVITE_CODE must be set for surface auth seeding".to_string())?;
+        let suffix = uuid::Uuid::new_v4().simple().to_string();
+        let url = format!("{base_url}/auth/register");
         let resp = http
             .post(&url)
+            .json(&serde_json::json!({
+                "phrase": format!("surface-password-{suffix}"),
+                "username": format!("Surface-{suffix}"),
+                "inviteCode": invite_code,
+            }))
             .send()
             .await
             .map_err(|e| format!("register request failed: {e}"))?;

--- a/tools/gui-surface-test/src/scenarios/auth_flow.rs
+++ b/tools/gui-surface-test/src/scenarios/auth_flow.rs
@@ -1,7 +1,7 @@
 /// Auth Flow Scenarios
 ///
 /// Tests the REST endpoints the GUI auth layer depends on:
-/// - POST /auth/register_device  — success, response shape
+/// - POST /auth/register  — success, response shape
 /// - POST /auth/refresh           — valid refresh, invalid token
 /// - Authenticated request with valid token succeeds
 /// - Authenticated request without token returns 401
@@ -66,12 +66,34 @@ async fn check_register_success(
     ctx: &TestContext,
     failures: &mut Vec<AssertionFailure>,
 ) -> Option<RegisterResponse> {
-    let url = format!("{}/auth/register_device", ctx.base_url);
-    let resp = match ctx.http_client.post(&url).send().await {
+    let invite_code = match std::env::var("ALPHA_INVITE_CODE") {
+        Ok(code) => code,
+        Err(_) => {
+            failures.push(AssertionFailure {
+                check: "ALPHA_INVITE_CODE env".into(),
+                expected: "configured invite code".into(),
+                actual: "missing".into(),
+            });
+            return None;
+        }
+    };
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let url = format!("{}/auth/register", ctx.base_url);
+    let resp = match ctx
+        .http_client
+        .post(&url)
+        .json(&serde_json::json!({
+            "phrase": format!("surface-auth-flow-{suffix}"),
+            "username": format!("SurfaceAuth-{suffix}"),
+            "inviteCode": invite_code,
+        }))
+        .send()
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
             failures.push(AssertionFailure {
-                check: "POST /auth/register_device request".into(),
+                check: "POST /auth/register request".into(),
                 expected: "response".into(),
                 actual: format!("error: {e}"),
             });
@@ -81,7 +103,7 @@ async fn check_register_success(
 
     if resp.status() != reqwest::StatusCode::CREATED {
         failures.push(AssertionFailure {
-            check: "POST /auth/register_device status".into(),
+            check: "POST /auth/register status".into(),
             expected: "201".into(),
             actual: format!("{}", resp.status()),
         });

--- a/tools/smoke/smoke.py
+++ b/tools/smoke/smoke.py
@@ -11,10 +11,11 @@ Environment variables:
   WS_URL              WebSocket URL   (e.g. wss://example.cloudfront.net/ws)
   LIVEKIT_HEALTH_URL  LiveKit health  (e.g. http://<ip>:7880/) - optional, skipped if unset
   SMOKE_TIMEOUT_SECS  Per-operation timeout in seconds (default: 10)
+  ALPHA_INVITE_CODE   Pre-seeded closed-alpha invite code for smoke users
 
 Test sequence (each depends on prior steps):
   1  HTTPS /health                          blocking
-  2  POST /auth/register_device             blocking
+  2  POST /auth/register                    blocking
   3  WebSocket connect                      blocking
   4  Ping (no error response)               blocking
   5  Auth -> auth_success                   blocking
@@ -25,7 +26,7 @@ Test sequence (each depends on prior steps):
   10 leave + disconnect                     blocking
   11 POST /channels                         blocking
   12 POST /channels/{id}/invites            blocking
-  13 POST /auth/register_device (user 2)    blocking
+  13 POST /auth/register (user 2)           blocking
   14 POST /channels/join                    blocking
   15 User 1 WSS auth + join_voice           blocking
   16 User 2 WSS auth + join_voice           blocking
@@ -57,6 +58,7 @@ BACKEND_URL = os.environ["BACKEND_URL"].rstrip("/")
 WS_URL = os.environ["WS_URL"]
 LIVEKIT_URL = os.environ.get("LIVEKIT_HEALTH_URL", "").strip()
 TIMEOUT = int(os.environ.get("SMOKE_TIMEOUT_SECS", "10"))
+ALPHA_INVITE_CODE = os.environ.get("ALPHA_INVITE_CODE", "").strip()
 
 PASSED = []
 FAILED = []
@@ -80,6 +82,21 @@ def warn(name: str, reason: str):
 
 def auth_headers(access_token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {access_token}"}
+
+
+def register_smoke_user(label: str) -> dict:
+    assert ALPHA_INVITE_CODE, "ALPHA_INVITE_CODE must be set to a pre-seeded alpha invite"
+    response = httpx.post(
+        f"{BACKEND_URL}/auth/register",
+        json={
+            "phrase": f"smoke-password-{label}-{uuid.uuid4()}",
+            "username": f"Smoke{label}-{uuid.uuid4().hex[:8]}",
+            "inviteCode": ALPHA_INVITE_CODE,
+        },
+        timeout=TIMEOUT,
+    )
+    assert response.status_code == 201, f"HTTP {response.status_code} (expected 201 CREATED)"
+    return response.json()
 
 
 def normalize_livekit_url(url: str) -> str:
@@ -226,14 +243,12 @@ async def run_smoke():
 
     access_token = None
     try:
-        r = httpx.post(f"{BACKEND_URL}/auth/register_device", timeout=TIMEOUT)
-        assert r.status_code == 201, f"HTTP {r.status_code} (expected 201 CREATED)"
-        body = r.json()
+        body = register_smoke_user("One")
         assert "access_token" in body, f"missing access_token in response: {list(body.keys())}"
         access_token = body["access_token"]
-        ok("2_device_register")
+        ok("2_register")
     except Exception as e:
-        fail("2_device_register", str(e))
+        fail("2_register", str(e))
 
     try:
         async with websockets.connect(WS_URL, open_timeout=TIMEOUT) as ws:
@@ -381,16 +396,14 @@ async def run_smoke():
         fail("12_create_invite", "skipped - no authenticated channel owner from steps 2/11")
 
     try:
-        r = httpx.post(f"{BACKEND_URL}/auth/register_device", timeout=TIMEOUT)
-        assert r.status_code == 201, f"HTTP {r.status_code} (expected 201 CREATED)"
-        body = r.json()
+        body = register_smoke_user("Two")
         second_access_token = body.get("access_token")
         second_user_id = body.get("user_id")
         assert second_access_token, f"missing access_token in response: {body}"
         assert second_user_id, f"missing user_id in response: {body}"
-        ok("13_second_device_register")
+        ok("13_second_register")
     except Exception as e:
-        fail("13_second_device_register", str(e))
+        fail("13_second_register", str(e))
 
     if invite_code and second_access_token and channel_id:
         try:

--- a/tools/stress/src/scenarios/auth_brute_force.rs
+++ b/tools/stress/src/scenarios/auth_brute_force.rs
@@ -1,6 +1,6 @@
 /// AuthBruteForceScenario — Auth REST rate limiter validation
 ///
-/// Hammers `POST /auth/register_device` and `POST /auth/refresh` from a single IP
+/// Hammers `POST /auth/register` and `POST /auth/refresh` from a single IP
 /// to validate that `AuthRateLimiter` fires correctly.
 ///
 /// Phase 1 — Register flood: Send N register requests (N > default threshold of 5).
@@ -131,21 +131,36 @@ async fn run_external(ctx: &TestContext, violations: &mut Vec<InvariantViolation
     let base_url = ws_url_to_http(&ctx.ws_url);
 
     // --- Phase 1: Register flood ---
-    let register_url = format!("{base_url}/auth/register_device");
+    let register_url = format!("{base_url}/auth/register");
+    let invite_code =
+        std::env::var("ALPHA_INVITE_CODE").unwrap_or_else(|_| "stress-invalid-alpha".to_string());
     let mut got_429_register = false;
     // Send more than the default threshold (5). Send 10 to be safe.
     let register_attempts = 10;
 
     for i in 0..register_attempts {
-        let resp = ctx.http_client.post(&register_url).send().await;
+        let resp = ctx
+            .http_client
+            .post(&register_url)
+            .json(&serde_json::json!({
+                "phrase": format!("stress-register-{i}"),
+                "username": format!("StressRegister{i}"),
+                "inviteCode": invite_code,
+            }))
+            .send()
+            .await;
 
         match resp {
             Ok(r) if r.status() == reqwest::StatusCode::TOO_MANY_REQUESTS => {
                 got_429_register = true;
                 break;
             }
-            Ok(r) if r.status() == reqwest::StatusCode::CREATED => {
-                // Allowed — expected for first N requests.
+            Ok(r)
+                if r.status() == reqwest::StatusCode::CREATED
+                    || r.status() == reqwest::StatusCode::UNAUTHORIZED =>
+            {
+                // Allowed through the rate limiter. The invite may be valid
+                // or invalid; this scenario only asserts limiter behavior.
             }
             Ok(r) => {
                 // 500 is acceptable (dummy DB in some configs), but not a rate limit.

--- a/tools/stress/src/scenarios/auth_state_machine_race.rs
+++ b/tools/stress/src/scenarios/auth_state_machine_race.rs
@@ -354,10 +354,17 @@ async fn get_access_token(ctx: &TestContext) -> Result<String, String> {
         .map_err(|e| format!("register_device failed: {e}"))?;
         Ok(reg.access_token)
     } else {
-        // External: register a device via REST.
+        // External: register a closed-alpha user via REST.
         let base_url = ws_url_to_http(&ctx.ws_url);
+        let invite_code = std::env::var("ALPHA_INVITE_CODE")
+            .map_err(|_| "ALPHA_INVITE_CODE must be set for external auth seeding".to_string())?;
         let resp = reqwest::Client::new()
-            .post(format!("{base_url}/auth/register_device"))
+            .post(format!("{base_url}/auth/register"))
+            .json(&serde_json::json!({
+                "phrase": "auth-state-machine-race-password",
+                "username": "AuthStateMachineRace",
+                "inviteCode": invite_code,
+            }))
             .send()
             .await
             .map_err(|e| format!("register request failed: {e}"))?;

--- a/tools/stress/src/scenarios/refresh_token_reuse.rs
+++ b/tools/stress/src/scenarios/refresh_token_reuse.rs
@@ -66,13 +66,34 @@ impl Scenario for RefreshTokenReuseScenario {
 
 async fn run_external(ctx: &TestContext, violations: &mut Vec<InvariantViolation>) {
     let base_url = ws_url_to_http(&ctx.ws_url);
-    let register_url = format!("{base_url}/auth/register_device");
+    let register_url = format!("{base_url}/auth/register");
     let refresh_url = format!("{base_url}/auth/refresh");
+    let invite_code = match std::env::var("ALPHA_INVITE_CODE") {
+        Ok(code) => code,
+        Err(_) => {
+            violations.push(InvariantViolation {
+                invariant: "refresh_reuse: alpha invite configured".to_owned(),
+                expected: "ALPHA_INVITE_CODE env var".to_owned(),
+                actual: "missing".to_owned(),
+            });
+            return;
+        }
+    };
 
     // =========================================================================
     // Step 1: Register a device
     // =========================================================================
-    let resp = match ctx.http_client.post(&register_url).send().await {
+    let resp = match ctx
+        .http_client
+        .post(&register_url)
+        .json(&serde_json::json!({
+            "phrase": "refresh-reuse-password",
+            "username": "RefreshReuse",
+            "inviteCode": invite_code,
+        }))
+        .send()
+        .await
+    {
         Ok(r) => r,
         Err(e) => {
             violations.push(InvariantViolation {

--- a/wavis-backend/migrations/019_create_alpha_invites.sql
+++ b/wavis-backend/migrations/019_create_alpha_invites.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS alpha_invites (
+    invite_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    code_hash BYTEA NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ,
+    disabled_at TIMESTAMPTZ,
+    max_redemptions INTEGER NOT NULL DEFAULT 1,
+    redemption_count INTEGER NOT NULL DEFAULT 0,
+    CHECK (max_redemptions > 0),
+    CHECK (redemption_count >= 0),
+    CHECK (redemption_count <= max_redemptions)
+);
+
+CREATE INDEX IF NOT EXISTS idx_alpha_invites_expires_at ON alpha_invites (expires_at);
+CREATE INDEX IF NOT EXISTS idx_alpha_invites_disabled_at ON alpha_invites (disabled_at);
+
+CREATE TABLE IF NOT EXISTS alpha_invite_redemptions (
+    redemption_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    invite_id UUID NOT NULL REFERENCES alpha_invites(invite_id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    device_id UUID NOT NULL REFERENCES devices(device_id) ON DELETE CASCADE,
+    redeemed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alpha_invite_redemptions_invite_id
+    ON alpha_invite_redemptions (invite_id);
+CREATE INDEX IF NOT EXISTS idx_alpha_invite_redemptions_user_id
+    ON alpha_invite_redemptions (user_id);

--- a/wavis-backend/src/app_state.rs
+++ b/wavis-backend/src/app_state.rs
@@ -257,7 +257,7 @@ impl AppState {
             Ok(s) => s,
             Err(_) => {
                 if cfg!(debug_assertions) {
-                    "dev-alpha-invite-pepper-32b!!XX".to_string()
+                    "dev-alpha-invite-pepper-32b!!XXX".to_string()
                 } else {
                     panic!("ALPHA_INVITE_CODE_PEPPER must be set in release builds");
                 }

--- a/wavis-backend/src/app_state.rs
+++ b/wavis-backend/src/app_state.rs
@@ -135,6 +135,8 @@ pub struct AppState {
     pub refresh_token_pepper: Arc<Vec<u8>>,
     /// Previous pepper for zero-downtime pepper rotation.
     pub refresh_token_pepper_previous: Option<Arc<Vec<u8>>>,
+    /// HMAC pepper for closed-alpha invite code hashing.
+    pub alpha_invite_code_pepper: Arc<Vec<u8>>,
     /// Channel_ID → active Room_ID mapping. A Channel has at most one active Room.
     /// Lock ordering position 0: active_room_map (0) → rooms (1) → per-room (2) → peer_to_room (3).
     pub active_room_map: ActiveRoomMap,
@@ -251,6 +253,21 @@ impl AppState {
         #[cfg(windows)]
         let ec2_controller = None;
 
+        let alpha_invite_code_pepper = match std::env::var("ALPHA_INVITE_CODE_PEPPER") {
+            Ok(s) => s,
+            Err(_) => {
+                if cfg!(debug_assertions) {
+                    "dev-alpha-invite-pepper-32b!!XX".to_string()
+                } else {
+                    panic!("ALPHA_INVITE_CODE_PEPPER must be set in release builds");
+                }
+            }
+        };
+        if alpha_invite_code_pepper.len() < 32 {
+            panic!("ALPHA_INVITE_CODE_PEPPER must be at least 32 bytes");
+        }
+        let alpha_invite_code_pepper = Arc::new(alpha_invite_code_pepper.into_bytes());
+
         Self {
             room_state: Arc::new(InMemoryRoomState::new()),
             connections: Arc::new(LiveConnections::new()),
@@ -316,6 +333,7 @@ impl AppState {
             admin_token: std::env::var("ADMIN_TOKEN").ok().filter(|s| !s.is_empty()),
             refresh_token_pepper,
             refresh_token_pepper_previous,
+            alpha_invite_code_pepper,
             active_room_map: Arc::new(RwLock::new(HashMap::new())),
             dummy_verifier,
             pairing_code_pepper,

--- a/wavis-backend/src/auth/alpha_invite.rs
+++ b/wavis-backend/src/auth/alpha_invite.rs
@@ -1,0 +1,150 @@
+//! Closed-alpha invite code normalization, hashing, and redemption.
+//!
+//! Raw invite codes are never persisted. The database stores only HMAC-SHA256
+//! hashes computed with a dedicated server-side pepper.
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use sqlx::{Postgres, Transaction};
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const HASH_DOMAIN: &[u8] = b"alpha-invite:v1:";
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AlphaInviteError {
+    #[error("invite code invalid")]
+    Invalid,
+    #[error("database error: {0}")]
+    DatabaseError(String),
+}
+
+pub fn normalize_invite_code(code: &str) -> Result<String, AlphaInviteError> {
+    let normalized: String = code
+        .trim()
+        .chars()
+        .filter(|c| !c.is_ascii_whitespace() && *c != '-')
+        .map(|c| c.to_ascii_uppercase())
+        .collect();
+
+    if normalized.is_empty() {
+        return Err(AlphaInviteError::Invalid);
+    }
+
+    Ok(normalized)
+}
+
+pub fn hash_invite_code(code: &str, pepper: &[u8]) -> Result<Vec<u8>, AlphaInviteError> {
+    let normalized = normalize_invite_code(code)?;
+    let mut mac = HmacSha256::new_from_slice(pepper).expect("HMAC-SHA256 accepts any key length");
+    mac.update(HASH_DOMAIN);
+    mac.update(normalized.as_bytes());
+    Ok(mac.finalize().into_bytes().to_vec())
+}
+
+pub async fn redeem_alpha_invite(
+    tx: &mut Transaction<'_, Postgres>,
+    code: &str,
+    pepper: &[u8],
+) -> Result<Uuid, AlphaInviteError> {
+    let code_hash = hash_invite_code(code, pepper)?;
+
+    let row: Option<(
+        Uuid,
+        Option<chrono::DateTime<chrono::Utc>>,
+        Option<chrono::DateTime<chrono::Utc>>,
+        i32,
+        i32,
+    )> = sqlx::query_as(
+        "SELECT invite_id, expires_at, disabled_at, max_redemptions, redemption_count \
+             FROM alpha_invites \
+             WHERE code_hash = $1 \
+             FOR UPDATE",
+    )
+    .bind(&code_hash)
+    .fetch_optional(&mut **tx)
+    .await
+    .map_err(|e| AlphaInviteError::DatabaseError(e.to_string()))?;
+
+    let Some((invite_id, expires_at, disabled_at, max_redemptions, redemption_count)) = row else {
+        return Err(AlphaInviteError::Invalid);
+    };
+
+    let now = chrono::Utc::now();
+    if disabled_at.is_some()
+        || expires_at.is_some_and(|expires_at| now >= expires_at)
+        || redemption_count >= max_redemptions
+    {
+        return Err(AlphaInviteError::Invalid);
+    }
+
+    sqlx::query(
+        "UPDATE alpha_invites \
+         SET redemption_count = redemption_count + 1 \
+         WHERE invite_id = $1",
+    )
+    .bind(invite_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| AlphaInviteError::DatabaseError(e.to_string()))?;
+
+    Ok(invite_id)
+}
+
+pub async fn record_redemption(
+    tx: &mut Transaction<'_, Postgres>,
+    invite_id: Uuid,
+    user_id: Uuid,
+    device_id: Uuid,
+) -> Result<(), AlphaInviteError> {
+    sqlx::query(
+        "INSERT INTO alpha_invite_redemptions (invite_id, user_id, device_id) \
+         VALUES ($1, $2, $3)",
+    )
+    .bind(invite_id)
+    .bind(user_id)
+    .bind(device_id)
+    .execute(&mut **tx)
+    .await
+    .map_err(|e| AlphaInviteError::DatabaseError(e.to_string()))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AlphaInviteError, hash_invite_code, normalize_invite_code};
+
+    const PEPPER: &[u8] = b"test-alpha-invite-pepper-32b!!!!";
+
+    #[test]
+    fn normalize_invite_code_removes_spacing_hyphens_and_uppercases() {
+        assert_eq!(
+            normalize_invite_code(" abcd-1234 ef ").unwrap(),
+            "ABCD1234EF"
+        );
+    }
+
+    #[test]
+    fn normalize_invite_code_rejects_empty_values() {
+        assert_eq!(
+            normalize_invite_code(" - \t\n ").unwrap_err(),
+            AlphaInviteError::Invalid
+        );
+    }
+
+    #[test]
+    fn hash_invite_code_is_stable_for_equivalent_codes() {
+        let a = hash_invite_code("alpha-code-1", PEPPER).unwrap();
+        let b = hash_invite_code(" ALPHA CODE 1 ", PEPPER).unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn hash_invite_code_differs_for_different_codes() {
+        let a = hash_invite_code("alpha-code-1", PEPPER).unwrap();
+        let b = hash_invite_code("alpha-code-2", PEPPER).unwrap();
+        assert_ne!(a, b);
+    }
+}

--- a/wavis-backend/src/auth/alpha_invite.rs
+++ b/wavis-backend/src/auth/alpha_invite.rs
@@ -9,6 +9,13 @@ use sqlx::{Postgres, Transaction};
 use uuid::Uuid;
 
 type HmacSha256 = Hmac<Sha256>;
+type AlphaInviteRow = (
+    Uuid,
+    Option<chrono::DateTime<chrono::Utc>>,
+    Option<chrono::DateTime<chrono::Utc>>,
+    i32,
+    i32,
+);
 
 const HASH_DOMAIN: &[u8] = b"alpha-invite:v1:";
 
@@ -50,13 +57,7 @@ pub async fn redeem_alpha_invite(
 ) -> Result<Uuid, AlphaInviteError> {
     let code_hash = hash_invite_code(code, pepper)?;
 
-    let row: Option<(
-        Uuid,
-        Option<chrono::DateTime<chrono::Utc>>,
-        Option<chrono::DateTime<chrono::Utc>>,
-        i32,
-        i32,
-    )> = sqlx::query_as(
+    let row: Option<AlphaInviteRow> = sqlx::query_as(
         "SELECT invite_id, expires_at, disabled_at, max_redemptions, redemption_count \
              FROM alpha_invites \
              WHERE code_hash = $1 \

--- a/wavis-backend/src/auth/auth.rs
+++ b/wavis-backend/src/auth/auth.rs
@@ -30,6 +30,7 @@ use sha2::Sha256;
 use uuid::Uuid;
 use zeroize::Zeroize;
 
+use crate::auth::alpha_invite;
 use crate::auth::device;
 use crate::auth::jwt::sign_access_token;
 use crate::auth::phrase::{self, DummyVerifier, PhraseConfig};
@@ -80,6 +81,8 @@ pub enum AuthError {
     RecoveryIdNotFound,
     #[error("device revoked")]
     DeviceRevoked,
+    #[error("invite code invalid")]
+    InviteInvalid,
 }
 
 /// Check that the token's epoch matches the current DB epoch for the user.
@@ -169,6 +172,7 @@ pub fn generate_recovery_id() -> String {
 /// Returns `DeviceRegistration` with `user_id`, `device_id`, `recovery_id`,
 /// `access_token`, `refresh_token`.
 #[allow(clippy::too_many_arguments)]
+#[allow(dead_code)]
 pub async fn register_user(
     pool: &sqlx::PgPool,
     phrase: &str,
@@ -269,11 +273,143 @@ pub async fn register_user(
     })
 }
 
+/// Register a new user only after redeeming a valid closed-alpha invite.
+///
+/// Invite redemption and all auth row creation are committed atomically. If
+/// any step fails, the invite is not consumed and no partial auth rows remain.
+#[allow(clippy::too_many_arguments)]
+pub async fn register_user_with_invite(
+    pool: &sqlx::PgPool,
+    phrase: &str,
+    username: &str,
+    invite_code: &str,
+    auth_secret: &[u8],
+    access_ttl_secs: u64,
+    refresh_ttl_days: u32,
+    refresh_pepper: &[u8],
+    alpha_invite_pepper: &[u8],
+    phrase_config: &PhraseConfig,
+    encryption_key: &[u8],
+) -> Result<DeviceRegistration, AuthError> {
+    let mut tx = pool
+        .begin()
+        .await
+        .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    let invite_id = alpha_invite::redeem_alpha_invite(&mut tx, invite_code, alpha_invite_pepper)
+        .await
+        .map_err(|e| match e {
+            alpha_invite::AlphaInviteError::Invalid => AuthError::InviteInvalid,
+            alpha_invite::AlphaInviteError::DatabaseError(e) => AuthError::DatabaseError(e),
+        })?;
+
+    let user_id: Uuid = sqlx::query_scalar("INSERT INTO users DEFAULT VALUES RETURNING user_id")
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    let mut phrase_copy = phrase.to_string();
+    let hash = phrase::hash_phrase(&phrase_copy, &user_id, phrase_config)
+        .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+    phrase_copy.zeroize();
+
+    let (enc_salt, enc_verifier) =
+        phrase::encrypt_phrase_data(&hash.salt, &hash.verifier, encryption_key)
+            .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    let recovery_id = generate_unique_recovery_id_in_tx(&mut tx).await?;
+
+    sqlx::query(
+        "UPDATE users \
+         SET phrase_salt = $1, phrase_verifier = $2, recovery_id = $3, username = $4 \
+         WHERE user_id = $5",
+    )
+    .bind(&enc_salt)
+    .bind(&enc_verifier)
+    .bind(&recovery_id)
+    .bind(username)
+    .bind(user_id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    let device_id: Uuid = sqlx::query_scalar(
+        "INSERT INTO devices (device_id, user_id, device_name, created_at) \
+         VALUES (gen_random_uuid(), $1, $2, now()) \
+         RETURNING device_id",
+    )
+    .bind(user_id)
+    .bind("primary")
+    .fetch_one(&mut *tx)
+    .await
+    .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    let raw_refresh = generate_refresh_token();
+    let token_hash = hash_refresh_token(&raw_refresh, refresh_pepper);
+    let expires_at = chrono::Utc::now() + chrono::Duration::days(refresh_ttl_days as i64);
+
+    sqlx::query(
+        "INSERT INTO refresh_tokens (refresh_id, device_id, token_hash, family_id, expires_at) \
+         VALUES (gen_random_uuid(), $1, $2, gen_random_uuid(), $3)",
+    )
+    .bind(device_id)
+    .bind(&token_hash)
+    .bind(expires_at)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    alpha_invite::record_redemption(&mut tx, invite_id, user_id, device_id)
+        .await
+        .map_err(|e| match e {
+            alpha_invite::AlphaInviteError::Invalid => AuthError::InviteInvalid,
+            alpha_invite::AlphaInviteError::DatabaseError(e) => AuthError::DatabaseError(e),
+        })?;
+
+    let access_token = sign_access_token(&user_id, &device_id, auth_secret, access_ttl_secs, 0)?;
+
+    tx.commit()
+        .await
+        .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+    Ok(DeviceRegistration {
+        user_id,
+        device_id,
+        recovery_id,
+        access_token,
+        refresh_token: raw_refresh,
+    })
+}
+
+async fn generate_unique_recovery_id_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+) -> Result<String, AuthError> {
+    let max_retries = 5;
+    for _ in 0..=max_retries {
+        let recovery_id = generate_recovery_id();
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM users WHERE recovery_id = $1)")
+                .bind(&recovery_id)
+                .fetch_one(&mut **tx)
+                .await
+                .map_err(|e| AuthError::DatabaseError(e.to_string()))?;
+
+        if !exists {
+            return Ok(recovery_id);
+        }
+    }
+
+    Err(AuthError::DatabaseError(
+        "failed to generate unique recovery_id".to_string(),
+    ))
+}
+
 /// Register a new device: create user + initial refresh token.
 /// Returns DeviceRegistration with user_id, access_token, refresh_token.
 ///
 /// DEPRECATED: Use `register_user` instead. This function is kept for backward
 /// compatibility with existing tests and the old `/auth/register_device` endpoint.
+#[allow(dead_code)]
 pub async fn register_device(
     pool: &sqlx::PgPool,
     auth_secret: &[u8],

--- a/wavis-backend/src/auth/mod.rs
+++ b/wavis-backend/src/auth/mod.rs
@@ -1,3 +1,4 @@
+pub mod alpha_invite;
 #[allow(clippy::module_inception)]
 pub mod auth;
 pub mod auth_rate_limiter;

--- a/wavis-backend/src/auth/routes.rs
+++ b/wavis-backend/src/auth/routes.rs
@@ -277,16 +277,6 @@ pub async fn register_device(
     headers: HeaderMap,
 ) -> Result<(StatusCode, Json<ErrorResponse>), AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
-    let now = Instant::now();
-
-    let retry_after_secs = app_state
-        .auth_rate_limiter
-        .seconds_until_register(client_ip, now);
-    if retry_after_secs.is_some() {
-        warn!(ip = %client_ip, retry_after = retry_after_secs, "register_device rate-limited");
-        return Err(rate_limited_response(retry_after_secs));
-    }
-    app_state.auth_rate_limiter.record_register(client_ip, now);
 
     warn!(ip = %client_ip, "legacy register_device rejected");
     Ok((
@@ -818,6 +808,62 @@ pub async fn refresh_token(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
+    use crate::auth::auth_rate_limiter::{AuthRateLimiter, AuthRateLimiterConfig};
+    use crate::auth::recovery_rate_limiter::{RecoveryRateLimiter, RecoveryRateLimiterConfig};
+    use crate::channel::invite::{InviteStore, InviteStoreConfig};
+    use crate::diagnostics::bug_report::MockGitHubClient;
+    use crate::diagnostics::llm_client::NoOpLlmClient;
+    use crate::ip::IpConfig;
+    use crate::voice::mock_sfu_bridge::MockSfuBridge;
+    use crate::voice::sfu_bridge::SfuRoomManager;
+    use serde_json::json;
+    use std::sync::Arc;
+
+    const TEST_AUTH_SECRET: &[u8] = b"test-auth-secret-at-least-32-bytes!!";
+    const TEST_REFRESH_PEPPER: &[u8] = b"test-pepper-at-least-32-bytes!!!!!!";
+
+    fn test_app_state() -> AppState {
+        let mock = Arc::new(MockSfuBridge::new());
+        AppState::new(
+            mock as Arc<dyn SfuRoomManager>,
+            None,
+            "sfu://localhost".to_string(),
+            Arc::new(InviteStore::new(InviteStoreConfig::default())),
+            Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::default())),
+            IpConfig {
+                trust_proxy_headers: false,
+                trusted_proxy_cidrs: vec![],
+            },
+            Arc::new(b"dev-secret-32-bytes-minimum!!!XX".to_vec()),
+            None,
+            "wavis-backend".to_string(),
+            sqlx::postgres::PgPoolOptions::new()
+                .connect_lazy("postgres://wavis:wavis@localhost:5432/wavis")
+                .unwrap(),
+            Arc::new(TEST_AUTH_SECRET.to_vec()),
+            None,
+            Arc::new(AuthRateLimiter::new(AuthRateLimiterConfig::default())),
+            30,
+            72,
+            Arc::new(TEST_REFRESH_PEPPER.to_vec()),
+            None,
+            Arc::new(crate::auth::phrase::generate_dummy_verifier(
+                &crate::auth::phrase::PhraseConfig::default(),
+            )),
+            Arc::new(b"test-pairing-pepper-32-bytes!!XX".to_vec()),
+            Arc::new(RecoveryRateLimiter::new(
+                RecoveryRateLimiterConfig::default(),
+            )),
+            Arc::new(crate::auth::phrase::PhraseConfig::default()),
+            Arc::new(vec![0u8; 32]),
+            24,
+            7,
+            Arc::new(MockGitHubClient::new()),
+            "owner/test-repo".to_string(),
+            Arc::new(NoOpLlmClient),
+        )
+    }
 
     #[test]
     fn validate_username_trims_valid_names() {
@@ -854,5 +900,55 @@ mod tests {
         assert_eq!(missing.username.as_deref().unwrap_or(""), "");
         assert_eq!(empty.username.as_deref().unwrap_or(""), "");
         assert!(validate_username("").is_err());
+    }
+
+    #[test]
+    fn register_request_accepts_invite_code_aliases() {
+        let snake: RegisterRequest = serde_json::from_value(json!({
+            "phrase": "phrase",
+            "username": "alice",
+            "invite_code": "ALPHA-SNAKE",
+        }))
+        .unwrap();
+        assert_eq!(snake.invite_code.as_deref(), Some("ALPHA-SNAKE"));
+
+        let camel: RegisterRequest = serde_json::from_value(json!({
+            "phrase": "phrase",
+            "username": "alice",
+            "inviteCode": "ALPHA-CAMEL",
+        }))
+        .unwrap();
+        assert_eq!(camel.invite_code.as_deref(), Some("ALPHA-CAMEL"));
+    }
+
+    #[tokio::test]
+    async fn register_device_returns_gone_without_consuming_register_limit() {
+        let app_state = test_app_state();
+        let ip = std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST);
+
+        assert!(
+            app_state
+                .auth_rate_limiter
+                .check_register(ip, std::time::Instant::now())
+        );
+
+        let result = register_device(
+            State(app_state.clone()),
+            ConnectInfo(std::net::SocketAddr::from(([127, 0, 0, 1], 12345))),
+            HeaderMap::new(),
+        )
+        .await;
+        let (status, Json(body)) = match result {
+            Ok(response) => response,
+            Err(_) => panic!("register_device should return 410, not an error response"),
+        };
+
+        assert_eq!(status, StatusCode::GONE);
+        assert_eq!(body.error, "gone");
+        assert!(
+            app_state
+                .auth_rate_limiter
+                .check_register(ip, std::time::Instant::now())
+        );
     }
 }

--- a/wavis-backend/src/auth/routes.rs
+++ b/wavis-backend/src/auth/routes.rs
@@ -53,6 +53,8 @@ pub struct RegisterRequest {
     pub phrase: String,
     #[serde(alias = "device_name", alias = "displayName", alias = "display_name")]
     pub username: String,
+    #[serde(alias = "inviteCode")]
+    pub invite_code: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -178,6 +180,9 @@ fn validate_username(username: &str) -> Result<&str, AuthErrorResponse> {
 }
 fn map_register_error(err: &AuthError) -> AuthErrorResponse {
     match err {
+        AuthError::InviteInvalid => {
+            error_response(StatusCode::UNAUTHORIZED, "authentication failed")
+        }
         AuthError::DatabaseError(_) | AuthError::SigningFailed(_) => {
             error_response(StatusCode::INTERNAL_SERVER_ERROR, "internal error")
         }
@@ -270,7 +275,7 @@ pub async fn register_device(
     State(app_state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-) -> Result<(StatusCode, Json<RegisterResponse>), AuthErrorResponse> {
+) -> Result<(StatusCode, Json<ErrorResponse>), AuthErrorResponse> {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
     let now = Instant::now();
 
@@ -283,31 +288,13 @@ pub async fn register_device(
     }
     app_state.auth_rate_limiter.record_register(client_ip, now);
 
-    let result = auth::register_device(
-        &app_state.db_pool,
-        &app_state.auth_jwt_secret,
-        ACCESS_TOKEN_TTL_SECS,
-        app_state.refresh_token_ttl_days,
-        &app_state.refresh_token_pepper,
-    )
-    .await;
-
-    match result {
-        Ok(reg) => Ok((
-            StatusCode::CREATED,
-            Json(RegisterResponse {
-                user_id: reg.user_id.to_string(),
-                device_id: reg.device_id.to_string(),
-                recovery_id: reg.recovery_id,
-                access_token: reg.access_token,
-                refresh_token: reg.refresh_token,
-            }),
-        )),
-        Err(err) => {
-            warn!(ip = %client_ip, error = %err, "register_device failed");
-            Err(map_register_error(&err))
-        }
-    }
+    warn!(ip = %client_ip, "legacy register_device rejected");
+    Ok((
+        StatusCode::GONE,
+        Json(ErrorResponse {
+            error: "gone".to_string(),
+        }),
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -332,15 +319,21 @@ pub async fn register(
     }
     app_state.auth_rate_limiter.record_register(client_ip, now);
     let username = validate_username(&body.username)?;
+    let invite_code = body
+        .invite_code
+        .as_deref()
+        .ok_or_else(|| error_response(StatusCode::UNAUTHORIZED, "authentication failed"))?;
 
-    let result = auth::register_user(
+    let result = auth::register_user_with_invite(
         &app_state.db_pool,
         &body.phrase,
         username,
+        invite_code,
         &app_state.auth_jwt_secret,
         ACCESS_TOKEN_TTL_SECS,
         app_state.refresh_token_ttl_days,
         &app_state.refresh_token_pepper,
+        &app_state.alpha_invite_code_pepper,
         &app_state.phrase_config,
         &app_state.phrase_encryption_key,
     )

--- a/wavis-backend/tests/auth_integration.rs
+++ b/wavis-backend/tests/auth_integration.rs
@@ -11,6 +11,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 // Re-export domain types for use in subsequent test tasks (11.2–11.5).
+use wavis_backend::auth::alpha_invite::hash_invite_code;
 #[allow(unused_imports)]
 use wavis_backend::auth::auth::{
     self, AuthError, DeviceRegistration, TokenPair, generate_refresh_token, hash_refresh_token,
@@ -39,10 +40,12 @@ async fn test_pool() -> PgPool {
 
 /// Truncate all auth-related tables. Call between tests for isolation.
 async fn truncate_auth_tables(pool: &PgPool) {
-    sqlx::query("TRUNCATE refresh_tokens, devices, users CASCADE")
-        .execute(pool)
-        .await
-        .expect("Failed to truncate auth tables");
+    sqlx::query(
+        "TRUNCATE alpha_invite_redemptions, alpha_invites, refresh_tokens, devices, users CASCADE",
+    )
+    .execute(pool)
+    .await
+    .expect("Failed to truncate auth tables");
 }
 
 /// A deterministic test secret (≥32 bytes) for signing access tokens.
@@ -53,6 +56,32 @@ fn test_auth_secret() -> Vec<u8> {
 /// A deterministic test pepper (≥32 bytes) for HMAC hashing refresh tokens.
 fn test_pepper() -> Vec<u8> {
     b"test-pepper-at-least-32-bytes!!!!!!".to_vec()
+}
+
+fn test_alpha_invite_pepper() -> Vec<u8> {
+    b"test-alpha-invite-pepper-32b!!!!".to_vec()
+}
+
+async fn seed_alpha_invite(
+    pool: &PgPool,
+    code: &str,
+    max_redemptions: i32,
+    expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    disabled: bool,
+) -> Uuid {
+    let hash = hash_invite_code(code, &test_alpha_invite_pepper()).unwrap();
+    sqlx::query_scalar(
+        "INSERT INTO alpha_invites (code_hash, max_redemptions, expires_at, disabled_at) \
+         VALUES ($1, $2, $3, CASE WHEN $4 THEN now() ELSE NULL END) \
+         RETURNING invite_id",
+    )
+    .bind(&hash)
+    .bind(max_redemptions)
+    .bind(expires_at)
+    .bind(disabled)
+    .fetch_one(pool)
+    .await
+    .unwrap()
 }
 
 // ---------------------------------------------------------------------------
@@ -1244,4 +1273,181 @@ async fn authenticate_access_token_rejects_stale_epoch() {
         "token issued before epoch bump must be rejected, got: {:?}",
         result
     );
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn alpha_invite_registration_succeeds_and_records_redemption() {
+    let pool = test_pool().await;
+    truncate_auth_tables(&pool).await;
+
+    let invite_id = seed_alpha_invite(&pool, "alpha-valid-1", 2, None, false).await;
+    let secret = test_auth_secret();
+    let pepper = test_pepper();
+    let phrase_config = test_phrase_config();
+
+    let reg = auth::register_user_with_invite(
+        &pool,
+        "test-phrase-alpha-valid",
+        "alpha-user",
+        " ALPHA VALID 1 ",
+        &secret,
+        900,
+        30,
+        &pepper,
+        &test_alpha_invite_pepper(),
+        &phrase_config,
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    assert!(!reg.access_token.is_empty());
+    assert!(!reg.refresh_token.is_empty());
+    assert!(!reg.recovery_id.is_empty());
+
+    let redemption_count: i32 =
+        sqlx::query_scalar("SELECT redemption_count FROM alpha_invites WHERE invite_id = $1")
+            .bind(invite_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(redemption_count, 1);
+
+    let audit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM alpha_invite_redemptions \
+         WHERE invite_id = $1 AND user_id = $2 AND device_id = $3",
+    )
+    .bind(invite_id)
+    .bind(reg.user_id)
+    .bind(reg.device_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(audit_count, 1);
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn alpha_invite_registration_rejects_bad_invites_without_partial_rows() {
+    let pool = test_pool().await;
+    let secret = test_auth_secret();
+    let pepper = test_pepper();
+    let phrase_config = test_phrase_config();
+
+    let cases = [
+        ("missing", "no-such-code"),
+        ("expired", "expired-code"),
+        ("disabled", "disabled-code"),
+        ("exhausted", "exhausted-code"),
+    ];
+
+    for (case, code) in cases {
+        truncate_auth_tables(&pool).await;
+        match case {
+            "expired" => {
+                seed_alpha_invite(
+                    &pool,
+                    code,
+                    1,
+                    Some(chrono::Utc::now() - chrono::Duration::seconds(1)),
+                    false,
+                )
+                .await;
+            }
+            "disabled" => {
+                seed_alpha_invite(&pool, code, 1, None, true).await;
+            }
+            "exhausted" => {
+                let invite_id = seed_alpha_invite(&pool, code, 1, None, false).await;
+                sqlx::query(
+                    "UPDATE alpha_invites SET redemption_count = max_redemptions WHERE invite_id = $1",
+                )
+                .bind(invite_id)
+                .execute(&pool)
+                .await
+                .unwrap();
+            }
+            _ => {}
+        }
+
+        let result = auth::register_user_with_invite(
+            &pool,
+            "test-phrase-alpha-invalid",
+            "alpha-user",
+            code,
+            &secret,
+            900,
+            30,
+            &pepper,
+            &test_alpha_invite_pepper(),
+            &phrase_config,
+            TEST_ENCRYPTION_KEY,
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(AuthError::InviteInvalid)),
+            "{case} invite should fail opaquely, got: {result:?}"
+        );
+
+        for table in [
+            "users",
+            "devices",
+            "refresh_tokens",
+            "alpha_invite_redemptions",
+        ] {
+            let sql = format!("SELECT COUNT(*) FROM {table}");
+            let count: i64 = sqlx::query_scalar(&sql).fetch_one(&pool).await.unwrap();
+            assert_eq!(count, 0, "{case} left partial rows in {table}");
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn alpha_invite_registration_exhausts_limited_invite() {
+    let pool = test_pool().await;
+    truncate_auth_tables(&pool).await;
+
+    seed_alpha_invite(&pool, "single-use-alpha", 1, None, false).await;
+    let secret = test_auth_secret();
+    let pepper = test_pepper();
+    let phrase_config = test_phrase_config();
+
+    auth::register_user_with_invite(
+        &pool,
+        "test-phrase-alpha-once",
+        "alpha-one",
+        "single-use-alpha",
+        &secret,
+        900,
+        30,
+        &pepper,
+        &test_alpha_invite_pepper(),
+        &phrase_config,
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let result = auth::register_user_with_invite(
+        &pool,
+        "test-phrase-alpha-twice",
+        "alpha-two",
+        "single-use-alpha",
+        &secret,
+        900,
+        30,
+        &pepper,
+        &test_alpha_invite_pepper(),
+        &phrase_config,
+        TEST_ENCRYPTION_KEY,
+    )
+    .await;
+
+    assert!(matches!(result, Err(AuthError::InviteInvalid)));
 }


### PR DESCRIPTION
## Description

Gates registration behind a closed-alpha invite code (issue #264).

## Summary

- Invite codes are never stored in plaintext — only an HMAC-SHA256 hash (dedicated `ALPHA_INVITE_CODE_PEPPER` secret) is persisted, in `wavis-backend/src/auth/alpha_invite.rs`.
- `POST /auth/register` now requires `invite_code`; a missing or invalid code returns a generic `401 authentication failed` (no information leak about invite gating).
- Invite redemption is atomic: the invite row is locked with `SELECT ... FOR UPDATE` inside the same transaction as user creation, so concurrent redemptions can't race past `max_redemptions`.
- The legacy `POST /auth/register_device` endpoint now returns `410 Gone` and no longer consumes the register rate limit.
- Smoke/stress tooling (`tools/smoke/smoke.py`, `tools/stress/src/scenarios/*`) seeds test users through `/auth/register` with a pre-provisioned invite code rather than the old device-registration path.

## Deploy Notes

- Requires `ALPHA_INVITE_CODE_PEPPER` (≥32 bytes) in SSM at `/wavis/dev/ALPHA_INVITE_CODE_PEPPER` — the release backend build exits at startup if it's missing or too short.
- Requires at least one seeded row in `alpha_invites` (see `scripts/seed-alpha-invite.py`) for real users and for CI smoke to register.
- Requires the `ALPHA_INVITE_CODE` GitHub Actions secret so `deploy-dev-ec2.yml`'s smoke step can register.
- Rotating the pepper invalidates all previously seeded invite hashes — they must be re-seeded under the new pepper.

## Type of Change

- [x] New feature

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [x] This PR does not touch signaling or token paths — checklist not applicable

---

## Tests

- [x] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [x] No tests were deleted or disabled to make the build pass
