### PR TITLE
fix: harden Watch All viewer connection against single dead-track teardown

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/ShareTile.tsx
+++ b/clients/wavis-gui/src/features/screen-share/ShareTile.tsx
@@ -147,6 +147,10 @@ const ShareTile = memo(function ShareTile({
   /* ── Stream lifecycle ── */
 
   const [retryCount, setRetryCount] = useState(0);
+  // Consecutive automatic dead-track retries since the last successfully
+  // delivered stream — escalates from per-identity refresh to a full Room
+  // reconnect so one poisoned publication can't loop the whole Watch All room.
+  const consecutiveDeadTrackRetriesRef = useRef(0);
 
   useEffect(() => {
     if (canvasFallback || isDiagnosticTest || !viewerConn) return;
@@ -168,6 +172,7 @@ const ShareTile = memo(function ShareTile({
         setStream(null);
         return;
       }
+      consecutiveDeadTrackRetriesRef.current = 0;
       setError(null);
       setStream(s);
       emitScreenShareViewerReady(participantId, 'watch-all');
@@ -317,6 +322,24 @@ const ShareTile = memo(function ShareTile({
     setRetryCount((c) => c + 1);
   }, [viewerConn]);
 
+  // Automatic dead-track recovery, escalating: the first two attempts
+  // resubscribe only this identity's publication (refreshIdentity) so a
+  // single poisoned track can't tear down the Room other tiles share; a
+  // third consecutive failure falls back to a full reconnect.
+  const handleDeadTrack = useCallback(() => {
+    setStream(null);
+    setError(null);
+    const identity = liveKitIdentity ?? participantId;
+    consecutiveDeadTrackRetriesRef.current += 1;
+    if (consecutiveDeadTrackRetriesRef.current >= 3) {
+      consecutiveDeadTrackRetriesRef.current = 0;
+      viewerConn?.forceReconnect();
+    } else {
+      viewerConn?.refreshIdentity(identity);
+    }
+    setRetryCount((c) => c + 1);
+  }, [liveKitIdentity, participantId, viewerConn]);
+
   // Frame-health + dead-track recovery. Canvas-fallback/diagnostic-test tiles
   // don't use a real <video> element, so pass stream: null to no-op the hook
   // for them (mirrors the previous effect's early-return guard).
@@ -324,7 +347,7 @@ const ShareTile = memo(function ShareTile({
     videoRef,
     stream: canvasFallback || isDiagnosticTest ? null : stream,
     onFrameDetected: markFrameRendered,
-    onDeadTrack: handleRetry,
+    onDeadTrack: handleDeadTrack,
     onReattach: markFrameRendered,
   });
 

--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -85,7 +85,17 @@ export default function WatchAllPage() {
   // tile subscribes over this single Room. Constructor is side-effect free;
   // the Room only connects once the first tile calls watch().
   const viewerConn = useMemo(
-    () => (isDiagnosticsTestMode ? null : new ViewerRoomConnection({ windowLabel: 'watch-all' })),
+    () =>
+      isDiagnosticsTestMode
+        ? null
+        : new ViewerRoomConnection({
+            windowLabel: 'watch-all',
+            // Unconditional: this is an error path, not diagnostic chatter, and it's
+            // the only signal a bug report has when the Watch All connection fails.
+            onConnectionError: (err) => {
+              console.warn('[wavis:viewer-connection] watch-all connect failed', err);
+            },
+          }),
     [isDiagnosticsTestMode],
   );
   useEffect(() => {

--- a/clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts
@@ -1,11 +1,138 @@
-import { describe, it, expect } from 'vitest';
-import { Track } from 'livekit-client';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Track, RoomEvent, VideoQuality } from 'livekit-client';
 import {
   computeViewerBackoffMs,
   makeViewerWindowId,
   pickScreenSharePublication,
+  ViewerRoomConnection,
   type ScreenSharePublicationLike,
 } from '../viewer-connection';
+
+/* ─── livekit-client mock ───────────────────────────────────────────
+ * A real constructable Room class (not vi.fn().mockImplementation(), which
+ * cannot be `new`ed) with a minimal on/off/emit event bus. `roomState` is
+ * declared via vi.hoisted so the mock factory below — which vitest hoists
+ * above these imports — can close over it safely. */
+
+const roomState = vi.hoisted<{ current: unknown }>(() => ({ current: null }));
+
+vi.mock('livekit-client', () => {
+  class MockRoom {
+    state = 'disconnected';
+    remoteParticipants = new Map<string, unknown>();
+    private handlers = new Map<string, Array<(...args: unknown[]) => void>>();
+    connect = vi.fn(() => {
+      this.state = 'connected';
+      return Promise.resolve();
+    });
+    disconnect = vi.fn(() => {
+      this.state = 'disconnected';
+      return Promise.resolve();
+    });
+    constructor() {
+      roomState.current = this;
+    }
+    on(event: string, handler: (...args: unknown[]) => void) {
+      const arr = this.handlers.get(event) ?? [];
+      arr.push(handler);
+      this.handlers.set(event, arr);
+      return this;
+    }
+    off(event: string, handler: (...args: unknown[]) => void) {
+      const arr = this.handlers.get(event);
+      if (arr)
+        this.handlers.set(
+          event,
+          arr.filter((h) => h !== handler),
+        );
+      return this;
+    }
+    emit(event: string, ...args: unknown[]) {
+      for (const h of this.handlers.get(event) ?? []) h(...args);
+    }
+  }
+
+  return {
+    Room: MockRoom,
+    RoomEvent: {
+      TrackSubscribed: 'trackSubscribed',
+      TrackUnsubscribed: 'trackUnsubscribed',
+      TrackMuted: 'trackMuted',
+      TrackUnmuted: 'trackUnmuted',
+      TrackPublished: 'trackPublished',
+      ParticipantConnected: 'participantConnected',
+      ParticipantDisconnected: 'participantDisconnected',
+      Reconnected: 'reconnected',
+      Disconnected: 'disconnected',
+    },
+    Track: {
+      Kind: { Audio: 'audio', Video: 'video', Unknown: 'unknown' },
+      Source: {
+        Camera: 'camera',
+        Microphone: 'microphone',
+        ScreenShare: 'screen_share',
+        ScreenShareAudio: 'screen_share_audio',
+        Unknown: 'unknown',
+      },
+    },
+    ConnectionState: {
+      Disconnected: 'disconnected',
+      Connecting: 'connecting',
+      Connected: 'connected',
+      Reconnecting: 'reconnecting',
+      SignalReconnecting: 'signalReconnecting',
+    },
+    VideoQuality: { LOW: 0, MEDIUM: 1, HIGH: 2 },
+  };
+});
+
+/* ─── @tauri-apps/api/event mock ─────────────────────────────────────
+ * Drives the viewer-token handshake: emitTo('main', 'viewer-token:request', …)
+ * is answered synchronously by echoing the windowId back through the
+ * registered 'viewer-token:response' listener, standing in for the main
+ * window's broker round-trip. */
+
+vi.mock('@tauri-apps/api/event', () => {
+  const listeners = new Map<string, Array<(event: { payload: unknown }) => void>>();
+  return {
+    listen: vi.fn((event: string, cb: (event: { payload: unknown }) => void) => {
+      const arr = listeners.get(event) ?? [];
+      arr.push(cb);
+      listeners.set(event, arr);
+      return Promise.resolve(() => {
+        const remaining = listeners.get(event);
+        if (remaining)
+          listeners.set(
+            event,
+            remaining.filter((h) => h !== cb),
+          );
+      });
+    }),
+    emitTo: vi.fn((_target: string, event: string, payload: unknown) => {
+      if (event !== 'viewer-token:request') return Promise.resolve();
+      const { windowId } = payload as { windowId: string };
+      for (const cb of listeners.get('viewer-token:response') ?? []) {
+        cb({
+          payload: { windowId, token: 'mock-token', sfuUrl: 'wss://mock-sfu', identity: 'viewer' },
+        });
+      }
+      return Promise.resolve();
+    }),
+  };
+});
+
+/* ─── MediaStream stub — vitest runs this file under environment: 'node' ── */
+
+class MockMediaStream {
+  private tracks: MediaStreamTrack[];
+  constructor(tracks: MediaStreamTrack[] = []) {
+    this.tracks = tracks;
+  }
+  getVideoTracks() {
+    return this.tracks;
+  }
+}
+vi.stubGlobal('MediaStream', MockMediaStream);
 
 describe('computeViewerBackoffMs', () => {
   it('starts at 1s and doubles per attempt', () => {
@@ -74,5 +201,135 @@ describe('pickScreenSharePublication', () => {
       [Track.Source.Camera]: { kind: Track.Kind.Video },
     });
     expect(pickScreenSharePublication(participant)).toBeNull();
+  });
+});
+
+/* ─── ViewerRoomConnection.refreshIdentity (Watch All dead-track recovery) ──
+ * Regression coverage for #283: a single dead track used to call
+ * forceReconnect(), tearing down the whole Room and blacking out every
+ * Watch All tile. refreshIdentity resubscribes one identity in place. */
+
+interface TestRoom {
+  state: string;
+  remoteParticipants: Map<string, unknown>;
+  disconnect: ReturnType<typeof vi.fn>;
+  emit: (event: string, ...args: unknown[]) => void;
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createMockPublication() {
+  return {
+    kind: Track.Kind.Video,
+    setSubscribed: vi.fn(),
+    setEnabled: vi.fn(),
+    setVideoQuality: vi.fn(),
+  };
+}
+
+function createMockParticipant(identity: string, publication: ScreenSharePublicationLike) {
+  return {
+    identity,
+    getTrackPublication: (source: Track.Source) =>
+      source === Track.Source.ScreenShare ? publication : undefined,
+  };
+}
+
+describe('ViewerRoomConnection.refreshIdentity', () => {
+  beforeEach(() => {
+    roomState.current = null;
+  });
+
+  it('resubscribes only the target identity and leaves the Room untouched', async () => {
+    const conn = new ViewerRoomConnection({ windowLabel: 'watch-all' });
+    const aliceEvents: Array<MediaStream | null> = [];
+    const bobEvents: Array<MediaStream | null> = [];
+    conn.watch('alice', (s) => aliceEvents.push(s));
+    conn.watch('bob', (s) => bobEvents.push(s));
+    await tick();
+    await tick();
+
+    const room = roomState.current as TestRoom;
+    expect(room).not.toBeNull();
+
+    const alicePub = createMockPublication();
+    const bobPub = createMockPublication();
+    room.remoteParticipants.set('alice', createMockParticipant('alice', alicePub));
+    room.remoteParticipants.set('bob', createMockParticipant('bob', bobPub));
+
+    // Both participants join and get pinned via the normal subscribe path.
+    room.emit(RoomEvent.ParticipantConnected, { identity: 'alice' });
+    room.emit(RoomEvent.ParticipantConnected, { identity: 'bob' });
+
+    // SFU delivers a live track for each.
+    const aliceTrack = { kind: Track.Kind.Video, mediaStreamTrack: {} as MediaStreamTrack };
+    const bobTrack = { kind: Track.Kind.Video, mediaStreamTrack: {} as MediaStreamTrack };
+    room.emit(
+      RoomEvent.TrackSubscribed,
+      aliceTrack,
+      { source: Track.Source.ScreenShare },
+      { identity: 'alice' },
+    );
+    room.emit(
+      RoomEvent.TrackSubscribed,
+      bobTrack,
+      { source: Track.Source.ScreenShare },
+      { identity: 'bob' },
+    );
+
+    expect(aliceEvents.at(-1)).toBeInstanceOf(MockMediaStream);
+    expect(bobEvents.at(-1)).toBeInstanceOf(MockMediaStream);
+
+    alicePub.setSubscribed.mockClear();
+    alicePub.setEnabled.mockClear();
+    alicePub.setVideoQuality.mockClear();
+    bobPub.setSubscribed.mockClear();
+    bobPub.setEnabled.mockClear();
+    bobPub.setVideoQuality.mockClear();
+
+    conn.refreshIdentity('alice');
+
+    // Alice: unsubscribe, then re-pin (subscribe, enable, quality).
+    expect(alicePub.setSubscribed.mock.calls.map((c: unknown[]) => c[0])).toEqual([false, true]);
+    expect(alicePub.setEnabled).toHaveBeenCalledWith(true);
+    expect(alicePub.setVideoQuality).toHaveBeenCalledWith(VideoQuality.HIGH);
+
+    // Bob's publication and the shared Room are untouched — no whole-room teardown.
+    expect(bobPub.setSubscribed).not.toHaveBeenCalled();
+    expect(bobPub.setEnabled).not.toHaveBeenCalled();
+    expect(bobPub.setVideoQuality).not.toHaveBeenCalled();
+    expect(room.disconnect).not.toHaveBeenCalled();
+
+    // Alice's tile is told to drop the dead stream; Bob's last delivery stands.
+    expect(aliceEvents.at(-1)).toBeNull();
+    expect(bobEvents).toHaveLength(1);
+
+    conn.dispose();
+  });
+
+  it('is a no-op after dispose()', async () => {
+    const conn = new ViewerRoomConnection({ windowLabel: 'watch-all' });
+    const events: Array<MediaStream | null> = [];
+    conn.watch('alice', (s) => events.push(s));
+    await tick();
+    await tick();
+
+    const room = roomState.current as TestRoom;
+    const alicePub = createMockPublication();
+    room.remoteParticipants.set('alice', createMockParticipant('alice', alicePub));
+    room.emit(RoomEvent.ParticipantConnected, { identity: 'alice' });
+
+    conn.dispose(); // dispose() itself calls room.disconnect() once — clear before asserting
+    alicePub.setSubscribed.mockClear();
+    room.disconnect.mockClear();
+    const eventsBefore = events.length;
+
+    conn.refreshIdentity('alice');
+
+    expect(alicePub.setSubscribed).not.toHaveBeenCalled();
+    expect(room.disconnect).not.toHaveBeenCalled();
+    expect(events).toHaveLength(eventsBefore);
   });
 });

--- a/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
+++ b/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
@@ -137,6 +137,29 @@ export class ViewerRoomConnection {
     };
   }
 
+  /**
+   * Per-identity dead-track recovery: resubscribe one identity's screen-share
+   * publication without tearing down the Room shared by other watched tiles.
+   */
+  refreshIdentity(identity: string): void {
+    if (this.disposed) return;
+    if (DEBUG_VIEWER_CONNECTION) {
+      console.log(LOG, `[${this.windowLabel}] refreshIdentity ${identity}`);
+    }
+    this.deliverNull(identity);
+
+    const participant = this.room?.remoteParticipants.get(identity);
+    if (!this.room || this.room.state !== ConnectionState.Connected || !participant) {
+      void this.ensureConnected();
+      return;
+    }
+
+    const publication = pickScreenSharePublication(participant);
+    if (!publication) return;
+    publication.setSubscribed(false);
+    this.pinPublication(publication);
+  }
+
   /** Tear down the Room and reconnect immediately (dead-track escape hatch). */
   forceReconnect(): void {
     if (this.disposed) return;


### PR DESCRIPTION
## Summary

Investigated bug #283 ("Watch All did not work, but single stream did"). The reporter's diagnostics show a desktop v0.2.2 build predating the direct-LiveKit-viewer-connections rework — the software-loopback bridge that caused that exact symptom class no longer exists on `pre-dev`. However, code review of the new path (`viewer-connection.ts` / `ShareTile.tsx` / `WatchAllPage.tsx`) found a real regression waiting to happen, plus a diagnosability gap, both fixed here:

- **Whole-room teardown on one dead track**: `ShareTile`'s automatic dead-track recovery called `viewerConn.forceReconnect()`, which disconnects the entire shared `Room` and nulls every tile's stream. A single track that keeps arriving dead (SFU muted-delivery, publisher restart edge) would retrigger the stall detector every few seconds, looping a whole-room teardown that blacks out every Watch All tile — a fresh reproduction of this exact report, and each loop burns a `request_viewer_token` against the backend's rate limit.
- **Silent Watch All connection failures**: `WatchAllPage` never wired `onConnectionError` (unlike `ScreenSharePage`, which does), so a failed Watch All connection left zero signal in bug reports.

## Changes

All in `clients/wavis-gui/src/features/screen-share/`:

1. **`viewer-connection.ts`** — new `ViewerRoomConnection.refreshIdentity(identity)`: drops and resubscribes one identity's screen-share publication (`setSubscribed(false)` → re-pin) without disconnecting the Room other tiles share.
2. **`ShareTile.tsx`** — automatic dead-track recovery now escalates: the first two consecutive hits call `refreshIdentity`, the third falls back to `forceReconnect()` (counter resets whenever a stream is successfully delivered again). The manual `/retry` button is unchanged — still an immediate `forceReconnect()`.
3. **`WatchAllPage.tsx`** — `onConnectionError` now logs unconditionally via `console.warn`. This is an error path, not diagnostic chatter, so it's exempt from the `VITE_DEBUG_*` logging convention — same pattern `ScreenSharePage` already uses.

## Test plan

- [x] New behavior tests in `viewer-connection.test.ts`: `refreshIdentity` re-pins only the target identity's publication, never calls `room.disconnect`, delivers `null` then a fresh stream to the target tile while leaving other identities untouched, and no-ops after `dispose()` — `npx vitest run src/features/screen-share/__tests__/viewer-connection.test.ts` (10/10 pass)
- [x] `npm run typecheck`, `npx eslint` (0 errors — only pre-existing complexity/line-count warnings on the two already-large files), `npx prettier --check` — all clean
- [x] Smoke test via debug build + CDP-driven Playwright: Watch All opens in diagnostics test mode and renders a synthetic tile with zero console errors in either window
- [ ] **Manual verification gap (documented, not closable from this environment)**: real multi-participant Watch All video can't be driven here. Before the next desktop release, smoke-test with two machines — open Watch All while a peer shares, confirm one tile going dark no longer takes the others down with it.

## Follow-up (not this branch)

Closing #283 for the reporter requires cutting the next desktop release containing the already-merged direct-LiveKit-viewer-connections rework, with the backend deployed first per the [viewer-connections rollout constraint](../.kiro/steering) (no client fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjuaWXD2ALLoqUNJkVy6Qv