### PR TITLE
e2e-tooling: drive two real GUI instances at once

### DIFF
--- a/clients/wavis-gui/.env.example
+++ b/clients/wavis-gui/.env.example
@@ -3,6 +3,16 @@
 # MUST be "false" in production builds — users should never connect over http.
 VITE_ALLOW_INSECURE_TLS=false
 
+# Tauri store filename for auth state (access token, device_id, username, ...).
+# Overridable so a live-backend e2e debug build (clients/wavis-gui/e2e-tooling)
+# never touches a developer's real persisted session on the same machine.
+# Baked in at build time; a single e2e debug exe launched twice (two real GUI
+# instances) needs a distinct store PER LAUNCH on top of this — see the
+# runtime WAVIS_AUTH_STORE_NAME env var (src-tauri/src/main.rs's
+# get_auth_store_name) that driver.mjs's `authStoreName` launchApp() option
+# sets, which wins over this build-time value when present.
+VITE_AUTH_STORE_NAME=wavis-auth.json
+
 # General frontend diagnostic logging for prefixed [wavis:*] console output.
 # Keep this off unless you are actively debugging client behavior.
 VITE_DEBUG_LOGS=false

--- a/clients/wavis-gui/e2e-tooling/README.md
+++ b/clients/wavis-gui/e2e-tooling/README.md
@@ -149,9 +149,11 @@ flaking on the other.
 
 Live-backend coverage: `login.spec.mjs`, `room-join.spec.mjs`,
 `chat.spec.mjs`, `participants.spec.mjs`, `audio-received.spec.mjs`,
-`screen-share.spec.mjs`, `camera.spec.mjs` — see "Live-backend specs" below
-for the extra build step and backend they require. These also
-`test.skip()` when the main window is mid-call, for the same reason.
+`screen-share.spec.mjs`, `camera.spec.mjs`, `two-instances.spec.mjs` — see
+"Live-backend specs" below for the extra build step and backend they
+require. These also `test.skip()` when the main window is mid-call, for the
+same reason. `two-instances.spec.mjs` additionally uses the `appB` fixture
+(a second real `launchApp()`) — see "Two simultaneous GUI instances" below.
 
 `clients/wavis-gui/vite.config.ts`'s vitest `test.exclude` explicitly
 excludes `e2e-tooling/**` — without it, vitest's default `*.spec.*` glob
@@ -190,8 +192,11 @@ top of the usual `npx tauri build --debug`:
   at a file distinct from `wavis-auth.json`, so registering/logging in
   during these specs never overwrites a real persisted session on this
   machine. (The other half of that isolation — the OS keychain refresh-token
-  entry — is handled automatically: `driver.mjs` sets
-  `WAVIS_KEYRING_SERVICE=com.wavis.gui.e2e` for every launch, unconditionally.)
+  entry — is handled automatically: `launchApp()` defaults
+  `keyringService` to `com.wavis.gui.e2e` for every launch. This build-time
+  var is the baseline for a single instance; two-instance specs additionally
+  override it per-launch at runtime — see "Two simultaneous GUI instances"
+  below.)
 
 ```powershell
 $env:VITE_ALLOW_INSECURE_TLS="true"; $env:VITE_AUTH_STORE_NAME="wavis-auth-e2e.json"; npx tauri build --debug
@@ -214,17 +219,94 @@ needs to touch the GUI at all. Closed-alpha registration requires
 `ALPHA_INVITE_CODE` to point at a pre-seeded multi-use invite.
 
 **Second participant (chat/participants specs).** These need a second
-connected participant to assert anything meaningful. Two real
-Playwright-driven GUI instances was considered and is unbuilt/unproven — no
-prior art for two concurrent `launchApp()` calls (port/profile conflicts
-unexplored). Instead, `spawnPeer()` drives `ws-sfu-test`
-(`scripts/ws-sfu-test`) in its interactive JSON-line mode as a scriptable
-second signaling participant. This was chosen over `wavis-client`'s REPL
+connected participant to assert anything meaningful. `spawnPeer()` drives
+`ws-sfu-test` (`scripts/ws-sfu-test`) in its interactive JSON-line mode as a
+scriptable second signaling participant — chosen over `wavis-client`'s REPL
 because `wavis-client` has no chat send/receive support at all (checked its
 command parser — `create`/`join`/`invite`/`revoke`/`leave`/`status`/`name`/
 `volume`/`help`/`quit` only). These specs verify the GUI's own rendering
 reacts correctly to a second real participant — they do not verify a second
-real GUI instance's own rendering.
+real GUI instance's own rendering. For that, see "Two simultaneous GUI
+instances" below (`two-instances.spec.mjs`); `spawnPeer()` stays the
+lighter-weight choice here since these specs don't need a second real
+window, just a second real signaling participant.
+
+### Two simultaneous GUI instances
+
+`two-instances.spec.mjs` drives **two real, independently-controlled**
+`launchApp()` instances at once against the same local backend — proving two
+different accounts can occupy the same voice room simultaneously with no
+"Session taken over by another device" error, and (a separate test)
+documenting that the SAME account joining the same room a second time
+genuinely IS displaced (server design, not a harness bug — see
+`voice_orchestrator.rs`'s `evict_stale_session`, which evicts by account
+`user_id`, not device or window).
+
+**What isolates the two instances**, both already true of any single
+`launchApp()` call plus two new per-launch options:
+
+- `WEBVIEW2_USER_DATA_FOLDER` — always a fresh temp dir per launch, so two
+  processes never share a WebView2 profile.
+- `port` — give the second instance its own CDP port (`9223`; `9222` stays
+  the default for `port`-less calls).
+- `authStoreName` — **new.** Without this, both instances share one Tauri
+  store file (`wavis-auth.json`/`wavis-auth-e2e.json`, whichever the exe was
+  built with) and race last-writer-wins on login state. Passing a distinct
+  name makes `launchApp()` set `WAVIS_AUTH_STORE_NAME` per-process, which
+  `auth.ts`'s `resolveStoreName()` reads at runtime via a Tauri command
+  (`get_auth_store_name` in `src-tauri/src/main.rs`) — it wins over the
+  build-time `VITE_AUTH_STORE_NAME` baked into the exe.
+- `keyringService` — **new.** Same problem, one level down: without this,
+  both instances share one OS keychain refresh-token entry and a token
+  rotation in one can invalidate the other mid-test. `keyring_service()` in
+  `main.rs` already read `WAVIS_KEYRING_SERVICE` at runtime; `launchApp()`
+  now exposes it as a per-call option instead of hardcoding one value for
+  every launch.
+
+`wavis-settings.json` (audio/video prefs) stays **shared on purpose** — it's
+prefs-only, not identity, and isolating it wasn't needed for anything this
+spec asserts.
+
+**The account rule.** Two different accounts in the same voice channel never
+displace each other. The SAME account joining the same voice channel twice
+(regardless of device/window) always does — that's the server's intended
+"ghost duplicate" prevention, not something to route around. A two-instance
+spec that wants no displacement needs two REAL DIFFERENT accounts, one per
+instance.
+
+Ad-hoc snippet (outside the formal suite, e.g. a scratchpad script):
+
+```js
+import { launchApp } from './driver.mjs';
+
+const a = await launchApp();
+const b = await launchApp({
+  port: 9223,
+  authStoreName: 'wavis-auth-e2e-b.json',
+  keyringService: 'com.wavis.gui.e2e-b',
+});
+try {
+  // drive a.page() and b.page() independently — two real windows, two real accounts
+} finally {
+  await a.close();
+  await b.close();
+}
+```
+
+**Known gap this spec routes around (not fixed here):** the real
+`DeviceSetup` registration UI (`registerViaUi`) has no invite-code field, but
+`POST /auth/register` now requires one (`routes.rs`'s `register` handler
+401s without `invite_code`/`inviteCode`) — so `registerViaUi` (and by
+extension `login.spec.mjs`, `room-join.spec.mjs`, `chat.spec.mjs`,
+`participants.spec.mjs`'s setup) is currently broken against a backend that
+enforces closed-alpha invites. `registerAndLoginViaUi` in
+`live-backend-helpers.mjs` works around this for `two-instances.spec.mjs`:
+`registerDevice()` (REST, already sends `inviteCode`) creates the account,
+then `loginViaUi` authenticates it through the real `Login` UI instead
+(`/login` is a top-level route reachable via direct navigation even on a
+device that's never registered locally — see `routes.ts` — so this doesn't
+need the broken registration form at all). Giving `DeviceSetup` an
+invite-code field is the real fix, out of scope here.
 
 Run once the backend is up and the live-backend exe is built:
 
@@ -444,7 +526,6 @@ without confirming both first.
 
 ## Other possible follow-ups (not built here)
 
-- A `WEBVIEW2_USER_DATA_FOLDER`/port-conflict story for running multiple
-  harness instances truly in parallel (currently: unique temp profile dir
-  per launch already avoids profile locking; port is fixed at 9222 by
-  default but overridable via `launchApp({ port })`).
+- Give `DeviceSetup` an invite-code field so `registerViaUi` (and the specs
+  that use it for setup) works against a backend that requires one — see
+  "Two simultaneous GUI instances" above for the current workaround.

--- a/clients/wavis-gui/e2e-tooling/driver.mjs
+++ b/clients/wavis-gui/e2e-tooling/driver.mjs
@@ -61,7 +61,11 @@ async function connectWithRetry(port, maxAttempts, delayMs) {
  *
  * Each launch gets a fresh, unique WEBVIEW2_USER_DATA_FOLDER (temp dir) so
  * it never conflicts with a normally-running Wavis instance's profile, and
- * multiple harness launches can coexist.
+ * multiple harness launches can coexist — including TWO REAL launches of
+ * the same debug exe at once (e.g. a two-instance live-backend spec): give
+ * each its own `port` and, since they'd otherwise share one Tauri store file
+ * and one OS keychain service, its own `authStoreName` / `keyringService`
+ * too. See README.md's "Two simultaneous GUI instances" section.
  *
  * `settleMs` (default 4000) is how long to wait after connecting before
  * windows/content are expected to be meaningfully rendered — the app talks
@@ -72,6 +76,8 @@ export async function launchApp({
   applicationPath = debugBinaryPath(),
   port = 9222,
   settleMs = 4000,
+  keyringService = 'com.wavis.gui.e2e',
+  authStoreName,
 } = {}) {
   const userDataDir = mkdtempSync(path.join(tmpdir(), 'wavis-cdp-'));
   const child = spawn(applicationPath, [], {
@@ -98,10 +104,18 @@ export async function launchApp({
       WEBVIEW2_USER_DATA_FOLDER: userDataDir,
       // Keeps the OS keychain refresh-token entry (src-tauri/src/main.rs's
       // keyring_service()) separate from a developer's real persisted login
-      // on this machine. The Tauri store JSON file itself (wavis-auth.json)
-      // is isolated separately via the VITE_AUTH_STORE_NAME build-time env
-      // var baked into the live-backend debug exe — see e2e-tooling/README.md.
-      WAVIS_KEYRING_SERVICE: 'com.wavis.gui.e2e',
+      // on this machine. Defaults to one shared e2e service; pass a distinct
+      // `keyringService` per launch when running two real instances at once
+      // so neither's token rotation can clobber the other's keychain entry.
+      WAVIS_KEYRING_SERVICE: keyringService,
+      // Runtime override for the Tauri store filename (auth.ts's
+      // resolveStoreName, read via src-tauri/src/main.rs's
+      // get_auth_store_name). Undefined `authStoreName` means "use the
+      // build-time VITE_AUTH_STORE_NAME baked into the exe" — explicit ''
+      // (not simply omitting the key) so a value inherited from the
+      // caller's own shell environment can't leak through the ...process.env
+      // spread above; the Rust side treats an empty string as unset too.
+      WAVIS_AUTH_STORE_NAME: authStoreName ?? '',
     },
     stdio: 'ignore',
   });

--- a/clients/wavis-gui/e2e-tooling/playwright.config.mjs
+++ b/clients/wavis-gui/e2e-tooling/playwright.config.mjs
@@ -11,7 +11,10 @@ export default defineConfig({
   globalSetup: './global-setup.mjs',
   // The app launch is stateful and pinned to a single fixed CDP port
   // (driver.mjs defaults to 9222) — parallel workers would collide launching
-  // separate app instances against the same port.
+  // separate app instances against the same port. Two-instance specs (e.g.
+  // two-instances.spec.mjs) don't change this: they add a SECOND launch on
+  // a different fixed port (9223, via the `appB` fixture) within the same
+  // worker, rather than running two workers.
   workers: 1,
   fullyParallel: false,
   retries: 0,

--- a/clients/wavis-gui/e2e-tooling/tests/fixtures.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/fixtures.mjs
@@ -10,6 +10,20 @@ export const test = base.extend({
     await use(app);
     await app.close();
   },
+  // A SECOND real, independently-driveable app instance — lazy (only
+  // launched by specs that destructure it, e.g. two-instances.spec.mjs), so
+  // it costs nothing to every other spec. Distinct CDP port, auth store
+  // file, and keychain service from `app` — see driver.mjs's launchApp
+  // options and README.md's "Two simultaneous GUI instances" section.
+  appB: async ({}, use) => {
+    const app = await launchApp({
+      port: 9223,
+      authStoreName: 'wavis-auth-e2e-b.json',
+      keyringService: 'com.wavis.gui.e2e-b',
+    });
+    await use(app);
+    await app.close();
+  },
 });
 
 export { expect };

--- a/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
@@ -38,6 +38,22 @@ export function visibleTitle(page, title) {
   return page.getByTitle(title).and(page.locator(':visible'));
 }
 
+/**
+ * A participant's row in ParticipantsPanel (ParticipantRow.tsx — a
+ * `role="button"` div wrapping a `[+]`/`[-]` expand indicator and the
+ * display name). Prefer this over `visibleText(page, displayName)` for
+ * "is this participant showing in the room" assertions: a plain text match
+ * also matches the transient "{name} joined" toast notification, which can
+ * still be on screen right after a join and makes the locator resolve to 2
+ * elements (Playwright strict-mode violation) instead of the persistent row.
+ */
+export function participantRow(page, displayName) {
+  const escaped = displayName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return page
+    .getByRole('button', { name: new RegExp(escaped) })
+    .and(page.locator(':visible'));
+}
+
 /* ─── REST setup (backend-side identities/channels — no GUI involved) ──── */
 
 async function postJson(pathname, body, accessToken) {
@@ -79,22 +95,28 @@ export async function waitForBackendHealth(timeoutMs = 30_000) {
  * Use this for identities that never need to touch the GUI (e.g. a channel
  * owner in room-join.spec.mjs), not as a substitute for exercising the real
  * auth UI (that's what registerViaUi / login.spec.mjs are for).
+ *
+ * Also used as the D2 workaround (see README.md's "Known gaps" section):
+ * DeviceSetup's registration UI has no invite-code field, so registerViaUi
+ * 401s against a backend that requires one (routes.rs's `register` handler).
+ * registerAndLoginViaUi below composes this REST call with loginViaUi to get
+ * a real GUI-authenticated session anyway. Returns `phrase`/`username` too
+ * (additive) so callers can log the same identity in a second time.
  */
 export async function registerDevice() {
   const inviteCode = process.env.ALPHA_INVITE_CODE;
   if (!inviteCode) throw new Error('ALPHA_INVITE_CODE must be set for REST auth seeding');
   const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const phrase = `e2e-password-${suffix}`;
+  const username = `E2E-${suffix}`;
   const res = await fetch(`${SERVER_URL}/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      phrase: `e2e-password-${suffix}`,
-      username: `E2E-${suffix}`,
-      inviteCode,
-    }),
+    body: JSON.stringify({ phrase, username, inviteCode }),
   });
   if (!res.ok) throw new Error(`register failed: ${res.status}`);
-  return res.json(); // { user_id, device_id, recovery_id, access_token, refresh_token }
+  const body = await res.json(); // { user_id, device_id, recovery_id, access_token, refresh_token }
+  return { ...body, phrase, username };
 }
 
 export async function createChannel(accessToken, name) {
@@ -171,6 +193,63 @@ export async function registerViaUi(page, { username, password, serverUrl = SERV
 }
 
 /**
+ * Drives the real Login UI's "new device" path (Wavis ID + Password + Server
+ * URL) to authenticate an identity that was created out-of-band (REST
+ * registerDevice() — the D2 workaround, see registerDevice's doc comment).
+ * Unlike registerViaUi, /login is a top-level route with no auth-gate
+ * redirect (see routes.ts), so it's reachable via a direct navigation even
+ * on a device that has never registered locally — no "Not you" detour
+ * needed, since a fresh authStoreName store has no locally-saved recovery ID
+ * and Login.tsx already defaults to new-device mode (deriveLoginMode).
+ */
+export async function loginViaUi(page, { recoveryId, password, serverUrl = SERVER_URL } = {}) {
+  if (new URL(page.url()).pathname !== '/login') {
+    await page.goto(new URL('/login', page.url()).href);
+  }
+
+  // Trusted-device mode (a locally-saved recovery ID from a prior run in
+  // this same store) shows only a password field — same "Not you" detour
+  // registerViaUi/getToSetup use to reach the full new-device form.
+  if ((await page.getByLabel('Wavis ID', { exact: true }).count()) === 0) {
+    try {
+      await page
+        .getByText('Not you / log in on a new device', { exact: true })
+        .click({ timeout: 10_000 });
+    } catch {
+      // Already in new-device mode.
+    }
+  }
+
+  await page.getByLabel('Wavis ID', { exact: true }).fill(recoveryId);
+  await page.getByLabel('Password', { exact: true }).fill(password);
+  await page.getByLabel('Server URL', { exact: true }).fill(serverUrl);
+  if (serverUrl.startsWith('http://')) {
+    // Unlike DeviceSetup's insecure-TLS checkbox (always starts unchecked —
+    // useState(false), no store read), Login.tsx's version is initialized
+    // from the persisted `insecure_tls` store value on mount
+    // (getInsecureTls() in its load effect). Since this is a real checkbox
+    // toggle, clicking unconditionally can turn an already-ON value OFF if a
+    // prior run in this same auth store left it set — check state first.
+    const insecureTlsCheckbox = page.locator(
+      'label:has-text("--danger-insecure-tls") input[type="checkbox"]',
+    );
+    if (!(await insecureTlsCheckbox.isChecked())) {
+      await page.getByText('--danger-insecure-tls', { exact: true }).click();
+    }
+  }
+  await page.getByText('/login', { exact: true }).click();
+
+  await page.waitForURL((url) => url.pathname !== '/login', { timeout: 15_000 });
+}
+
+/** Composes REST registerDevice() (D2 workaround) with loginViaUi for a real GUI-authenticated session. */
+export async function registerAndLoginViaUi(page, { serverUrl = SERVER_URL } = {}) {
+  const identity = await registerDevice();
+  await loginViaUi(page, { recoveryId: identity.recovery_id, password: identity.phrase, serverUrl });
+  return identity;
+}
+
+/**
  * Drives ChannelsList's "/join" form with a pre-generated invite code.
  * Assumes an already-authenticated page; gets to the channels list first via
  * the app's own "← /channels" back link if landed elsewhere.
@@ -220,15 +299,23 @@ export async function enterChannelRoom(page, channelName) {
  * the real single row. Clicking during that window trips Playwright's
  * strict-mode "resolved to 2 elements" check, so this waits for exactly one
  * stable match first.
+ *
+ * `expectedCount` is the participant count the sub-room header should settle
+ * on afterward — 1 for the first (only) participant, 2+ when joining a room
+ * that already has other real participants in it (e.g. a second live GUI
+ * instance in the two-instances spec).
  */
-export async function joinDefaultSubRoomViaUi(page) {
+export async function joinDefaultSubRoomViaUi(page, { expectedCount = 1 } = {}) {
   const joinButton = visibleText(page, '/join');
   const deadline = Date.now() + 10_000;
   while ((await joinButton.count()) !== 1 && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
   await joinButton.click();
-  await visibleText(page, /ROOM \d+\s*\(1\)/).waitFor({ state: 'visible', timeout: 15_000 });
+  await visibleText(page, new RegExp(`ROOM \\d+\\s*\\(${expectedCount}\\)`)).waitFor({
+    state: 'visible',
+    timeout: 15_000,
+  });
 }
 
 /**

--- a/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
@@ -49,9 +49,7 @@ export function visibleTitle(page, title) {
  */
 export function participantRow(page, displayName) {
   const escaped = displayName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return page
-    .getByRole('button', { name: new RegExp(escaped) })
-    .and(page.locator(':visible'));
+  return page.getByRole('button', { name: new RegExp(escaped) }).and(page.locator(':visible'));
 }
 
 /* ─── REST setup (backend-side identities/channels — no GUI involved) ──── */
@@ -245,7 +243,11 @@ export async function loginViaUi(page, { recoveryId, password, serverUrl = SERVE
 /** Composes REST registerDevice() (D2 workaround) with loginViaUi for a real GUI-authenticated session. */
 export async function registerAndLoginViaUi(page, { serverUrl = SERVER_URL } = {}) {
   const identity = await registerDevice();
-  await loginViaUi(page, { recoveryId: identity.recovery_id, password: identity.phrase, serverUrl });
+  await loginViaUi(page, {
+    recoveryId: identity.recovery_id,
+    password: identity.phrase,
+    serverUrl,
+  });
   return identity;
 }
 

--- a/clients/wavis-gui/e2e-tooling/tests/two-instances.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/two-instances.spec.mjs
@@ -1,0 +1,127 @@
+// Live-backend, TWO REAL Wavis GUI instances at once (not spawnPeer's
+// signaling-only stand-in — see the `appB` fixture in fixtures.mjs and
+// README.md's "Two simultaneous GUI instances" section).
+//
+// Two things are proven here:
+// 1. Two different accounts can each drive a real GUI instance into the
+//    SAME voice room simultaneously with no displacement — the "another
+//    window" error (session_displaced) is keyed by account user_id
+//    server-side (voice_orchestrator.rs's evict_stale_session), not by
+//    device or window, so this only works because the two instances log in
+//    as two DIFFERENT accounts.
+// 2. The inverse: the SAME account joining the same voice room a second
+//    time (here via a spawnPeer() authenticating with the first session's
+//    own access token) genuinely displaces the first — this is a server
+//    design constraint, not a harness bug, and is worth documenting
+//    alongside (1) so nobody "fixes" two-instance flakiness by chasing it.
+//
+// Both instances launch from the SAME debug exe (build once, per README),
+// isolated from each other via driver.mjs's per-launch authStoreName /
+// keyringService options — see main.rs's get_auth_store_name /
+// keyring_service and auth.ts's resolveStoreName.
+import { test, expect } from './fixtures.mjs';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  seedChannelWithInvite,
+  registerAndLoginViaUi,
+  joinChannelViaUi,
+  enterChannelRoom,
+  leaveRoomIfActive,
+  joinDefaultSubRoomViaUi,
+  joinDefaultSubRoomAsPeer,
+  visibleText,
+  participantRow,
+  spawnPeer,
+  joinVoiceAsPeer,
+  registerDevice,
+  loginViaUi,
+} from './live-backend-helpers.mjs';
+
+test('two accounts in two real GUI instances join the same voice room with no displacement', async ({
+  app,
+  appB,
+}) => {
+  test.setTimeout(180_000);
+  await waitForBackendHealth();
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-two-instances-${suffix}`;
+  const { invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  const other = appB.page();
+  await leaveRoomIfActive(main);
+  await leaveRoomIfActive(other);
+
+  const identityA = await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
+  const identityB = await registerAndLoginViaUi(other, { serverUrl: SERVER_URL });
+  expect(identityA.user_id).not.toBe(identityB.user_id);
+
+  await joinChannelViaUi(main, invite.code);
+  await joinChannelViaUi(other, invite.code);
+
+  await enterChannelRoom(main, channelName);
+  await enterChannelRoom(other, channelName);
+
+  await joinDefaultSubRoomViaUi(main, { expectedCount: 1 });
+  await joinDefaultSubRoomViaUi(other, { expectedCount: 2 });
+
+  // Both windows converge on the same 2-participant room state, each
+  // showing the OTHER account's username — real cross-instance visibility,
+  // not each window just seeing itself.
+  await expect(visibleText(main, /ROOM \d+\s*\(2\)/)).toBeVisible({ timeout: 10_000 });
+  await expect(participantRow(main, identityB.username)).toBeVisible();
+  await expect(participantRow(other, identityA.username)).toBeVisible();
+
+  // The core claim under test: neither instance was evicted by the other.
+  await expect(main.getByText('Session taken over by another device')).toHaveCount(0);
+  await expect(other.getByText('Session taken over by another device')).toHaveCount(0);
+  await expect(main).toHaveURL(/\/room/);
+  await expect(other).toHaveURL(/\/room/);
+});
+
+test('the SAME account joining the same voice room a second time IS displaced', async ({ app }) => {
+  test.setTimeout(60_000);
+  await waitForBackendHealth();
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-displacement-${suffix}`;
+  const { channel, invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  await leaveRoomIfActive(main);
+
+  // registerDevice() (REST) mints the account's first session; loginViaUi
+  // then authenticates the SAME account a second time (its own device
+  // session) into the GUI — mirroring how a real second window would log
+  // in, without needing a second real GUI instance for this assertion.
+  const identity = await registerDevice();
+  await loginViaUi(main, {
+    recoveryId: identity.recovery_id,
+    password: identity.phrase,
+    serverUrl: SERVER_URL,
+  });
+
+  await joinChannelViaUi(main, invite.code);
+  await enterChannelRoom(main, channelName);
+  await joinDefaultSubRoomViaUi(main, { expectedCount: 1 });
+
+  const peer = spawnPeer();
+  try {
+    // Same account (identity.access_token), same channel -> server-side
+    // evict_stale_session evicts by user_id, displacing the GUI's session.
+    await joinVoiceAsPeer(peer, {
+      accessToken: identity.access_token,
+      channelId: channel.channel_id,
+      displayName: 'DisplacerBot',
+    });
+    await joinDefaultSubRoomAsPeer(peer);
+
+    await expect(main.getByText('Session taken over by another device')).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    await peer.close();
+  }
+});

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -599,6 +599,7 @@ fn main() {
             store_token,
             get_token,
             delete_token,
+            get_auth_store_name,
             set_peer_volume,
             set_master_volume,
             set_audio_device,
@@ -910,6 +911,20 @@ const KEYRING_SERVICE: &str = "com.wavis.gui";
 /// same machine — driver.mjs sets WAVIS_KEYRING_SERVICE per-launch.
 fn keyring_service() -> String {
     std::env::var("WAVIS_KEYRING_SERVICE").unwrap_or_else(|_| KEYRING_SERVICE.to_string())
+}
+
+/// Runtime override for the Tauri store filename, read by auth.ts on top of
+/// its build-time VITE_AUTH_STORE_NAME fallback. Exists so two Playwright-
+/// driven live-backend e2e instances launched from the SAME debug exe
+/// (clients/wavis-gui/e2e-tooling's driver.mjs launchApp) can each point at a
+/// distinct auth store file instead of racing last-writer-wins on one — see
+/// driver.mjs's `authStoreName` option. `None` (unset or empty) means "no
+/// override", so a normal launch is unaffected.
+#[tauri::command]
+fn get_auth_store_name() -> Option<String> {
+    std::env::var("WAVIS_AUTH_STORE_NAME")
+        .ok()
+        .filter(|s| !s.is_empty())
 }
 
 /// In-memory cache for keyring values.

--- a/clients/wavis-gui/src/features/auth/auth.ts
+++ b/clients/wavis-gui/src/features/auth/auth.ts
@@ -14,7 +14,11 @@ import { fetch as tauriFetch } from '@tauri-apps/plugin-http';
 /**
  * Overridable so live-backend e2e runs (clients/wavis-gui/e2e-tooling) can
  * point at a store file distinct from a developer's real persisted session
- * on the same machine — see VITE_AUTH_STORE_NAME in .env.example.
+ * on the same machine — see VITE_AUTH_STORE_NAME in .env.example. This is
+ * the build-time fallback; getStore() below also checks a per-launch
+ * runtime override (WAVIS_AUTH_STORE_NAME via the get_auth_store_name Tauri
+ * command) so two e2e instances launched from the SAME debug exe can each
+ * use a distinct store file — see driver.mjs's `authStoreName` option.
  */
 const STORE_NAME = import.meta.env.VITE_AUTH_STORE_NAME || 'wavis-auth.json';
 /** Fallback TTL if JWT exp parsing fails */
@@ -54,14 +58,27 @@ export interface DeviceInfo {
 
 // --- Session State ---
 let storeInstance: Awaited<ReturnType<typeof load>> | null = null;
+let storeNamePromise: Promise<string> | null = null;
 let inflightRefresh: Promise<RefreshResult> | null = null;
 let tokenRefreshedCallbacks: Array<() => void> = [];
 
 // --- Helpers (private) ---
 
+/** Runtime override (per-launch, e2e two-instance case) -> build-time env -> default. */
+async function resolveStoreName(): Promise<string> {
+  try {
+    const runtime = await invoke<string | null>('get_auth_store_name');
+    if (runtime) return runtime;
+  } catch {
+    // Command unavailable (older build) — fall back to the build-time name.
+  }
+  return STORE_NAME;
+}
+
 async function getStore() {
   if (!storeInstance) {
-    storeInstance = await load(STORE_NAME, { defaults: {}, autoSave: true });
+    storeNamePromise ??= resolveStoreName();
+    storeInstance = await load(await storeNamePromise, { defaults: {}, autoSave: true });
   }
   return storeInstance;
 }


### PR DESCRIPTION
## Summary
- `driver.mjs`'s `launchApp()` gains `keyringService`/`authStoreName` options so two real, independently-driven Tauri instances launched from the same debug exe don't race one Tauri store file / OS keychain entry.
- Runtime override wired through `main.rs`'s new `get_auth_store_name` command (mirrors the existing `keyring_service()` pattern) and `auth.ts`'s `resolveStoreName()`.
- New `appB` fixture + `two-instances.spec.mjs`: proves two different accounts can share a voice room in two real GUI windows with no "Session taken over by another device" displacement, and that the same account joining twice still correctly gets displaced (server-side design, documented not "fixed").
- Fixes a real bug found while building this: `loginViaUi`'s insecure-TLS checkbox click was unconditional — since it's a toggle initialized from persisted state, clicking it when already ON turned it OFF.
- README + local skill docs updated; documents the known D2 gap (`DeviceSetup` registration UI has no invite-code field, so `registerViaUi`-dependent specs 401 against a backend that requires one) as an existing, unrelated follow-up.

## Test plan
- [x] `two-instances.spec.mjs` passes against local docker backend (both tests)
- [x] Pre-existing non-D2-affected specs (`launch`, `title-bar`, `multi-window`, `settings`) still pass
- [x] `npm run typecheck`, `eslint` on touched files, `cargo clippy -p wavis-gui` all clean
- [x] 86 auth unit tests pass (`vitest run src/features/auth`)
- [ ] `login.spec.mjs`/`room-join.spec.mjs`/`participants.spec.mjs`/`chat.spec.mjs` still fail against a local backend requiring invite codes — pre-existing, unrelated (documented in README as a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQsvYBT8ZbBHCS85oMnLv