### PR TITLE
fix: nightly-stress gui-surface startup and cross-rep rate-limit false positive

### DIFF
--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -100,6 +100,10 @@ jobs:
       # The full suite registers more users than the default 5/hour per-IP
       # limit allows; the harness only resets limiters between scenarios.
       AUTH_REGISTER_RATE_LIMIT: '200'
+      # Required by config_validation.rs since the admin bug-report feature
+      # landed; the backend won't start without these.
+      GITHUB_BUG_REPORT_TOKEN: ci-dummy-token
+      GITHUB_BUG_REPORT_REPO: ci-dummy/ci-dummy
 
     steps:
       - uses: actions/checkout@v5
@@ -127,7 +131,8 @@ jobs:
           cargo build -p gui-surface-test
 
       # Debug builds default every secret and fall back to the dev stub SFU,
-      # so only DATABASE_URL / TEST_METRICS_TOKEN need to be provided.
+      # so only DATABASE_URL / TEST_METRICS_TOKEN / GITHUB_BUG_REPORT_TOKEN /
+      # GITHUB_BUG_REPORT_REPO need to be provided.
       - name: Start backend
         run: |
           cargo run -p wavis-backend --features test-metrics > backend.log 2>&1 &

--- a/tools/stress/src/runner.rs
+++ b/tools/stress/src/runner.rs
@@ -293,13 +293,19 @@ impl ScenarioRunner {
                     // Already failed — no need to run more repetitions.
                     break;
                 }
-                // Reset global rate limiters between repetitions so token buckets
-                // don't carry over depletion from the previous rep.
+                // Reset rate limiters between repetitions so token buckets/sliding
+                // windows don't carry over depletion from the previous rep. All
+                // in-process clients share source IP 127.0.0.1 (see server.rs), so
+                // without this a scenario that intentionally produces some failed
+                // joins each rep (e.g. auth-state-machine-race's Test 4) can trip
+                // join_rate_limiter's ip_failed window on a later rep even though
+                // that rep's own behavior was correct.
                 if let Some(ref app_state) = ctx.app_state {
                     app_state.global_ws_limiter.reconfigure();
                     app_state.global_join_limiter.reconfigure();
                     app_state.auth_rate_limiter.clear();
                 }
+                apply_preset(ctx, scenario.config_preset());
                 let rep_result = match tokio::time::timeout(
                     scenario_timeout,
                     run_scenario_with_panic_detection(scenario.as_ref(), ctx),


### PR DESCRIPTION
## Summary
- `gui-surface` job's backend never started: it fatal-errors without `GITHUB_BUG_REPORT_TOKEN`/`GITHUB_BUG_REPORT_REPO`, which have been required since the admin bug-report feature landed (`715752f`) but were never added to `nightly-stress.yml`. Added CI dummy values, matching the existing `TEST_METRICS_TOKEN` pattern.
- `auth-state-machine-race` failed nondeterministically on rep 3: the harness's per-rep reset (`runner.rs`) reconfigured `global_ws_limiter`/`global_join_limiter`/`auth_rate_limiter` but not `join_rate_limiter`. Since all in-process clients share source IP `127.0.0.1`, and this scenario's own Test 4 intentionally produces some failed joins each rep, the `ip_failed` sliding window accumulated across reps and eventually rejected a legitimate join. Now calls `apply_preset()` on each rep, same as at scenario start/end.

Closes the underlying cause of #287 (today's nightly-stress failure — first run of the corrected job structure from #270).

## Test plan
- [x] `cargo check -p stress-harness` — clean
- [x] YAML parses (`python -c "import yaml; yaml.safe_load(...)"`)
- [x] Ran `auth-state-machine-race` alone at `--ci` scale (3 reps) against a fresh throwaway Postgres — passed all 3 reps
- [ ] Confirm tonight's scheduled run is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQsvYBT8ZbBHCS85oMnLv