### PR TITLE
e2e: network-quality netem spec + fix full-suite auth cascade and icon locators

### DIFF
--- a/clients/wavis-gui/e2e-tooling/README.md
+++ b/clients/wavis-gui/e2e-tooling/README.md
@@ -515,7 +515,7 @@ contaminate any other spec) proves media stays smooth under a good network,
 degrades observably but keeps flowing under a simulated bad one, and
 recovers once the bad network clears. `audio-received.spec.mjs` and
 `screen-share-audio-not-heard-until-opened.spec.mjs` already prove media
-*arrives*; this is the smoothness/resilience proof neither one covers.
+_arrives_; this is the smoothness/resilience proof neither one covers.
 
 **Why netem on the LiveKit container, not CDP/Playwright throttling.**
 Playwright's own network-condition APIs (and CDP's `Network.emulateNetworkConditions`
@@ -535,7 +535,7 @@ sufficient — no client-side or host-level shaping needed.
   specs skip-with-reason (not fail) if this is false, e.g. the container
   started offline and `apk add` never ran.
 - `setNetworkConditions({ delayMs, jitterMs, lossPct, rateKbit })` — `docker
-  exec wavis-livekit tc qdisc replace dev eth0 root netem ...`.
+exec wavis-livekit tc qdisc replace dev eth0 root netem ...`.
 - `clearNetworkConditions()` — `tc qdisc del dev eth0 root`, tolerating a
   "no qdisc" error so it's safe to call unconditionally (e.g. in a `finally`,
   even if a prior run crashed mid-shape).

--- a/clients/wavis-gui/e2e-tooling/README.md
+++ b/clients/wavis-gui/e2e-tooling/README.md
@@ -207,13 +207,17 @@ specs still run fine against it, but going back to plain manual
 verification (a build that reuses your real persisted login) needs a
 rebuild without these two env vars.
 
-Each live-backend spec that needs a GUI-side authenticated identity gets one
-by registering a fresh, timestamp-suffixed throwaway account via the real
-`DeviceSetup` UI (`registerViaUi` in `tests/live-backend-helpers.mjs`) —
-registration has no email/CAPTCHA step, so this is cheap. `login.spec.mjs`
-is the one spec that exercises that UI as the thing under test; the other
-three treat it as setup. Channel/invite seeding for `room-join`/`chat`/
-`participants` uses REST (`POST /auth/register`, `POST /channels`,
+Each live-backend spec that needs a GUI-side authenticated identity reuses
+the persisted e2e session when one exists, and otherwise gets one via
+`registerAndLoginViaUi` in `tests/live-backend-helpers.mjs`: a fresh,
+timestamp-suffixed throwaway account created over REST (`registerDevice()`,
+which sends the required invite code), then authenticated through the real
+`Login` UI. Registration through the real `DeviceSetup` UI is not possible
+against a closed-alpha backend — see "Known gap" below. `login.spec.mjs`
+exercises the Login UI itself as the thing under test (both the new-device
+and trusted-device paths); the other specs treat authentication purely as
+setup. Channel/invite seeding for `room-join`/`chat`/`participants` uses
+REST (`POST /auth/register`, `POST /channels`,
 `POST /channels/:id/invites`) for the channel _owner_, so that identity never
 needs to touch the GUI at all. Closed-alpha registration requires
 `ALPHA_INVITE_CODE` to point at a pre-seeded multi-use invite.
@@ -293,20 +297,23 @@ try {
 }
 ```
 
-**Known gap this spec routes around (not fixed here):** the real
-`DeviceSetup` registration UI (`registerViaUi`) has no invite-code field, but
-`POST /auth/register` now requires one (`routes.rs`'s `register` handler
-401s without `invite_code`/`inviteCode`) — so `registerViaUi` (and by
-extension `login.spec.mjs`, `room-join.spec.mjs`, `chat.spec.mjs`,
-`participants.spec.mjs`'s setup) is currently broken against a backend that
-enforces closed-alpha invites. `registerAndLoginViaUi` in
-`live-backend-helpers.mjs` works around this for `two-instances.spec.mjs`:
+**Known gap (routed around, not fixed):** the real `DeviceSetup`
+registration UI has no invite-code field, but `POST /auth/register` requires
+one (`routes.rs`'s `register` handler 401s without
+`invite_code`/`inviteCode`) — so UI-driven registration (`registerViaUi`,
+kept in `live-backend-helpers.mjs` but unused) cannot succeed against a
+backend that enforces closed-alpha invites. Every live-backend spec
+therefore authenticates via `registerAndLoginViaUi` instead:
 `registerDevice()` (REST, already sends `inviteCode`) creates the account,
-then `loginViaUi` authenticates it through the real `Login` UI instead
+then `loginViaUi` authenticates it through the real `Login` UI
 (`/login` is a top-level route reachable via direct navigation even on a
 device that's never registered locally — see `routes.ts` — so this doesn't
-need the broken registration form at all). Giving `DeviceSetup` an
-invite-code field is the real fix, out of scope here.
+need the broken registration form at all). Before this was suite-wide, full
+sequential runs cascade-failed: `login.spec.mjs` logged out the persisted
+session, its UI registration 401'd, and every later spec that fell back to
+`registerViaUi` died in setup — while the same specs passed in isolation by
+silently riding the persisted session. Giving `DeviceSetup` an invite-code
+field is the real fix, out of scope here.
 
 Run once the backend is up and the live-backend exe is built:
 
@@ -373,14 +380,13 @@ active-speaker events can set those independent of real decoded audio.
 - Reverse audio direction (GUI mic → peer hears) — GUI mic capture is
   nondeterministic real hardware. `livekit-tone-peer.mjs`'s `Room` could
   gain a subscribe-and-measure mode as a follow-up.
-- Real watched pixels for screen share (a peer that actually publishes
-  video, and the GUI's Watch All viewer path) and a remote camera tile —
-  both need a video-publishing peer via `@livekit/rtc-node`'s
-  `VideoSource`. This was scoped as a timeboxed stretch and not attempted
-  in the session that added `audio-received.spec.mjs`; the concrete blocker
-  to resolve first is matching the track source/name conventions the GUI's
-  `onScreenShareSubscribed` (`voice-room.ts`) keys on against what
-  `clients/shared/src/livekit_connection.rs`'s Rust publisher actually sends.
+- ~~Real watched pixels for screen share~~ — **done**: `livekit-tone-peer.mjs`'s
+  `startVideoPattern()`/`stopVideoPattern()` publish a real moving RGBA video
+  track under `TrackSource.SOURCE_SCREENSHARE` via `@livekit/rtc-node`'s
+  `VideoSource`/`VideoFrame`, exercised by `zz-network-quality.spec.mjs` (see
+  "Media quality + network simulation" below). A remote camera tile is still
+  not covered — `LocalVideoTrack` would need to publish under
+  `TrackSource.SOURCE_CAMERA` instead, as a separate follow-up.
 - `screen-share.spec.mjs`'s Direction B (peer signals `start_share` with no
   media) intentionally only asserts the "waiting for stream..." indicator —
   there is no track to watch, by construction.
@@ -464,22 +470,31 @@ tests/audio-received.spec.mjs` — must connect and read a real decoded
 
 All three specs, plus the full pre-existing suite, pass now.
 
-**Rate limiting.** The backend's registration rate limiter is
-in-process, per-IP, and allows only **5 registrations per hour** by default
-(`AuthRateLimiterConfig` in `wavis-backend/src/auth/auth_rate_limiter.rs`) —
-and `/auth/register` calls from both `registerViaUi` and
-`seedChannelWithInvite` draw from the **same** window. At ~2 registrations per
-spec, one full 7-spec run needs ~14, so specs past the first two or three fail
-setup with `429` even on a freshly restarted backend. For e2e use, raise the
-limit when starting the stack — the backend reads `AUTH_REGISTER_RATE_LIMIT`
-and docker-compose.yml passes it through (default stays 5):
+**Rate limiting.** Two in-process, per-IP backend limiters bite during
+suite runs, both on 1-hour sliding windows:
+
+- **Registration** — 5/hour by default (`AuthRateLimiterConfig` in
+  `wavis-backend/src/auth/auth_rate_limiter.rs`); `/auth/register` calls
+  from both `registerAndLoginViaUi` and `seedChannelWithInvite` draw from
+  the same window, at ~2 registrations per spec. Override:
+  `AUTH_REGISTER_RATE_LIMIT`.
+- **Recovery** — 30/hour by default (`RecoveryRateLimiterConfig` in
+  `wavis-backend/src/auth/recovery_rate_limiter.rs`). Every Login-UI
+  authentication (`loginViaUi`, both new-device and trusted paths) is a
+  `/auth/recover` call, so repeated suite runs within an hour exhaust this
+  one too — observed as `loginViaUi` timing out on `/login` while the
+  backend logs `recover rate-limited (IP)` with a ~25-minute retry_after.
+  Override: `AUTH_RECOVER_RATE_LIMIT`.
+
+docker-compose.yml passes both through (defaults stay 5/30). For e2e use,
+raise them when starting the stack:
 
 ```powershell
-$env:AUTH_REGISTER_RATE_LIMIT="200"; docker compose up -d --build
+$env:AUTH_REGISTER_RATE_LIMIT="200"; $env:AUTH_RECOVER_RATE_LIMIT="200"; docker compose up -d --build
 ```
 
 (`docker compose restart wavis-backend` alone only clears the in-memory
-window — enough when iterating on a single spec, not for a full-suite run.)
+windows — enough when iterating on a single spec, not for a full-suite run.)
 
 **Multi-tier DOM duplication.** `ActiveRoom` mounts `ChatPanel`/
 `LogsPanel`/`ParticipantsPanel` once per responsive layout tier (mobile /
@@ -491,6 +506,73 @@ order does not reliably match which tier is rendered. `visibleText()` and
 the `:visible`-filtered locators in `live-backend-helpers.mjs` exist
 specifically to dodge this; reuse them for anything inside `/room` rather
 than reaching for a raw `getByText`.
+
+## Media quality + network simulation
+
+`zz-network-quality.spec.mjs` (named `zz-` so it runs last in the suite's
+alphabetical single-worker order — a netem teardown failure then can't
+contaminate any other spec) proves media stays smooth under a good network,
+degrades observably but keeps flowing under a simulated bad one, and
+recovers once the bad network clears. `audio-received.spec.mjs` and
+`screen-share-audio-not-heard-until-opened.spec.mjs` already prove media
+*arrives*; this is the smoothness/resilience proof neither one covers.
+
+**Why netem on the LiveKit container, not CDP/Playwright throttling.**
+Playwright's own network-condition APIs (and CDP's `Network.emulateNetworkConditions`
+generally) only intercept the page's HTTP(S)/fetch/XHR traffic — they do not
+touch WebRTC's UDP media path at all, confirmed against the driver's CDP
+session. The only leg that's actually shapeable is the LiveKit container's
+own egress: `docker-compose.yml`'s `livekit` service gets `cap_add:
+[NET_ADMIN]` and installs `iproute2` (`tc`) once at container start (before
+the existing config-templating `sed` + `exec /livekit-server`). Since
+LiveKit → GUI downstream is exactly the "incoming media" leg these specs
+want to degrade, shaping the container's `eth0` with `tc qdisc ... netem` is
+sufficient — no client-side or host-level shaping needed.
+
+**Helpers** (`live-backend-helpers.mjs`):
+
+- `hasNetemSupport()` — `docker exec wavis-livekit sh -c "command -v tc"`;
+  specs skip-with-reason (not fail) if this is false, e.g. the container
+  started offline and `apk add` never ran.
+- `setNetworkConditions({ delayMs, jitterMs, lossPct, rateKbit })` — `docker
+  exec wavis-livekit tc qdisc replace dev eth0 root netem ...`.
+- `clearNetworkConditions()` — `tc qdisc del dev eth0 root`, tolerating a
+  "no qdisc" error so it's safe to call unconditionally (e.g. in a `finally`,
+  even if a prior run crashed mid-shape).
+
+**Video peer.** `livekit-tone-peer.mjs`'s `connectTonePeer()` gained
+`startVideoPattern()`/`stopVideoPattern()`, publishing a real 640×360 @15fps
+moving RGBA pattern under `TrackSource.SOURCE_SCREENSHARE` (real frames that
+actually change, so the encoder can't collapse them to near-zero bitrate).
+No Watch All / share-tile step is needed first — unlike screen-share
+audio-only (deliberately gated behind explicit viewer intent, see issue
+#174's spec), `ScreenShare` video publications are subscribed unconditionally
+in `TrackPublished` (`livekit-media.ts` ~2740-2765), and the stats-interval's
+video receiver polling only needs `publication.track` to be present — which
+subscription alone provides.
+
+**Stats plumbing.** `App.tsx`'s `VITE_DIAGNOSTICS`-gated diagnostics tick
+already read both `networkStats` (voice-room.ts) and `videoReceiveStats`
+(livekit-media.ts) every second, but only forwarded them to the Tauri
+`diagnostics:voice-stats` event — `window.__wavisVoiceStats` (the hook e2e
+specs actually read, since `window.__TAURI__` isn't exposed) carried only
+`participants`/`selfParticipantId`. Both fields were widened onto
+`window.__wavisVoiceStats` too — additive, production-absent (same
+`VITE_DIAGNOSTICS` gate as before), and **requires rebuilding the debug exe**
+(`npx tauri build --debug` with the usual e2e env vars — see "Building the
+debug exe" above) before the suite sees them; a stale debug exe will read
+`undefined` for both new fields.
+
+**Thresholds.** The "good" vs "degraded" line reuses
+`DiagnosticsPage.tsx`'s own bad-network thresholds (concealment >10
+events/interval, packet loss >5%), and the degraded-phase assertion compares
+against the spec's own recorded baseline (`>`, not a fixed magic number) to
+avoid flake from any single noisy 10s stats interval.
+
+**Verify manually if this ever needs re-diagnosing:** with a real call up,
+`docker exec wavis-livekit tc qdisc replace dev eth0 root netem loss 30%`
+should visibly degrade audio within a few seconds, and `docker exec
+wavis-livekit tc qdisc del dev eth0 root` should restore it.
 
 ## Deferred: CI
 
@@ -526,6 +608,7 @@ without confirming both first.
 
 ## Other possible follow-ups (not built here)
 
-- Give `DeviceSetup` an invite-code field so `registerViaUi` (and the specs
-  that use it for setup) works against a backend that requires one — see
-  "Two simultaneous GUI instances" above for the current workaround.
+- Give `DeviceSetup` an invite-code field so UI-driven registration
+  (`registerViaUi`) works against a backend that requires one, and
+  `login.spec.mjs` can cover the registration flow again — see the "Known
+  gap" note above for the current REST-based workaround.

--- a/clients/wavis-gui/e2e-tooling/tests/audio-received.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/audio-received.spec.mjs
@@ -43,7 +43,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
@@ -92,11 +92,7 @@ test('audio published by a peer is decoded and reflected in the GUI as real rmsL
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-audio-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);

--- a/clients/wavis-gui/e2e-tooling/tests/camera.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/camera.spec.mjs
@@ -22,13 +22,13 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
   joinDefaultSubRoomViaUi,
   visibleText,
-  visibleTitle,
+  visibleIcon,
 } from './live-backend-helpers.mjs';
 
 /**
@@ -57,11 +57,7 @@ test('toggling the camera publishes and un-publishes a real local video tile', a
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-camera-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);
@@ -73,7 +69,7 @@ test('toggling the camera publishes and un-publishes a real local video tile', a
     // "camera device is already in use" instead of publishing, and the
     // assertion below times out visibly rather than hanging silently.
     await cameraButton(main, '/camera-on').click();
-    await expect(visibleTitle(main, 'your camera is on')).toBeVisible({ timeout: 10_000 });
+    await expect(visibleIcon(main, 'your camera is on')).toBeVisible({ timeout: 10_000 });
 
     await main
       .locator('button:visible', { hasText: /^VIDEOS?\b/ })
@@ -82,7 +78,7 @@ test('toggling the camera publishes and un-publishes a real local video tile', a
     await expect(visibleText(main, 'No video active')).toHaveCount(0);
 
     await cameraButton(main, '/camera-off').click();
-    await expect(main.getByTitle('your camera is on')).toHaveCount(0);
+    await expect(main.getByRole('img', { name: 'your camera is on' })).toHaveCount(0);
 
     // By design (ActiveRoom.tsx's groupedPanelVideoActivityKey effect), the
     // grouped panel auto-switches itself away from VIDEO the instant

--- a/clients/wavis-gui/e2e-tooling/tests/chat.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/chat.spec.mjs
@@ -9,7 +9,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
@@ -32,11 +32,7 @@ test('chat messages are exchanged between the GUI and a second participant', asy
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-chat-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);

--- a/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
@@ -4,9 +4,12 @@
 //
 // Not used by the backend-independent specs (launch/title-bar/multi-window/
 // settings) — those stay dependency-free on purpose.
-import { spawn } from 'node:child_process';
+import { spawn, execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+const execFileAsync = promisify(execFile);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // e2e-tooling/tests -> e2e-tooling -> wavis-gui -> clients -> workspace root
@@ -36,6 +39,21 @@ export function visibleText(page, textOrPattern) {
 /** Same tier-duplication problem as visibleText, but for elements matched by their `title` attribute. */
 export function visibleTitle(page, title) {
   return page.getByTitle(title).and(page.locator(':visible'));
+}
+
+/**
+ * For SVG icon indicators (ParticipantRow's lucide camera/screen-share
+ * icons): their accessible name comes from an aria-label or a nested SVG
+ * <title> CHILD ELEMENT, not a `title` attribute, so getByTitle/visibleTitle
+ * can never match them (commit 23719f1's glyph→lucide swap converted the
+ * old title attributes). Playwright's role engine computes the name from
+ * both sources, so match by role=img instead. Extra trap getByTitle also
+ * had: it substring-matches, so 'you are sharing' would false-positive on
+ * the adjacent title="you are sharing audio" badge — role-name matching is
+ * whole-string and avoids that.
+ */
+export function visibleIcon(page, name) {
+  return page.getByRole('img', { name }).and(page.locator(':visible'));
 }
 
 /**
@@ -148,6 +166,13 @@ export async function seedChannelWithInvite(name) {
  * continue) and returns the scraped recovery ID. Requires the debug exe to
  * have been built with VITE_ALLOW_INSECURE_TLS=true (see README) so the
  * insecure-TLS toggle is present for a plain-http serverUrl.
+ *
+ * CURRENTLY CANNOT SUCCEED against a closed-alpha backend: POST
+ * /auth/register 401s without an invite code, and DeviceSetup has no
+ * invite-code field yet (README's "Known gap"). No spec uses this anymore —
+ * use registerAndLoginViaUi (REST registration + real Login UI) for spec
+ * setup. Kept so it can be reinstated (with an invite-code fill step) once
+ * DeviceSetup gains the field.
  */
 export async function registerViaUi(page, { username, password, serverUrl = SERVER_URL } = {}) {
   // A stale wavis-auth-e2e.json (stored recovery ID from a previous run, but
@@ -511,4 +536,69 @@ export async function waitForMediaToken(peer) {
   const line = await peer.waitForOutput(/"type":"media_token"/);
   const parsed = JSON.parse(line.replace(/^<<\s*/, ''));
   return { token: parsed.token, sfuUrl: parsed.sfuUrl };
+}
+
+/* ─── Network-condition simulation (LiveKit container netem) ───────────
+ * CDP/Playwright network throttling does not touch WebRTC UDP, so media
+ * degradation has to be injected at the LiveKit container's egress (its
+ * eth0 — LiveKit -> GUI downstream is exactly the "incoming media" leg
+ * these specs want to degrade). docker-compose.yml gives the livekit
+ * service NET_ADMIN + installs iproute2 (tc) at container start.
+ */
+const LIVEKIT_CONTAINER = 'wavis-livekit';
+const NETEM_INTERFACE = 'eth0';
+
+/** True if `tc` is available in the livekit container — false means skip-with-reason, not fail. */
+export async function hasNetemSupport() {
+  try {
+    await execFileAsync('docker', ['exec', LIVEKIT_CONTAINER, 'sh', '-c', 'command -v tc']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Shapes the livekit container's egress via netem. Any of delayMs/jitterMs/lossPct/rateKbit may be omitted. */
+export async function setNetworkConditions({
+  delayMs = 0,
+  jitterMs = 0,
+  lossPct = 0,
+  rateKbit,
+} = {}) {
+  const args = [
+    'exec',
+    LIVEKIT_CONTAINER,
+    'tc',
+    'qdisc',
+    'replace',
+    'dev',
+    NETEM_INTERFACE,
+    'root',
+    'netem',
+  ];
+  if (delayMs > 0) {
+    args.push('delay', `${delayMs}ms`);
+    if (jitterMs > 0) args.push(`${jitterMs}ms`);
+  }
+  if (lossPct > 0) args.push('loss', `${lossPct}%`);
+  if (rateKbit) args.push('rate', `${rateKbit}kbit`);
+  await execFileAsync('docker', args);
+}
+
+/** Removes netem shaping. Tolerates "no qdisc to delete" so it's safe to call unconditionally (e.g. in a finally). */
+export async function clearNetworkConditions() {
+  try {
+    await execFileAsync('docker', [
+      'exec',
+      LIVEKIT_CONTAINER,
+      'tc',
+      'qdisc',
+      'del',
+      'dev',
+      NETEM_INTERFACE,
+      'root',
+    ]);
+  } catch {
+    // No qdisc present — already clear.
+  }
 }

--- a/clients/wavis-gui/e2e-tooling/tests/livekit-tone-peer.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/livekit-tone-peer.mjs
@@ -1,19 +1,26 @@
-// Media-publishing peer for audio-received.spec.mjs. wavis-cli-test cannot
-// fill this role — its `start_share` is a bare signaling message with no
-// pixels/audio ever attached (clients/cli-test/src/main.rs), and it can't
-// auth/join_voice into a GUI channel's voice call at all. This connects
-// directly to LiveKit via @livekit/rtc-node, reusing the same media_token
-// the backend hands a ws-sfu-test peer on join_voice (see
-// waitForMediaToken in live-backend-helpers.mjs), and publishes a real
-// decodable audio track so the GUI's analyser-based rmsLevel is genuine
-// decoded-audio evidence, not a signaling-path artifact.
+// Media-publishing peer for audio-received.spec.mjs and
+// zz-network-quality.spec.mjs. wavis-cli-test cannot fill this role — its
+// `start_share` is a bare signaling message with no pixels/audio ever
+// attached (clients/cli-test/src/main.rs), and it can't auth/join_voice
+// into a GUI channel's voice call at all. This connects directly to
+// LiveKit via @livekit/rtc-node, reusing the same media_token the backend
+// hands a ws-sfu-test peer on join_voice (see waitForMediaToken in
+// live-backend-helpers.mjs), and publishes a real decodable audio track so
+// the GUI's analyser-based rmsLevel is genuine decoded-audio evidence, not
+// a signaling-path artifact. startVideoPattern()/stopVideoPattern()
+// additionally publish a real moving video track under
+// TrackSource.SOURCE_SCREENSHARE for specs that need real decoded pixels.
 import {
   AudioFrame,
   AudioSource,
   LocalAudioTrack,
+  LocalVideoTrack,
   Room,
   TrackPublishOptions,
   TrackSource,
+  VideoBufferType,
+  VideoFrame,
+  VideoSource,
 } from '@livekit/rtc-node';
 
 const SAMPLE_RATE = 48_000;
@@ -24,6 +31,11 @@ const TONE_HZ = 440;
 const AMPLITUDE = Math.round(0.8 * 32_767);
 const PHASE_STEP = (2 * Math.PI * TONE_HZ) / SAMPLE_RATE;
 const TWO_PI = 2 * Math.PI;
+
+const VIDEO_WIDTH = 640;
+const VIDEO_HEIGHT = 360;
+const VIDEO_FPS = 15;
+const VIDEO_FRAME_INTERVAL_MS = 1000 / VIDEO_FPS;
 
 /**
  * Connects to LiveKit as a real publishing participant and immediately
@@ -36,11 +48,7 @@ const TWO_PI = 2 * Math.PI;
  * `SOURCE_SCREENSHARE_AUDIO` so the GUI routes the track through its
  * deferred screen-share-audio path instead of the plain-voice path.
  */
-export async function connectTonePeer({
-  sfuUrl,
-  token,
-  source = TrackSource.SOURCE_MICROPHONE,
-}) {
+export async function connectTonePeer({ sfuUrl, token, source = TrackSource.SOURCE_MICROPHONE }) {
   const room = new Room();
   await room.connect(sfuUrl, token, { autoSubscribe: false, dynacast: false });
 
@@ -69,9 +77,16 @@ export async function connectTonePeer({
         }
       }
       // else: data stays zero-filled — genuine silent PCM, not "no frames".
-      await audioSource.captureFrame(new AudioFrame(data, SAMPLE_RATE, CHANNELS, SAMPLES_PER_FRAME));
+      await audioSource.captureFrame(
+        new AudioFrame(data, SAMPLE_RATE, CHANNELS, SAMPLES_PER_FRAME),
+      );
     }
   })();
+
+  let videoSource = null;
+  let videoTrack = null;
+  let videoRunning = false;
+  let videoPump = null;
 
   return {
     /**
@@ -86,9 +101,66 @@ export async function connectTonePeer({
     stopTone() {
       toneActive = false;
     },
+    /**
+     * Publishes a moving RGBA pattern (640x360 @ ~15fps) under
+     * TrackSource.SOURCE_SCREENSHARE — the source the GUI's
+     * videoReceiveStats path and share pipeline key on. The pattern
+     * actually changes each frame so it encodes as real motion, not a
+     * single static frame the encoder could collapse to near-zero bitrate.
+     */
+    async startVideoPattern() {
+      if (videoSource) return;
+      videoSource = new VideoSource(VIDEO_WIDTH, VIDEO_HEIGHT);
+      videoTrack = LocalVideoTrack.createVideoTrack('pattern', videoSource);
+      await room.localParticipant.publishTrack(
+        videoTrack,
+        new TrackPublishOptions({ source: TrackSource.SOURCE_SCREENSHARE }),
+      );
+
+      videoRunning = true;
+      let frameIndex = 0;
+      const rowBytes = VIDEO_WIDTH * 4;
+      const rowTemplate = new Uint8Array(rowBytes);
+      videoPump = (async () => {
+        while (videoRunning) {
+          const splitX = frameIndex % VIDEO_WIDTH;
+          for (let x = 0; x < VIDEO_WIDTH; x++) {
+            const bright = x < splitX;
+            const i = x * 4;
+            rowTemplate[i] = bright ? 255 : 0; // R
+            rowTemplate[i + 1] = bright ? 0 : 255; // G
+            rowTemplate[i + 2] = frameIndex % 256; // B
+            rowTemplate[i + 3] = 255; // A
+          }
+          const data = new Uint8Array(rowBytes * VIDEO_HEIGHT);
+          for (let y = 0; y < VIDEO_HEIGHT; y++) {
+            data.set(rowTemplate, y * rowBytes);
+          }
+          videoSource.captureFrame(
+            new VideoFrame(data, VIDEO_WIDTH, VIDEO_HEIGHT, VideoBufferType.RGBA),
+          );
+          frameIndex++;
+          await new Promise((resolve) => setTimeout(resolve, VIDEO_FRAME_INTERVAL_MS));
+        }
+      })();
+    },
+    async stopVideoPattern() {
+      if (!videoRunning) return;
+      videoRunning = false;
+      await videoPump;
+      await videoTrack.close();
+      videoSource = null;
+      videoTrack = null;
+      videoPump = null;
+    },
     async close() {
       running = false;
       await pump;
+      if (videoRunning) {
+        videoRunning = false;
+        await videoPump;
+      }
+      if (videoTrack) await videoTrack.close();
       await audioSource.close();
       await room.disconnect();
     },

--- a/clients/wavis-gui/e2e-tooling/tests/livekit-tone-peer.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/livekit-tone-peer.mjs
@@ -29,17 +29,24 @@ const TWO_PI = 2 * Math.PI;
  * Connects to LiveKit as a real publishing participant and immediately
  * starts pumping a 440Hz sine tone as 10ms Int16 PCM frames. Returns
  * `{ stopTone(), close() }`. `close()` does full teardown.
+ *
+ * `source` selects the LiveKit track source the tone publishes under
+ * (default `SOURCE_MICROPHONE`, what audio-received.spec.mjs relies on).
+ * screen-share-audio-not-heard-until-opened.spec.mjs passes
+ * `SOURCE_SCREENSHARE_AUDIO` so the GUI routes the track through its
+ * deferred screen-share-audio path instead of the plain-voice path.
  */
-export async function connectTonePeer({ sfuUrl, token }) {
+export async function connectTonePeer({
+  sfuUrl,
+  token,
+  source = TrackSource.SOURCE_MICROPHONE,
+}) {
   const room = new Room();
   await room.connect(sfuUrl, token, { autoSubscribe: false, dynacast: false });
 
-  const source = new AudioSource(SAMPLE_RATE, CHANNELS);
-  const track = LocalAudioTrack.createAudioTrack('tone', source);
-  await room.localParticipant.publishTrack(
-    track,
-    new TrackPublishOptions({ source: TrackSource.SOURCE_MICROPHONE }),
-  );
+  const audioSource = new AudioSource(SAMPLE_RATE, CHANNELS);
+  const track = LocalAudioTrack.createAudioTrack('tone', audioSource);
+  await room.localParticipant.publishTrack(track, new TrackPublishOptions({ source }));
 
   let phase = 0;
   let running = true;
@@ -62,7 +69,7 @@ export async function connectTonePeer({ sfuUrl, token }) {
         }
       }
       // else: data stays zero-filled — genuine silent PCM, not "no frames".
-      await source.captureFrame(new AudioFrame(data, SAMPLE_RATE, CHANNELS, SAMPLES_PER_FRAME));
+      await audioSource.captureFrame(new AudioFrame(data, SAMPLE_RATE, CHANNELS, SAMPLES_PER_FRAME));
     }
   })();
 
@@ -82,7 +89,7 @@ export async function connectTonePeer({ sfuUrl, token }) {
     async close() {
       running = false;
       await pump;
-      await source.close();
+      await audioSource.close();
       await room.disconnect();
     },
   };

--- a/clients/wavis-gui/e2e-tooling/tests/login.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/login.spec.mjs
@@ -1,67 +1,31 @@
-// Live-backend: exercises the real auth UI end to end — DeviceSetup
-// registration, logout, and Login's recovery-ID-based re-login (both the
-// "trusted device" password-only path and the manual "new device" Wavis ID
-// entry path). This is the ONLY spec that drives the real auth UI from
-// scratch; room-join/chat/participants use registerViaUi (a thinner version
-// of the same flow) purely as setup, not as something under test.
+// Live-backend: exercises the real Login UI end to end — the manual
+// "new device" Wavis-ID entry path and the trusted-device password-only
+// path — with an account created out-of-band via REST.
+//
+// The DeviceSetup registration UI is deliberately NOT exercised here:
+// POST /auth/register 401s without a closed-alpha invite code
+// (wavis-backend/src/auth/routes.rs's register handler), and DeviceSetup has
+// no invite-code field, so UI registration cannot succeed against this
+// backend at all — see README.md's "Known gap" note. Until DeviceSetup gains
+// that field, account creation goes through registerDevice() (REST, which
+// does send ALPHA_INVITE_CODE), and this spec covers the login flows only.
 //
 // Requires a reachable backend (see README's "Live-backend specs" section)
 // and a debug exe built with VITE_ALLOW_INSECURE_TLS=true /
 // VITE_AUTH_STORE_NAME set, so it never touches a real persisted session on
 // this machine (see driver.mjs's WAVIS_KEYRING_SERVICE).
-//
-// Each run registers a fresh throwaway account (timestamp-suffixed
-// username) — registration has no email/CAPTCHA step, so this is cheap and
-// deterministic, at the cost of leaving throwaway accounts in the backend's
-// database (acceptable for a disposable local docker-compose instance).
 import { test, expect } from './fixtures.mjs';
-import { SERVER_URL, waitForBackendHealth, leaveRoomIfActive } from './live-backend-helpers.mjs';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  leaveRoomIfActive,
+  registerDevice,
+  loginViaUi,
+} from './live-backend-helpers.mjs';
 
 const UNAUTHENTICATED_PATHS = ['/login', '/setup', '/recover', '/pair'];
 
-async function currentPathname(page) {
-  return new URL(page.url()).pathname;
-}
-
-/** Navigates from wherever the app currently is to the /setup registration form. */
-async function getToSetup(main) {
-  let pathname = await currentPathname(main);
-
-  if (!UNAUTHENTICATED_PATHS.some((p) => pathname.startsWith(p))) {
-    // Authenticated somewhere (/, /channels, /settings, ...) — log out first.
-    await main.getByText('/settings', { exact: true }).first().click();
-    await main.getByText('/logout — sign out of this device', { exact: true }).click();
-    await expect(main).toHaveURL(/\/login/);
-    pathname = await currentPathname(main);
-  }
-
-  test.skip(
-    pathname.startsWith('/recover') || pathname.startsWith('/pair'),
-    'App landed on /recover or /pair, not /login or /setup — no scripted path from here without assuming unrelated in-progress state.',
-  );
-
-  if (pathname.startsWith('/login')) {
-    // Trusted-device mode shows only a password field; reveal the /setup
-    // link by declaring "not you" first (also required to reach /setup at
-    // all) — unless already in new-device mode, where it doesn't exist.
-    // Login.tsx renders "loading..." until its async store reads resolve, so
-    // an instant .isVisible() snapshot here would race that — use a real
-    // click with Playwright's built-in auto-wait/retry instead, and only
-    // treat a genuine absence (not-yet-rendered doesn't count) as "already
-    // in new-device mode".
-    try {
-      await main
-        .getByText('Not you / log in on a new device', { exact: true })
-        .click({ timeout: 10_000 });
-    } catch {
-      // Already in new-device mode — /setup should be directly reachable.
-    }
-    await main.getByText('/setup', { exact: true }).click();
-    await expect(main).toHaveURL(/\/setup/);
-  }
-}
-
-test('register creates an account, and recovery ID logs back in on both trusted and new-device paths', async ({
+test('recovery ID logs in on the new-device path, then password-only on the trusted-device path', async ({
   app,
 }) => {
   await waitForBackendHealth();
@@ -69,59 +33,37 @@ test('register creates an account, and recovery ID logs back in on both trusted 
   const main = app.page();
   await leaveRoomIfActive(main);
 
-  await getToSetup(main);
+  const identity = await registerDevice();
 
-  const suffix = Date.now().toString(36);
-  const username = `e2e-login-${suffix}`;
-  const password = `e2e-password-${suffix}`;
-
-  await main.getByLabel('Username', { exact: true }).fill(username);
-  await main.getByLabel('Password', { exact: true }).fill(password);
-  await main.getByLabel('Confirm Password', { exact: true }).fill(password);
-  await main.getByText('/next', { exact: true }).click();
-
-  await main.getByLabel('Server URL', { exact: true }).fill(SERVER_URL);
-  if (SERVER_URL.startsWith('http://')) {
-    await main.getByText('--danger-insecure-tls', { exact: true }).click();
+  // Log out any persisted session first so the login flows under test start
+  // from a real logged-out state. (On /recover or /pair there is nothing to
+  // log out of — loginViaUi navigates straight to /login from anywhere.)
+  const pathname = new URL(main.url()).pathname;
+  if (!UNAUTHENTICATED_PATHS.some((p) => pathname.startsWith(p))) {
+    await main.getByText('/settings', { exact: true }).first().click();
+    await main.getByText('/logout — sign out of this device', { exact: true }).click();
+    await expect(main).toHaveURL(/\/login/);
   }
-  await main.getByText('/register', { exact: true }).click();
 
-  const recoveryIdLocator = main.locator('code').first();
-  await expect(recoveryIdLocator).toBeVisible({ timeout: 15_000 });
-  const recoveryId = (await recoveryIdLocator.innerText()).trim();
-  expect(recoveryId.length).toBeGreaterThan(0);
-
-  await main.getByText('I have saved my Recovery ID (required)', { exact: false }).click();
-  await main.getByText('/continue', { exact: true }).click();
-
-  // Authenticated: AuthGate's /settings link should now be reachable.
-  await expect(main).not.toHaveURL(/\/setup/);
+  // Manual "new device" path: Wavis ID + password + server URL.
+  await loginViaUi(main, {
+    recoveryId: identity.recovery_id,
+    password: identity.phrase,
+    serverUrl: SERVER_URL,
+  });
+  await expect(main).not.toHaveURL(/\/login/);
   await expect(main.getByText('/settings', { exact: true }).first()).toBeVisible();
 
-  // Log out -> lands on /login in trusted mode (recovery ID preserved by logout()).
+  // Log out -> lands on /login in trusted mode (recovery ID preserved by
+  // logout()), which shows only a password field.
   await main.getByText('/settings', { exact: true }).first().click();
   await main.getByText('/logout — sign out of this device', { exact: true }).click();
   await expect(main).toHaveURL(/\/login/);
   await expect(main.getByLabel('Wavis ID', { exact: true })).toHaveCount(0);
 
-  // Password-only trusted-device login with the just-created account.
-  await main.getByLabel('Password', { exact: true }).fill(password);
+  // Password-only trusted-device login with the same account.
+  await main.getByLabel('Password', { exact: true }).fill(identity.phrase);
   await main.getByText('/login', { exact: true }).click();
-  await expect(main).not.toHaveURL(/\/login/);
-  await expect(main.getByText('/settings', { exact: true }).first()).toBeVisible();
-
-  // Log out again, then exercise the manual "new device" Wavis-ID entry path.
-  await main.getByText('/settings', { exact: true }).first().click();
-  await main.getByText('/logout — sign out of this device', { exact: true }).click();
-  await expect(main).toHaveURL(/\/login/);
-
-  await main.getByText('Not you / log in on a new device', { exact: true }).click();
-  await expect(main.getByLabel('Wavis ID', { exact: true })).toBeVisible();
-
-  await main.getByLabel('Wavis ID', { exact: true }).fill(recoveryId);
-  await main.getByLabel('Password', { exact: true }).fill(password);
-  await main.getByText('/login', { exact: true }).click();
-
   await expect(main).not.toHaveURL(/\/login/);
   await expect(main.getByText('/settings', { exact: true }).first()).toBeVisible();
 });

--- a/clients/wavis-gui/e2e-tooling/tests/participants.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/participants.spec.mjs
@@ -14,7 +14,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
@@ -39,11 +39,7 @@ test('the participant count and row update when a second participant joins and l
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-participants-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);

--- a/clients/wavis-gui/e2e-tooling/tests/room-join.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/room-join.spec.mjs
@@ -7,7 +7,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   leaveRoomIfActive,
 } from './live-backend-helpers.mjs';
@@ -24,11 +24,7 @@ test('joining a channel by invite code shows it in the channel list', async ({ a
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-joiner-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
@@ -46,7 +46,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
@@ -90,11 +90,7 @@ test('a peer\'s screen-share audio stays silent until the user unmutes it', asyn
   await leaveRoomIfActive(main);
   const pathname = new URL(main.url()).pathname;
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-ssaudio-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
@@ -71,7 +71,7 @@ const ATTACH_LOG = /\[mac-share-audio\] attached screen share audio/;
 // suppressed pre-intent and is NOT a reliable "arrived" signal.
 const TRACK_ARRIVED_LOG = /\[diag\] TrackPublished[^\n]*source: screen_share_audio/;
 
-test('a peer\'s screen-share audio stays silent until the user unmutes it', async ({ app }) => {
+test("a peer's screen-share audio stays silent until the user unmutes it", async ({ app }) => {
   // Peer spawn (cargo run -p ws-sfu-test) + LiveKit connect + the settle
   // window for the negative assertion push this past the 30s default.
   test.setTimeout(90_000);

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
@@ -1,0 +1,166 @@
+// Live-backend, real media: the belt-and-braces proof for GitHub issue #174
+// ("I can hear a new stream even without opening it"). audio-received.spec.mjs
+// already proves plain *voice* audio decodes and plays; this proves the
+// opposite gate for *screen-share* audio — that a real ScreenShareAudio track
+// arriving on the SFU is deliberately NOT played until the local user
+// expresses intent, and DOES attach the moment they do.
+//
+// Why this is real proof, not a mocked unit test: a @livekit/rtc-node peer
+// (livekit-tone-peer.mjs) publishes a real 440Hz tone under
+// TrackSource.SOURCE_SCREENSHARE_AUDIO — a genuine decodable track over the
+// real local LiveKit/docker stack, attributed to the peer's own signaling
+// participant row (same media_token path as audio-received.spec.mjs). The
+// assertions read the GUI's own unconditional attach log
+// (livekit-media.ts:6655, `[mac-share-audio] attached screen share audio …`),
+// which fires only from attachDesiredScreenShareAudio — reachable only after
+// the public attachScreenShareAudio() adds the participant to
+// screenShareAudioViewerOwners, the single gate shouldPlayScreenShareAudio
+// keys off. That method is only called from the viewer-ready handshake and
+// the explicit unmute path (useShareViewerWindows.ts), never on track arrival.
+//
+// Scenario chosen — audio-only share + explicit unmute, NOT Watch-All:
+// reading the actual code (not the original handoff's summary) showed
+// audio-only shares never flow through Watch-All's attach path.
+// getWatchAllScope(roomState).streams contains only *video* screenShareStreams,
+// so an audio-only sharer is instead force-muted/detached by a dedicated
+// effect (useShareViewerWindows.ts:966-1005) — even while Watch-All is open.
+// The only attach path for audio-only is the user unmuting the share
+// (syncScreenShareMuted(id,false) -> attachScreenShareAudio). That makes this
+// a STRONGER demonstration of #174 than "open the viewer": the audio stays
+// silent through the whole render, and only an explicit unmute plays it.
+//
+// The negative assertion is the heart of #174. It is paired with a positive
+// "the track really did arrive" check so that "no attach" can't be a false
+// pass from the track never reaching the client at all. That check is the
+// [diag] TrackPublished log (the peer's ScreenShareAudio *publication* reaching
+// the GUI's SFU connection), NOT TrackSubscribed: the GUI deliberately
+// setSubscribed(false)s the deferred track, so TrackSubscribed is intentionally
+// suppressed pre-intent — confirmed live, the subscription is cancelled and the
+// SDK logs a stream of "Tried to add a track for a participant, that's not
+// present" until the unmute below re-subscribes it. That suppression IS the fix
+// working; the unmute path (attachScreenShareAudio -> setSubscribed(true)) then
+// lets TrackSubscribed fire and the audio attach.
+import { test, expect } from './fixtures.mjs';
+import { TrackSource } from '@livekit/rtc-node';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  seedChannelWithInvite,
+  registerViaUi,
+  joinChannelViaUi,
+  enterChannelRoom,
+  leaveRoomIfActive,
+  joinDefaultSubRoomViaUi,
+  joinDefaultSubRoomAsPeer,
+  visibleTitle,
+  spawnPeer,
+  joinVoiceAsPeer,
+  waitForMediaToken,
+} from './live-backend-helpers.mjs';
+import { connectTonePeer } from './livekit-tone-peer.mjs';
+
+// livekit-media.ts:6655 — unconditional (not behind a debug flag), so absence
+// is genuine "never attached", not "debug logging was off". Distinct substring
+// from the `attachScreenShareAudio called for …` debug line so the negative
+// assertion can't match that instead.
+const ATTACH_LOG = /\[mac-share-audio\] attached screen share audio/;
+// livekit-media.ts:2700 — the peer's ScreenShareAudio *publication* reached
+// the GUI's SFU connection (gated by VITE_DEBUG_SHARE_TRACK_SUBSCRIPTION, baked
+// true in .env). This is the right arrival proof: the GUI deliberately
+// setSubscribed(false)s the deferred track, so TrackSubscribed is intentionally
+// suppressed pre-intent and is NOT a reliable "arrived" signal.
+const TRACK_ARRIVED_LOG = /\[diag\] TrackPublished[^\n]*source: screen_share_audio/;
+
+test('a peer\'s screen-share audio stays silent until the user unmutes it', async ({ app }) => {
+  // Peer spawn (cargo run -p ws-sfu-test) + LiveKit connect + the settle
+  // window for the negative assertion push this past the 30s default.
+  test.setTimeout(90_000);
+  await waitForBackendHealth();
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-ssaudio-${suffix}`;
+  const { owner, channel, invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  // Capture console before anything publishes — the whole point is proving a
+  // log never fired, so the listener must predate the peer's track.
+  const logs = [];
+  main.on('console', (msg) => logs.push(msg.text()));
+
+  await leaveRoomIfActive(main);
+  const pathname = new URL(main.url()).pathname;
+  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+    await registerViaUi(main, {
+      username: `e2e-ssaudio-gui-${suffix}`,
+      password: `e2e-password-${suffix}`,
+      serverUrl: SERVER_URL,
+    });
+  }
+
+  await joinChannelViaUi(main, invite.code);
+  await enterChannelRoom(main, channelName);
+  await joinDefaultSubRoomViaUi(main);
+
+  const peer = spawnPeer();
+  let tone;
+  try {
+    await joinVoiceAsPeer(peer, {
+      accessToken: owner.access_token,
+      channelId: channel.channel_id,
+      displayName: 'AudioSharePeer',
+    });
+    // ParticipantsPanel only renders participants inside the joined sub-room,
+    // so the peer must share the GUI's sub-room for its row (and the unmute
+    // button) to appear at all.
+    await joinDefaultSubRoomAsPeer(peer);
+
+    const { token, sfuUrl } = await waitForMediaToken(peer);
+    // Real ScreenShareAudio track — the GUI routes this through its deferred
+    // screen-share-audio path (isDeferredScreenShareAudioTrack returns true
+    // for TrackSource.ScreenShareAudio), not the plain-voice attach path.
+    tone = await connectTonePeer({ sfuUrl, token, source: TrackSource.SOURCE_SCREENSHARE_AUDIO });
+    // The signaling half of a real audio-only share: makes the peer
+    // isSharing + a confirmed audioOnlySharer, so ParticipantsPanel renders
+    // the row's "unmute audio share" button (ParticipantRow.tsx:185-204).
+    peer.send({ type: 'start_share', shareType: 'audio_only' });
+
+    // The button only appears once share_started(audio_only) is processed —
+    // its visibility is the GUI's own confirmation it registered the share.
+    const unmuteBtn = visibleTitle(main, 'unmute audio share').first();
+    await unmuteBtn.waitFor({ state: 'visible', timeout: 15_000 });
+
+    // The track genuinely reached the client (so the negative below isn't a
+    // false pass from a track that never arrived).
+    await expect
+      .poll(() => logs.some((l) => TRACK_ARRIVED_LOG.test(l)), {
+        timeout: 15_000,
+        message: 'GUI never logged TrackPublished for the peer ScreenShareAudio track',
+      })
+      .toBe(true);
+
+    // CORE #174 ASSERTION: the track arrived and the row is on screen, yet
+    // nothing has attached/played it. Hold a settle window so a late attach
+    // would have fired, then assert it did not.
+    await new Promise((resolve) => setTimeout(resolve, 4_000));
+    expect(
+      logs.some((l) => ATTACH_LOG.test(l)),
+      'screen-share audio attached before any user intent (issue #174 regression)',
+    ).toBe(false);
+
+    // POSITIVE: an explicit unmute is real viewer intent — attach must fire
+    // now, and only now (everything before this point already established no
+    // attach line existed).
+    const marker = logs.length;
+    await unmuteBtn.click();
+    await expect
+      .poll(() => logs.slice(marker).some((l) => ATTACH_LOG.test(l)), {
+        timeout: 10_000,
+        message: 'screen-share audio never attached after the user unmuted it',
+      })
+      .toBe(true);
+  } finally {
+    if (tone) await tone.close();
+    await peer.close();
+    await leaveRoomIfActive(main);
+  }
+});

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
@@ -16,7 +16,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
@@ -55,11 +55,7 @@ test('rejoining participant sees both video-share and audio-share badges for a c
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-share-rejoin-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share.spec.mjs
@@ -29,7 +29,7 @@ import {
   SERVER_URL,
   waitForBackendHealth,
   seedChannelWithInvite,
-  registerViaUi,
+  registerAndLoginViaUi,
   joinChannelViaUi,
   enterChannelRoom,
   leaveRoomIfActive,
@@ -37,6 +37,7 @@ import {
   joinDefaultSubRoomAsPeer,
   visibleText,
   visibleTitle,
+  visibleIcon,
   spawnPeer,
   joinVoiceAsPeer,
   sendCliCommand,
@@ -56,11 +57,7 @@ test('GUI shares its screen and a peer observes start/stop; a peer signaling a s
   const pathname = new URL(main.url()).pathname;
 
   if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerViaUi(main, {
-      username: `e2e-share-gui-${suffix}`,
-      password: `e2e-password-${suffix}`,
-      serverUrl: SERVER_URL,
-    });
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
   }
 
   await joinChannelViaUi(main, invite.code);
@@ -88,11 +85,11 @@ test('GUI shares its screen and a peer observes start/stop; a peer signaling a s
     await main.getByRole('button', { name: 'Share', exact: true }).click();
 
     await peer.waitForOutput(/"type":"share_started"/, 15_000);
-    await expect(visibleTitle(main, 'you are sharing')).toBeVisible({ timeout: 10_000 });
+    await expect(visibleIcon(main, 'you are sharing')).toBeVisible({ timeout: 10_000 });
 
     await sendCliCommand(main, '/stopshare');
     await peer.waitForOutput(/"type":"share_stopped"/, 15_000);
-    await expect(main.getByTitle('you are sharing')).toHaveCount(0);
+    await expect(main.getByRole('img', { name: 'you are sharing' })).toHaveCount(0);
 
     /* ── Direction B: peer signals a share, GUI shows waiting indicator ── */
     peer.send({ type: 'start_share' });

--- a/clients/wavis-gui/e2e-tooling/tests/zz-network-quality.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/zz-network-quality.spec.mjs
@@ -1,0 +1,215 @@
+// Live-backend, real media: proves media stays smooth under good network
+// conditions, degrades observably (but keeps flowing) under a simulated bad
+// network, and recovers once the bad network clears. audio-received.spec.mjs
+// and screen-share-audio-not-heard-until-opened.spec.mjs already prove media
+// arrives at all; this is the smoothness/resilience proof neither covers, and
+// closes screen-share.spec.mjs's "real watched pixels" scope-limit comment by
+// using a real video-publishing peer for the first time.
+//
+// Named zz- so it runs last in the suite's alphabetical single-worker order:
+// if netem teardown ever fails, a shaped container can't contaminate any
+// other spec's assertions.
+//
+// Network simulation mechanism: CDP/Playwright network throttling does not
+// touch WebRTC UDP traffic at all (confirmed against the driver's CDP
+// session), so the only real lever is shaping traffic at the LiveKit
+// container itself — docker-compose.yml gives the `livekit` service
+// NET_ADMIN and installs iproute2 (tc) at container start. netem on the
+// container's eth0 shapes LiveKit's egress, which is exactly the GUI's
+// incoming-media leg (the direction these specs want to degrade). See
+// live-backend-helpers.mjs's netem section and README.md's "Media quality +
+// network simulation" section for the full mechanism writeup.
+//
+// Video auto-subscribe: unlike screen-share audio-only (deliberately gated
+// behind explicit viewer intent — see issue #174's spec), ScreenShare video
+// publications are subscribed unconditionally in TrackPublished
+// (livekit-media.ts ~2740-2765: setSubscribed(true)/setEnabled(true) with no
+// gate), and the stats-interval's video receiver polling only needs
+// `publication.track` to be present (~3319-3330) — which subscription alone
+// provides. So this spec does not need to open Watch All or a share tile
+// first; the video peer's track decodes and reports fps as soon as it's
+// published, the same way plain voice audio does in audio-received.spec.mjs.
+import { test, expect } from './fixtures.mjs';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  seedChannelWithInvite,
+  registerAndLoginViaUi,
+  joinChannelViaUi,
+  enterChannelRoom,
+  leaveRoomIfActive,
+  joinDefaultSubRoomViaUi,
+  joinDefaultSubRoomAsPeer,
+  spawnPeer,
+  joinVoiceAsPeer,
+  waitForMediaToken,
+  hasNetemSupport,
+  setNetworkConditions,
+  clearNetworkConditions,
+} from './live-backend-helpers.mjs';
+import { connectTonePeer } from './livekit-tone-peer.mjs';
+
+// Same band as audio-received.spec.mjs — see that file's header comment for
+// why this range can only be reached by genuine decoded-audio analyser RMS.
+const DECODED_AUDIO_RMS_MIN = 0.2;
+const DECODED_AUDIO_RMS_MAX = 0.95;
+
+// DiagnosticsPage.tsx's own "this is bad" thresholds (concealment >10
+// events/interval, packet loss >5%) — reused here as the good/bad line so
+// this spec's notion of "degraded" matches what a real user would see
+// flagged in the diagnostics window.
+const GOOD_CONCEALMENT_MAX = 10;
+const GOOD_LOSS_MAX_PERCENT = 5;
+
+const STATS_POLL_INTERVAL_MS = 2_000;
+
+/** Reads the full exposed voice-stats snapshot, plus the peer's (non-self) participant entry. */
+async function readStats(page) {
+  return page.evaluate(() => {
+    const stats = window.__wavisVoiceStats;
+    if (!stats) return null;
+    const peer = stats.participants.find((p) => p.id !== stats.selfParticipantId) ?? null;
+    return {
+      networkStats: stats.networkStats,
+      videoReceiveStats: stats.videoReceiveStats,
+      peerRmsLevel: peer?.rmsLevel ?? null,
+    };
+  });
+}
+
+test('media quality survives and reports a simulated bad network, then recovers', async ({
+  app,
+}) => {
+  // Stats tick every 10s (voice-room.ts's statsInterval) — each phase needs
+  // 2-3 fresh samples, plus peer spawn/join/publish overhead.
+  test.setTimeout(180_000);
+  await waitForBackendHealth();
+
+  if (!(await hasNetemSupport())) {
+    test.skip(true, 'wavis-livekit container has no tc/netem support (offline apk add at start?)');
+    return;
+  }
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-netq-${suffix}`;
+  const { owner, channel, invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  await leaveRoomIfActive(main);
+  const pathname = new URL(main.url()).pathname;
+
+  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
+  }
+
+  await joinChannelViaUi(main, invite.code);
+  await enterChannelRoom(main, channelName);
+  await joinDefaultSubRoomViaUi(main);
+
+  const peer = spawnPeer();
+  let tone;
+  try {
+    await joinVoiceAsPeer(peer, {
+      accessToken: owner.access_token,
+      channelId: channel.channel_id,
+      displayName: 'NetQualityPeer',
+    });
+    await joinDefaultSubRoomAsPeer(peer);
+
+    const { token, sfuUrl } = await waitForMediaToken(peer);
+    tone = await connectTonePeer({ sfuUrl, token });
+    await tone.startVideoPattern();
+    // Signaling half of the share — marks the peer as sharing so the GUI's
+    // "waiting for stream..." state resolves once the real track arrives.
+    peer.send({ type: 'start_share' });
+
+    /* ── Phase 1: baseline (good network) ─────────────────────────── */
+    let baseline;
+    await expect
+      .poll(
+        async () => {
+          const stats = await readStats(main);
+          if (!stats) return false;
+          baseline = stats;
+          return (
+            stats.peerRmsLevel !== null &&
+            stats.peerRmsLevel > DECODED_AUDIO_RMS_MIN &&
+            stats.peerRmsLevel < DECODED_AUDIO_RMS_MAX &&
+            stats.videoReceiveStats !== null &&
+            stats.videoReceiveStats.fps > 0 &&
+            stats.networkStats.concealmentEventsPerInterval <= GOOD_CONCEALMENT_MAX &&
+            stats.networkStats.packetLossPercent < GOOD_LOSS_MAX_PERCENT
+          );
+        },
+        {
+          timeout: 60_000,
+          intervals: [STATS_POLL_INTERVAL_MS],
+          message:
+            'media never reached a smooth baseline (decoded audio + decoded video + good network stats)',
+        },
+      )
+      .toBe(true);
+
+    /* ── Phase 2: degraded network ─────────────────────────────────── */
+    await setNetworkConditions({ delayMs: 150, jitterMs: 50, lossPct: 8 });
+
+    await expect
+      .poll(
+        async () => {
+          const stats = await readStats(main);
+          if (!stats) return false;
+          const audioOk =
+            stats.peerRmsLevel !== null &&
+            stats.peerRmsLevel > DECODED_AUDIO_RMS_MIN &&
+            stats.peerRmsLevel < DECODED_AUDIO_RMS_MAX;
+          const videoOk = stats.videoReceiveStats !== null && stats.videoReceiveStats.fps > 0;
+          // Comparative (>, not ==) against the recorded baseline to avoid
+          // flake from any single noisy interval — the impairment just has
+          // to be visibly worse than the known-good baseline, not hit an
+          // exact number.
+          const impaired =
+            stats.networkStats.packetLossPercent > baseline.networkStats.packetLossPercent ||
+            stats.networkStats.concealmentEventsPerInterval >
+              baseline.networkStats.concealmentEventsPerInterval;
+          return audioOk && videoOk && impaired;
+        },
+        {
+          timeout: 60_000,
+          intervals: [STATS_POLL_INTERVAL_MS],
+          message:
+            'media did not stay resilient under a degraded network, or the stats pipeline never reflected the impairment',
+        },
+      )
+      .toBe(true);
+
+    /* ── Phase 3: recovery ────────────────────────────────────────── */
+    await clearNetworkConditions();
+
+    await expect
+      .poll(
+        async () => {
+          const stats = await readStats(main);
+          if (!stats) return false;
+          return (
+            stats.networkStats.concealmentEventsPerInterval <= GOOD_CONCEALMENT_MAX &&
+            stats.networkStats.packetLossPercent < GOOD_LOSS_MAX_PERCENT
+          );
+        },
+        {
+          timeout: 60_000,
+          intervals: [STATS_POLL_INTERVAL_MS],
+          message: 'network stats never returned to a good band after clearing netem',
+        },
+      )
+      .toBe(true);
+  } finally {
+    // Unconditional and tolerant-if-absent (see clearNetworkConditions'
+    // comment) — a crashed prior assertion above must never leave the
+    // shared docker-compose LiveKit container shaped for the next spec.
+    await clearNetworkConditions();
+    if (tone) await tone.stopVideoPattern().catch(() => {});
+    if (tone) await tone.close();
+    await peer.close();
+    await leaveRoomIfActive(main);
+  }
+});

--- a/clients/wavis-gui/src/App.tsx
+++ b/clients/wavis-gui/src/App.tsx
@@ -9,6 +9,8 @@ import { emit } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import AppUpdatePrompt from '@shared/AppUpdatePrompt';
 import type { AppDimensions } from '@features/diagnostics/diagnostics';
+import type { NetworkStats } from '@features/voice/voice-room';
+import type { VideoReceiveStats } from '@features/voice/livekit-media';
 
 type VoiceRoomGetState = typeof import('@features/voice/voice-room').getState;
 
@@ -16,6 +18,8 @@ type VoiceRoomGetState = typeof import('@features/voice/voice-room').getState;
 interface WavisVoiceStatsSnapshot {
   participants: Array<{ id: string; rmsLevel: number; isSpeaking: boolean }>;
   selfParticipantId: string | null;
+  networkStats: NetworkStats;
+  videoReceiveStats: VideoReceiveStats | null;
 }
 
 declare global {
@@ -141,6 +145,8 @@ export default function App() {
           isSpeaking: p.isSpeaking,
         })),
         selfParticipantId,
+        networkStats,
+        videoReceiveStats,
       };
 
       void emit('diagnostics:voice-stats', {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,10 +26,13 @@ services:
   livekit:
     container_name: wavis-livekit
     image: livekit/livekit-server:latest
+    cap_add:
+      - NET_ADMIN
     entrypoint: /bin/sh
     command:
       - -c
       - |
+        apk add --no-cache iproute2 >/dev/null
         sed -e "s|LIVEKIT_API_KEY_PLACEHOLDER|$$LIVEKIT_API_KEY|" \
             -e "s|LIVEKIT_API_SECRET_PLACEHOLDER|$$LIVEKIT_API_SECRET|" \
             /etc/livekit.yaml.tpl > /etc/livekit.yaml
@@ -85,6 +88,7 @@ services:
       SFU_TOKEN_TTL_SECS: ${SFU_TOKEN_TTL_SECS:-600}
       TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
       AUTH_REGISTER_RATE_LIMIT: ${AUTH_REGISTER_RATE_LIMIT:-5}
+      AUTH_RECOVER_RATE_LIMIT: ${AUTH_RECOVER_RATE_LIMIT:-30}
       AUTH_REFRESH_PEPPER: ${AUTH_REFRESH_PEPPER:-dev-pepper-32-bytes-minimum!!XXX}
       REFRESH_TOKEN_TTL_DAYS: ${REFRESH_TOKEN_TTL_DAYS:-180}
       PHRASE_ENCRYPTION_KEY: ${PHRASE_ENCRYPTION_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}

--- a/wavis-backend/src/main.rs
+++ b/wavis-backend/src/main.rs
@@ -450,9 +450,16 @@ async fn main() -> io::Result<()> {
     let pairing_code_pepper = Arc::new(pairing_code_pepper.into_bytes());
 
     // --- Recovery rate limiter ---
-    let recovery_rate_limiter = Arc::new(RecoveryRateLimiter::new(
-        RecoveryRateLimiterConfig::default(),
-    ));
+    // Per-IP ceiling is env-overridable for local e2e runs (every Login-UI
+    // authentication is a /auth/recover call), same pattern as
+    // AUTH_REGISTER_RATE_LIMIT above. Default and all other knobs unchanged.
+    let recovery_rate_limiter = Arc::new(RecoveryRateLimiter::new(RecoveryRateLimiterConfig {
+        per_ip_max: env::var("AUTH_RECOVER_RATE_LIMIT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(RecoveryRateLimiterConfig::default().per_ip_max),
+        ..RecoveryRateLimiterConfig::default()
+    }));
 
     // --- Background cleanup retention config ---
     let pairing_retention_hours: u64 = env::var("PAIRING_RETENTION_HOURS")


### PR DESCRIPTION
## What this does

**New coverage — media quality under a bad network** (`zz-network-quality.spec.mjs`): proves media reaches a smooth baseline (real decoded audio + real decoded screen-share video), degrades observably but keeps flowing under netem-simulated loss/jitter/delay shaped on the LiveKit container's egress, and recovers once cleared. Supporting infra: `cap_add: NET_ADMIN` + `iproute2` for the livekit service in docker-compose, a real 640x360@15fps `SOURCE_SCREENSHARE` video publisher in `livekit-tone-peer.mjs`, and `networkStats`/`videoReceiveStats` widened onto `window.__wavisVoiceStats` (`VITE_DIAGNOSTICS`-gated, production-absent).

**Fixes the full-suite failures** (6–7 specs failed in every sequential `npm run test` while passing in isolation — three root causes, none flakiness):

1. **Registration cascade** — `POST /auth/register` requires a closed-alpha invite code but the `DeviceSetup` UI has no invite field, so `registerViaUi` could never succeed. Isolated runs silently rode the persisted auth-store session; in full runs `login.spec` logged that session out and stranded every later spec. All spec setup now uses REST-based `registerAndLoginViaUi`; `login.spec` reworked to cover both real Login-UI paths (new-device Wavis ID, trusted-device password-only) with a REST-created account. **The DeviceSetup invite-code field is deliberately NOT added here** — `registerViaUi` stays in the helpers, marked unusable, for when that field lands.
2. **`getByTitle` blind to lucide SVG icons** — 23719f1 converted "your camera is on" / "you are sharing" from `title` attributes to SVG `<title>` children, which `getByTitle` never matches (its substring matching sometimes false-passed via the adjacent `title="you are sharing audio"` badge, disguising the break as flakiness). New `visibleIcon()` helper matches by `role=img` accessible name.
3. **Recovery rate limiter** — every Login-UI auth is a `/auth/recover` call and the per-IP ceiling was a hard-coded 30/hour, so repeated suite runs exhausted it. `AUTH_RECOVER_RATE_LIMIT` env override added in `wavis-backend/src/main.rs`, mirroring the existing `AUTH_REGISTER_RATE_LIMIT` pattern — **default (30) and all other limiter knobs unchanged; behavior without the env var is byte-for-byte identical**.

## Validation

- Full e2e suite from a forced-logged-out auth store (hardest state — every spec exercises the auth fallback): **16 passed / 0 failed / 1 skipped** (3.0m). The skip is `settings.spec`'s pre-existing by-design state guard.
- `cargo fmt --all --check` clean, `cargo clippy -p wavis-backend -- -D warnings` clean, GUI `typecheck`/`prettier` clean, eslint 0 errors on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MA9XdNXWtFkh9ZBh4GEnjk