### PR TITLE
fix(ci): stop backend integration suites reporting phantom green

### DIFF
--- a/.github/scripts/strict-cargo-test.sh
+++ b/.github/scripts/strict-cargo-test.sh
@@ -6,12 +6,24 @@
 # a silently ghost-green suite. Real test failures still fail immediately via
 # pipefail; this only adds a check for the "0 tests ran" case that would
 # otherwise pass.
+#
+# The "Doc-tests <crate>" section legitimately reports "running 0 tests" when
+# a crate has no doc tests (true here) — that block is excluded, everything
+# else reporting 0 tests is treated as phantom coverage.
 set -euo pipefail
 
 log="$(mktemp)"
 "$@" 2>&1 | tee "$log"
 
-if grep -q "running 0 tests" "$log"; then
+clean_log="$(mktemp)"
+sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g' "$log" > "$clean_log"
+
+if awk '
+  /Doc-tests/ { in_doctest = 1; next }
+  /Running / { in_doctest = 0 }
+  /running 0 tests/ && !in_doctest { found = 1 }
+  END { exit(found ? 0 : 1) }
+' "$clean_log"; then
   echo "::error::A named test binary reported 'running 0 tests' — check for a missing --features flag or a #![cfg(...)] gate silently skipping the whole suite (ghost-green coverage)."
   exit 1
 fi

--- a/.github/scripts/strict-cargo-test.sh
+++ b/.github/scripts/strict-cargo-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Runs a cargo test invocation and fails the job if any named --test binary
+# reported "running 0 tests". Integration test files in wavis-backend are
+# gated with #![cfg(feature = "test-support")] (and similar), so a missing
+# feature flag lets the file compile to an empty binary that still exits 0 —
+# a silently ghost-green suite. Real test failures still fail immediately via
+# pipefail; this only adds a check for the "0 tests ran" case that would
+# otherwise pass.
+set -euo pipefail
+
+log="$(mktemp)"
+"$@" 2>&1 | tee "$log"
+
+if grep -q "running 0 tests" "$log"; then
+  echo "::error::A named test binary reported 'running 0 tests' — check for a missing --features flag or a #![cfg(...)] gate silently skipping the whole suite (ghost-green coverage)."
+  exit 1
+fi

--- a/.github/workflows/workspace-ci.yml
+++ b/.github/workflows/workspace-ci.yml
@@ -260,41 +260,52 @@ jobs:
         if: github.ref == 'refs/heads/main' || needs.changes.outputs.core == 'true' || needs.changes.outputs.shared == 'true'
         run: cargo test $CI_PACKAGES
 
+      # test-support gates mock_sfu_bridge and most integration test files
+      # (#![cfg(feature = "test-support")]) — it can't go in $CI_PACKAGES
+      # above because the feature only exists on wavis-backend. Without this
+      # step those files never compile in the "core changed" path either and
+      # silently report 0 tests. test_metrics_integration.rs additionally
+      # gates its inner mod on test-metrics — both features are required or
+      # that file's tests silently report 0 too.
+      - name: Full workspace tests (wavis-backend, test-support feature)
+        if: github.ref == 'refs/heads/main' || needs.changes.outputs.core == 'true' || needs.changes.outputs.shared == 'true'
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support,test-metrics
+
       # Backend changed in a path no granular bucket covers (chat, diagnostics,
       # connections, …) — run the whole backend suite rather than nothing.
       - name: "Targeted Backend: Fallback (uncategorized paths)"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.backend-other == 'true'
-        run: cargo test -p wavis-backend
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support,test-metrics
 
       # Targeted runs only exercise --test binaries; unit tests in src/ must
       # still run whenever any backend code changed.
       - name: "Targeted Backend: Unit tests"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.backend == 'true' && needs.changes.outputs.backend-other != 'true'
-        run: cargo test -p wavis-backend --lib --bins
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --lib --bins
 
       - name: "Targeted Backend: Auth"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.auth == 'true'
-        run: cargo test -p wavis-backend --test auth_integration --test ws_auth_integration --test jwt_validation --test device_integration --test pairing_integration --test recovery_integration
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support --test auth_integration --test ws_auth_integration --test jwt_validation --test device_integration --test pairing_integration --test recovery_integration
 
       - name: "Targeted Backend: Voice"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.voice == 'true'
-        run: cargo test -p wavis-backend --test voice_orchestration_integration --test voice_ws_integration --test sfu_relay_integration --test p2p_relay_integration --test turn_credentials_integration --test livekit_e2e_integration
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support --test voice_orchestration_integration --test voice_ws_integration --test sfu_relay_integration --test p2p_relay_integration --test turn_credentials_integration --test livekit_e2e_integration
 
       - name: "Targeted Backend: Channel"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.channel == 'true'
-        run: cargo test -p wavis-backend --test channel_integration --test channel_rest_integration --test invite_lifecycle_integration --test create_room_integration --test display_name_integration
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support --test channel_integration --test channel_rest_integration --test invite_lifecycle_integration --test create_room_integration --test display_name_integration
 
       - name: "Targeted Backend: WS & Signaling"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.ws == 'true'
-        run: cargo test -p wavis-backend --test signaling_relay_integration --test ws_auth_integration
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support --test signaling_relay_integration --test ws_auth_integration --test concurrency
 
       - name: "Targeted Backend: Security & Abuse"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && (needs.changes.outputs.security == 'true' || needs.changes.outputs.abuse == 'true')
-        run: cargo test -p wavis-backend --test security_hardening_integration --test no_sensitive_logs --test authorization_matrix_integration --test abuse_controls_integration
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support --test security_hardening_integration --test no_sensitive_logs --test authorization_matrix_integration --test abuse_controls_integration
 
       - name: "Targeted Backend: Screen Share"
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.screen == 'true'
-        run: cargo test -p wavis-backend --test screen_share_integration --test screen_share_ws_integration
+        run: bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --features test-support --test screen_share_integration --test screen_share_ws_integration
 
       - name: Client tests
         if: needs.changes.outputs.core != 'true' && needs.changes.outputs.shared != 'true' && needs.changes.outputs.clients == 'true'
@@ -510,3 +521,10 @@ jobs:
 
       - name: Cargo check Tauri crate
         run: cargo check -p wavis-gui --message-format=short
+
+      # wavis-gui has no [lib] target (main.rs only), so `--lib` errors with
+      # "no library targets found" — plain `cargo test -p wavis-gui` runs the
+      # crate's #[cfg(test)] unit tests (~95 of them), which previously never
+      # ran anywhere in CI (this job only compiled, never tested).
+      - name: Cargo test Tauri crate
+        run: cargo test -p wavis-gui --message-format=short


### PR DESCRIPTION
## Summary

Wave 0 of the combined test-coverage backlog (own audit 2026-07-15 + external audit). Makes already-written backend and src-tauri tests actually execute in CI instead of silently reporting 0 tests.

- Most `wavis-backend/tests/*.rs` integration files are gated with `#![cfg(feature = "test-support")]`; no CI step ever passed that feature, so those files compiled to empty test binaries and reported `running 0 tests` with exit 0 — every targeted backend CI path (Auth, Voice, Channel, WS & Signaling, Security & Abuse, Screen Share, Fallback, and the core/shared "Full workspace tests" path) was silently skipping these suites. Fixed by adding `--features test-support` (and `test-metrics`, for `test_metrics_integration.rs` which gates on both) everywhere it was missing.
- Added `.github/scripts/strict-cargo-test.sh`: wraps a `cargo test` invocation and fails the job if any named binary reports `running 0 tests`, so this class of regression can't silently recur.
- `wavis-backend/tests/concurrency.rs` was never referenced by any CI step — wired into "Targeted Backend: WS & Signaling".
- `tauri-check` (Windows) only ran `cargo check`, never `cargo test` — added a test step. `wavis-gui` has no `[lib]` target, so `--lib` errors with "no library targets found"; plain `cargo test -p wavis-gui` runs the crate's `#[cfg(test)]` unit tests directly.

No production code changed — CI workflow + one new shell script only.

## Extra finding beyond the original audit scope

While validating, found `test_metrics_integration.rs` needs **both** `test-support` and `test-metrics` features (not just `test-support`) — `test-metrics` was passed nowhere in CI. Fixed in the same 2 spots as the `test-support` fix, confirmed by the user to fold into this wave.

## Validation

All done locally on Windows (mirrors the `windows-latest`/`ubuntu-latest` runner behavior for these specific commands):

- `bash .github/scripts/strict-cargo-test.sh cargo test -p wavis-backend --test screen_share_integration --test screen_share_ws_integration` (no feature) → exits 1, guard fires correctly on the phantom-zero case.
- Same command + `--features test-support` → exits 0, 13 real tests pass.
- `--test signaling_relay_integration --test ws_auth_integration --test concurrency --features test-support` → 20 tests pass total, including `concurrency.rs`'s 5 (previously never run anywhere).
- `--test test_metrics_integration --features test-support,test-metrics` → 7 tests pass (previously never run anywhere).
- Full `cargo test -p wavis-backend --features test-support,test-metrics` (no DB) → 36 test-result blocks, 0 failures, 0 unexpected "running 0 tests".
- `cargo test -p wavis-gui` (workspace root, dist placeholder present) → 95 tests pass.
- `cargo fmt --all --check` and `node scripts/arch-check.mjs` → both pass.
- YAML syntax validated with `yaml.safe_load`.

## Test plan

- [ ] CI on this PR: confirm each targeted backend suite (especially Security & Abuse) now reports real test counts, not `running 0 tests`, in the Actions log.
- [ ] Confirm the Windows `tauri-check` job runs and passes the new `cargo test -p wavis-gui` step.
- [ ] Confirm the meta-guard script doesn't false-positive on any legitimately-empty binary (doc-tests already excluded — only file-level test binaries are checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SweFhNT6BYwFzG4sXw4yAX