### PR TITLE
test(auth): wave 1 security/authorization backlog (P0-2, P1-1..P1-6, P2-11)

### DIFF
--- a/wavis-backend/src/auth/pairing.rs
+++ b/wavis-backend/src/auth/pairing.rs
@@ -485,9 +485,6 @@ mod tests {
 
     type HmacSha256Test = Hmac<Sha256>;
 
-    /// Maximum failed attempts before lockout (matches production logic).
-    const MAX_ATTEMPTS: i32 = 5;
-
     // Feature: user-identity-recovery, Property 7: HMAC pairing code round-trip
     // **Validates: Requirements 8.2, 9.2**
     proptest! {
@@ -569,67 +566,6 @@ mod tests {
                     CODE_CHARSET.contains(&(ch as u8)),
                     "character '{}' is not in the base32 charset (A-Z, 2-7)",
                     ch
-                );
-            }
-        }
-    }
-
-    // Feature: user-identity-recovery, Property 9: Pairing lockout after max failures
-    // **Validates: Requirements 8.8, 9.8**
-    //
-    // Pure logic test: simulates the attempt_count tracking and verifies that
-    // after 5 total failures the system rejects further attempts.
-    proptest! {
-        #![proptest_config(ProptestConfig::with_cases(100))]
-
-        #[test]
-        fn prop_pairing_lockout_after_max_failures(
-            attempt_count in 0i32..=10,
-        ) {
-            // The production code uses `attempt_count >= 5` as the lockout check.
-            let is_locked = attempt_count >= MAX_ATTEMPTS;
-
-            if attempt_count < MAX_ATTEMPTS {
-                prop_assert!(
-                    !is_locked,
-                    "attempt_count {} is below threshold {}, should NOT be locked out",
-                    attempt_count,
-                    MAX_ATTEMPTS
-                );
-            } else {
-                prop_assert!(
-                    is_locked,
-                    "attempt_count {} is at or above threshold {}, MUST be locked out",
-                    attempt_count,
-                    MAX_ATTEMPTS
-                );
-            }
-        }
-
-        #[test]
-        fn prop_pairing_lockout_boundary(
-            extra_failures in 0i32..=5,
-        ) {
-            // Simulate accumulating failures from 0 up to MAX_ATTEMPTS + extra
-            let total_failures = MAX_ATTEMPTS + extra_failures;
-
-            // Before reaching MAX_ATTEMPTS, each attempt should be allowed
-            for count in 0..MAX_ATTEMPTS {
-                prop_assert!(
-                    count < MAX_ATTEMPTS,
-                    "attempt {} should be allowed (below threshold {})",
-                    count,
-                    MAX_ATTEMPTS
-                );
-            }
-
-            // At and beyond MAX_ATTEMPTS, every attempt must be rejected
-            for count in MAX_ATTEMPTS..=total_failures {
-                prop_assert!(
-                    count >= MAX_ATTEMPTS,
-                    "attempt {} must be locked out (at or above threshold {})",
-                    count,
-                    MAX_ATTEMPTS
                 );
             }
         }

--- a/wavis-backend/src/auth/phrase.rs
+++ b/wavis-backend/src/auth/phrase.rs
@@ -477,4 +477,92 @@ mod tests {
             prop_assert!(result.is_err(), "decrypting with a different key must fail");
         }
     }
+
+    // P1-4: verify_dummy is the functional half of the anti-timing-oracle for
+    // unknown Recovery IDs — it must NEVER return true, for any input.
+    // A stray `true` here would mean recovery-by-nonexistent-ID succeeds.
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        #[test]
+        fn prop_verify_dummy_always_false(phrase in ".{0,128}") {
+            let config = test_config();
+            let dummy = generate_dummy_verifier(&config);
+
+            let result = verify_dummy(&phrase, &dummy, &config).unwrap();
+            prop_assert!(!result, "verify_dummy must never return true, got true for phrase {:?}", phrase);
+        }
+    }
+
+    // P1-4: AES-GCM error paths — short ciphertext, tampered bytes, wrong key length.
+
+    #[test]
+    fn decrypt_rejects_short_ciphertext() {
+        // 27 bytes: one short of the 28-byte minimum (12-byte nonce + 16-byte tag).
+        let short = [0u8; 27];
+        let result = decrypt_blob(&short, &[0u8; 32]);
+        assert!(
+            matches!(result, Err(PhraseError::DecryptionFailed(_))),
+            "ciphertext shorter than nonce+tag must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn decrypt_accepts_minimum_length_empty_plaintext() {
+        // Exactly 28 bytes (12-byte nonce + 16-byte tag, empty plaintext) is a
+        // valid encrypted-empty-blob shape produced by encrypt_blob("").
+        let encrypted = encrypt_blob(&[], &[7u8; 32]).unwrap();
+        assert_eq!(encrypted.len(), 28);
+        let decrypted = decrypt_blob(&encrypted, &[7u8; 32]).unwrap();
+        assert!(decrypted.is_empty());
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(50))]
+
+        #[test]
+        fn prop_single_byte_tamper_fails_decryption(
+            plaintext in prop::collection::vec(any::<u8>(), 1..64),
+            key in prop::collection::vec(any::<u8>(), 32),
+            tamper_idx_seed in any::<u64>(),
+            tamper_bit_seed in any::<u8>(),
+        ) {
+            let encrypted = encrypt_blob(&plaintext, &key).unwrap();
+
+            let mut tampered = encrypted.clone();
+            let idx = (tamper_idx_seed as usize) % tampered.len();
+            // Flip at least one bit — never a no-op XOR.
+            let bit = 1u8 << (tamper_bit_seed % 8);
+            tampered[idx] ^= bit;
+
+            let result = decrypt_blob(&tampered, &key);
+            prop_assert!(result.is_err(), "a single flipped bit anywhere in the blob must fail decryption");
+        }
+    }
+
+    #[test]
+    fn encrypt_rejects_wrong_key_length() {
+        for len in [31usize, 33] {
+            let key = vec![0u8; len];
+            let result = encrypt_blob(b"plaintext", &key);
+            assert!(
+                matches!(result, Err(PhraseError::EncryptionFailed(_))),
+                "encrypt_blob must reject a {len}-byte key, got {result:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn decrypt_rejects_wrong_key_length() {
+        let valid_key = [9u8; 32];
+        let encrypted = encrypt_blob(b"plaintext", &valid_key).unwrap();
+        for len in [31usize, 33] {
+            let bad_key = vec![0u8; len];
+            let result = decrypt_blob(&encrypted, &bad_key);
+            assert!(
+                matches!(result, Err(PhraseError::DecryptionFailed(_))),
+                "decrypt_blob must reject a {len}-byte key, got {result:?}"
+            );
+        }
+    }
 }

--- a/wavis-backend/src/auth/routes.rs
+++ b/wavis-backend/src/auth/routes.rs
@@ -378,7 +378,7 @@ pub async fn recover(
     if retry_after_secs.is_some() {
         warn!(
             ip = %client_ip,
-            recovery_id = %body.recovery_id,
+            recovery_id = %redact_token(&body.recovery_id),
             retry_after = retry_after_secs,
             "recover rate-limited (recovery_id)"
         );
@@ -407,7 +407,7 @@ pub async fn recover(
                 .recovery_rate_limiter
                 .record_recovery_id(&body.recovery_id, now);
             warn!(
-                recovery_id = %body.recovery_id,
+                recovery_id = %redact_token(&body.recovery_id),
                 new_device_id = %reg.device_id,
                 "account recovered"
             );
@@ -434,7 +434,7 @@ pub async fn recover(
             };
             warn!(
                 ip = %client_ip,
-                recovery_id = %body.recovery_id,
+                recovery_id = %redact_token(&body.recovery_id),
                 reason = reason,
                 "recovery failed"
             );
@@ -949,6 +949,89 @@ mod tests {
             app_state
                 .auth_rate_limiter
                 .check_register(ip, std::time::Instant::now())
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // P1-5: map_pairing_error / map_device_error HTTP contract — every
+    // variant must map to the exact status + opaque body security.md
+    // documents, and DatabaseError must never leak its inner SQL detail.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn map_pairing_error_matches_security_contract() {
+        let cases: Vec<(PairingError, StatusCode, &str)> = vec![
+            (PairingError::NotFound, StatusCode::NOT_FOUND, "not found"),
+            (
+                PairingError::Expired,
+                StatusCode::UNAUTHORIZED,
+                "authentication failed",
+            ),
+            (
+                PairingError::CodeMismatch,
+                StatusCode::UNAUTHORIZED,
+                "authentication failed",
+            ),
+            (PairingError::AlreadyUsed, StatusCode::CONFLICT, "conflict"),
+            (
+                PairingError::AlreadyApproved,
+                StatusCode::CONFLICT,
+                "conflict",
+            ),
+            (
+                PairingError::NotApproved,
+                StatusCode::FORBIDDEN,
+                "forbidden",
+            ),
+            (
+                PairingError::LockedOut,
+                StatusCode::TOO_MANY_REQUESTS,
+                "too many requests",
+            ),
+        ];
+        for (err, expected_status, expected_body) in cases {
+            let (status, _headers, Json(body)) = map_pairing_error(&err);
+            assert_eq!(status, expected_status, "status mismatch for {err:?}");
+            assert_eq!(body.error, expected_body, "body mismatch for {err:?}");
+        }
+    }
+
+    #[test]
+    fn map_pairing_error_database_error_never_leaks_sql_detail() {
+        let secret_detail = "duplicate key value violates unique constraint \"users_pkey\"";
+        let (status, _headers, Json(body)) =
+            map_pairing_error(&PairingError::DatabaseError(secret_detail.to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body.error, "internal error");
+        assert!(
+            !body.error.contains(secret_detail),
+            "SQL error detail must never reach the client"
+        );
+    }
+
+    #[test]
+    fn map_device_error_matches_security_contract() {
+        let cases: Vec<(DeviceError, StatusCode, &str)> = vec![
+            (DeviceError::NotFound, StatusCode::NOT_FOUND, "not found"),
+            (DeviceError::NotOwned, StatusCode::FORBIDDEN, "forbidden"),
+        ];
+        for (err, expected_status, expected_body) in cases {
+            let (status, _headers, Json(body)) = map_device_error(&err);
+            assert_eq!(status, expected_status, "status mismatch for {err:?}");
+            assert_eq!(body.error, expected_body, "body mismatch for {err:?}");
+        }
+    }
+
+    #[test]
+    fn map_device_error_database_error_never_leaks_sql_detail() {
+        let secret_detail = "connection refused at 10.0.0.5:5432";
+        let (status, _headers, Json(body)) =
+            map_device_error(&DeviceError::DatabaseError(secret_detail.to_string()));
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body.error, "internal error");
+        assert!(
+            !body.error.contains(secret_detail),
+            "SQL error detail must never reach the client"
         );
     }
 }

--- a/wavis-backend/tests/auth_integration.rs
+++ b/wavis-backend/tests/auth_integration.rs
@@ -1451,3 +1451,156 @@ async fn alpha_invite_registration_exhausts_limited_invite() {
 
     assert!(matches!(result, Err(AuthError::InviteInvalid)));
 }
+
+// ---------------------------------------------------------------------------
+// P1-1: Concurrent redemption of the last alpha-invite slot — the invite's
+// `SELECT ... FOR UPDATE` row lock must serialize concurrent registrations
+// so exactly one wins, never zero and never more than one.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn concurrent_redemption_of_last_slot_admits_exactly_one() {
+    let pool = test_pool().await;
+    truncate_auth_tables(&pool).await;
+
+    seed_alpha_invite(&pool, "race-single-slot", 1, None, false).await;
+    let secret = test_auth_secret();
+    let pepper = test_pepper();
+    let phrase_config = test_phrase_config();
+
+    let mut handles = Vec::new();
+    for i in 0..8 {
+        let pool = pool.clone();
+        let secret = secret.clone();
+        let pepper = pepper.clone();
+        let phrase_config = phrase_config.clone();
+        handles.push(tokio::spawn(async move {
+            auth::register_user_with_invite(
+                &pool,
+                &format!("race-phrase-{i}"),
+                &format!("race-user-{i}"),
+                "race-single-slot",
+                &secret,
+                900,
+                30,
+                &pepper,
+                &test_alpha_invite_pepper(),
+                &phrase_config,
+                TEST_ENCRYPTION_KEY,
+            )
+            .await
+        }));
+    }
+
+    let mut results = Vec::new();
+    for handle in handles {
+        results.push(handle.await.expect("registration task panicked"));
+    }
+
+    let ok_count = results.iter().filter(|r| r.is_ok()).count();
+    let invalid_count = results
+        .iter()
+        .filter(|r| matches!(r, Err(AuthError::InviteInvalid)))
+        .count();
+    assert_eq!(
+        ok_count, 1,
+        "exactly one concurrent redemption of the last slot must win: {results:?}"
+    );
+    assert_eq!(
+        invalid_count, 7,
+        "the other 7 concurrent attempts must see InviteInvalid: {results:?}"
+    );
+
+    let redemption_count: i32 =
+        sqlx::query_scalar("SELECT redemption_count FROM alpha_invites WHERE code_hash = $1")
+            .bind(hash_invite_code("race-single-slot", &test_alpha_invite_pepper()).unwrap())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        redemption_count, 1,
+        "redemption_count must stop at 1, not overshoot"
+    );
+
+    let redemption_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM alpha_invite_redemptions")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        redemption_rows, 1,
+        "exactly one redemption row, not one per loser"
+    );
+
+    // Negative: losers must not leave orphaned users/devices behind — the
+    // containing transaction (register_user_with_invite) rolls back whole.
+    let user_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM users")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        user_count, 1,
+        "losing registrations must not leave orphaned user rows"
+    );
+    let device_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM devices")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        device_count, 1,
+        "losing registrations must not leave orphaned device rows"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P1-1: Expiry boundary — an invite must be rejected at and after its exact
+// expiry instant (`now >= expires_at`), not just "well past" it.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn redeem_rejects_at_exact_expiry_instant() {
+    let pool = test_pool().await;
+    truncate_auth_tables(&pool).await;
+
+    // expires_at set to a fixed instant already in the past by the time the
+    // query runs — exercises the `now >= expires_at` boundary from the
+    // production check.
+    let already_expired = chrono::Utc::now() - chrono::Duration::milliseconds(1);
+    seed_alpha_invite(&pool, "expiry-boundary", 5, Some(already_expired), false).await;
+
+    let result = auth::register_user_with_invite(
+        &pool,
+        "expiry-boundary-phrase",
+        "expiry-boundary-user",
+        "expiry-boundary",
+        &test_auth_secret(),
+        900,
+        30,
+        &test_pepper(),
+        &test_alpha_invite_pepper(),
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await;
+
+    assert!(
+        matches!(result, Err(AuthError::InviteInvalid)),
+        "an invite at/after its exact expiry instant must be rejected, got {result:?}"
+    );
+
+    // Negative: a rejected redemption at the expiry boundary must not
+    // increment redemption_count (the check runs before the UPDATE).
+    let redemption_count: i32 =
+        sqlx::query_scalar("SELECT redemption_count FROM alpha_invites WHERE code_hash = $1")
+            .bind(hash_invite_code("expiry-boundary", &test_alpha_invite_pepper()).unwrap())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        redemption_count, 0,
+        "a rejected expired redemption must not consume a slot"
+    );
+}

--- a/wavis-backend/tests/device_integration.rs
+++ b/wavis-backend/tests/device_integration.rs
@@ -9,7 +9,9 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use wavis_backend::auth::auth::{generate_refresh_token, hash_refresh_token, register_user};
-use wavis_backend::auth::device::{create_device, list_devices, logout_all, revoke_device};
+use wavis_backend::auth::device::{
+    DeviceError, create_device, is_device_active, list_devices, logout_all, revoke_device,
+};
 use wavis_backend::auth::phrase::PhraseConfig;
 
 const TEST_SECRET: &[u8] = b"test-secret-at-least-32-bytes!!!";
@@ -338,4 +340,144 @@ async fn prop16_device_listing_completeness() {
             "created_at should be roughly now, not far in the future"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// P1-2: revoke_device authorization — a user revoking a device that belongs
+// to someone else must be rejected with no side effects, not silently
+// succeed or leak whether the device exists.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn revoke_foreign_device_returns_not_owned_without_side_effects() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let user_a = register_user(
+        &pool,
+        "user-a-phrase",
+        "device-a",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+    let user_b = register_user(
+        &pool,
+        "user-b-phrase",
+        "device-b",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    // A tries to revoke B's device.
+    let result = revoke_device(&pool, user_a.user_id, user_b.device_id).await;
+    assert!(
+        matches!(result, Err(DeviceError::NotOwned)),
+        "revoking another user's device must return NotOwned, got {result:?}"
+    );
+
+    // Negative: B's device must be untouched.
+    let revoked_at: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT revoked_at FROM devices WHERE device_id = $1")
+            .bind(user_b.device_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        revoked_at.is_none(),
+        "a rejected NotOwned revocation must not revoke the target device"
+    );
+
+    // Negative: B's refresh token must still be active.
+    let token_revoked: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT revoked_at FROM refresh_tokens WHERE device_id = $1")
+            .bind(user_b.device_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        token_revoked.is_none(),
+        "a rejected NotOwned revocation must not revoke the target device's tokens"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn revoke_missing_device_returns_not_found() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let user = register_user(
+        &pool,
+        "missing-device-phrase",
+        "device-x",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let result = revoke_device(&pool, user.user_id, Uuid::new_v4()).await;
+    assert!(
+        matches!(result, Err(DeviceError::NotFound)),
+        "revoking a nonexistent device_id must return NotFound, got {result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn is_device_active_false_for_revoked_and_missing() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let user = register_user(
+        &pool,
+        "active-check-phrase",
+        "device-active",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        is_device_active(&pool, user.device_id).await.unwrap(),
+        "a freshly registered device must be active"
+    );
+
+    revoke_device(&pool, user.user_id, user.device_id)
+        .await
+        .unwrap();
+    assert!(
+        !is_device_active(&pool, user.device_id).await.unwrap(),
+        "a revoked device must report inactive"
+    );
+
+    assert!(
+        !is_device_active(&pool, Uuid::new_v4()).await.unwrap(),
+        "a nonexistent device must report inactive, indistinguishable from revoked"
+    );
 }

--- a/wavis-backend/tests/no_sensitive_logs.rs
+++ b/wavis-backend/tests/no_sensitive_logs.rs
@@ -45,7 +45,10 @@ fn is_log_line(line: &str) -> bool {
 /// Each entry is (disallowed_pattern, &[safe_prefixes_that_override_it]).
 const SENSITIVE_PATTERNS: &[(&str, &[&str])] = &[
     // Token fields
-    ("token =", &["token_issued_at =", "token_ttl ="]),
+    (
+        "token =",
+        &["token_issued_at =", "token_ttl =", "token = %redact_token("],
+    ),
     ("jwt =", &[]),
     ("media_token =", &[]),
     // Invite code fields
@@ -56,26 +59,102 @@ const SENSITIVE_PATTERNS: &[(&str, &[&str])] = &[
     ("session_description =", &[]),
     // ICE candidate fields
     ("candidate =", &["candidate_count =", "candidate_type ="]),
+    // Recovery ID — a quasi-secret account-recovery credential (format
+    // wvs-XXXX-XXXX). Must be redacted, never logged raw.
+    ("recovery_id =", &["recovery_id = %redact_token("]),
 ];
 
-/// Check a single line for disallowed sensitive patterns.
-/// Returns a list of (pattern, line_content) violations found.
-fn check_line(line: &str) -> Vec<String> {
-    if !is_log_line(line) {
-        return vec![];
+/// Rust-source-aware paren depth tracking: parens inside string literals
+/// (e.g. a log message like `"recover rate-limited (recovery_id)"`) must not
+/// count towards the invocation's depth.
+struct ParenTracker {
+    depth: i32,
+    in_string: bool,
+    escaped: bool,
+}
+
+impl ParenTracker {
+    fn new() -> Self {
+        Self {
+            depth: 0,
+            in_string: false,
+            escaped: false,
+        }
     }
 
+    /// Feed one line's characters, updating paren depth. Returns true once
+    /// depth has gone positive and returned back to zero (invocation closed).
+    fn consume(&mut self, line: &str) -> bool {
+        let mut started = self.depth > 0;
+        for ch in line.chars() {
+            if self.in_string {
+                if self.escaped {
+                    self.escaped = false;
+                } else if ch == '\\' {
+                    self.escaped = true;
+                } else if ch == '"' {
+                    self.in_string = false;
+                }
+                continue;
+            }
+            match ch {
+                '"' => self.in_string = true,
+                '(' => {
+                    self.depth += 1;
+                    started = true;
+                }
+                ')' => self.depth -= 1,
+                _ => {}
+            }
+        }
+        started && self.depth <= 0
+    }
+}
+
+/// Group a file's lines into log-macro invocation blocks. A block starts at
+/// a line matching `is_log_line` and accumulates subsequent lines until the
+/// invocation's parentheses close — this is what lets the scanner catch
+/// sensitive fields on their own line inside a multi-line, rustfmt-wrapped
+/// `warn!(...)` / `info!(...)` call, not just single-line invocations.
+fn collect_log_macro_blocks(content: &str) -> Vec<(usize, String)> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut blocks = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if is_log_line(lines[i]) {
+            let start_line = i;
+            let mut block = String::new();
+            let mut tracker = ParenTracker::new();
+            loop {
+                let line = lines[i];
+                block.push_str(line);
+                block.push('\n');
+                let closed = tracker.consume(line);
+                i += 1;
+                if closed || i >= lines.len() {
+                    break;
+                }
+            }
+            blocks.push((start_line, block));
+        } else {
+            i += 1;
+        }
+    }
+    blocks
+}
+
+/// Check a log macro invocation block for disallowed sensitive patterns.
+fn check_block(block: &str) -> Vec<String> {
     let mut violations = Vec::new();
 
     for (pattern, safe_overrides) in SENSITIVE_PATTERNS {
-        if line.contains(pattern) {
-            // Check if any safe override prefix is present — if so, it's allowed
-            let is_safe = safe_overrides.iter().any(|safe| line.contains(safe));
+        if block.contains(pattern) {
+            let is_safe = safe_overrides.iter().any(|safe| block.contains(safe));
             if !is_safe {
                 violations.push(format!(
-                    "  disallowed pattern {:?} found in log macro: {}",
+                    "  disallowed pattern {:?} found in log macro:\n{}",
                     pattern,
-                    line.trim()
+                    block.trim()
                 ));
             }
         }
@@ -124,8 +203,8 @@ fn no_sensitive_fields_in_log_macros() {
         let content = fs::read_to_string(file_path)
             .unwrap_or_else(|e| panic!("failed to read {}: {e}", file_path.display()));
 
-        for (line_no, line) in content.lines().enumerate() {
-            let violations = check_line(line);
+        for (start_line, block) in collect_log_macro_blocks(&content) {
+            let violations = check_block(&block);
             for v in violations {
                 all_violations.push(format!(
                     "{}:{}: {}",
@@ -133,7 +212,7 @@ fn no_sensitive_fields_in_log_macros() {
                         .strip_prefix(&src_dir)
                         .unwrap_or(file_path)
                         .display(),
-                    line_no + 1,
+                    start_line + 1,
                     v
                 ));
             }

--- a/wavis-backend/tests/pairing_integration.rs
+++ b/wavis-backend/tests/pairing_integration.rs
@@ -224,3 +224,593 @@ async fn prop11_pairing_rate_limiter_ceiling() {
         "approve should be allowed after window expires"
     );
 }
+
+// ---------------------------------------------------------------------------
+// P0-2: Pairing lockout — real production behavior, not a reimplemented
+// threshold check. 5 total failed attempts must permanently lock the pairing
+// (until TTL expiry), even for the correct code.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn lockout_after_five_mismatches_persists_for_correct_code() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let approver = register_user(
+        &pool,
+        "lockout-approver-phrase",
+        "trusted-device",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let (pairing_id, code) = start_pairing(&pool, "attacker-device", TEST_PEPPER)
+        .await
+        .unwrap();
+
+    // Attempts 1-4 with the wrong code: CodeMismatch.
+    for attempt in 1..=4 {
+        let result = approve_pairing(
+            &pool,
+            pairing_id,
+            "WRONGCODE",
+            approver.user_id,
+            approver.device_id,
+            TEST_PEPPER,
+        )
+        .await;
+        assert!(
+            matches!(
+                result,
+                Err(wavis_backend::auth::pairing::PairingError::CodeMismatch)
+            ),
+            "attempt {attempt} should be CodeMismatch, got {result:?}"
+        );
+    }
+
+    // Attempt 5 with the wrong code crosses the threshold: LockedOut, not CodeMismatch.
+    let fifth = approve_pairing(
+        &pool,
+        pairing_id,
+        "WRONGCODE",
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            fifth,
+            Err(wavis_backend::auth::pairing::PairingError::LockedOut)
+        ),
+        "5th attempt should be LockedOut, got {fifth:?}"
+    );
+
+    // Attempt 6 with the CORRECT code: still LockedOut — lockout is not
+    // bypassable by finally guessing right.
+    let sixth = approve_pairing(
+        &pool,
+        pairing_id,
+        &code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            sixth,
+            Err(wavis_backend::auth::pairing::PairingError::LockedOut)
+        ),
+        "6th attempt with correct code should still be LockedOut, got {sixth:?}"
+    );
+
+    let attempt_count: i32 =
+        sqlx::query_scalar("SELECT attempt_count FROM pairings WHERE pairing_id = $1")
+            .bind(pairing_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        attempt_count, 5,
+        "attempt_count must stop at 5, not overshoot"
+    );
+
+    let approved_at: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT approved_at FROM pairings WHERE pairing_id = $1")
+            .bind(pairing_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        approved_at.is_none(),
+        "a locked-out pairing must never end up approved, even with the correct code"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P0-2: finish_pairing error paths — Expired, NotApproved, AlreadyUsed.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn finish_rejects_expired_used_unapproved() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let approver = register_user(
+        &pool,
+        "finish-approver-phrase",
+        "trusted-device",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    // --- NotApproved: never approved, finish fails before any code check ---
+    let (not_approved_id, not_approved_code) =
+        start_pairing(&pool, "device-a", TEST_PEPPER).await.unwrap();
+    let result = finish_pairing(
+        &pool,
+        not_approved_id,
+        &not_approved_code,
+        TEST_PEPPER,
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            result,
+            Err(wavis_backend::auth::pairing::PairingError::NotApproved)
+        ),
+        "unapproved pairing must reject finish with NotApproved, got {result:?}"
+    );
+
+    // --- Expired: approved but TTL elapsed ---
+    let (expired_id, expired_code) = start_pairing(&pool, "device-b", TEST_PEPPER).await.unwrap();
+    approve_pairing(
+        &pool,
+        expired_id,
+        &expired_code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE pairings SET expires_at = now() - interval '1 minute' WHERE pairing_id = $1",
+    )
+    .bind(expired_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+    let result = finish_pairing(
+        &pool,
+        expired_id,
+        &expired_code,
+        TEST_PEPPER,
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            result,
+            Err(wavis_backend::auth::pairing::PairingError::Expired)
+        ),
+        "expired pairing must reject finish with Expired, got {result:?}"
+    );
+
+    // --- AlreadyUsed: finish twice ---
+    let (used_id, used_code) = start_pairing(&pool, "device-c", TEST_PEPPER).await.unwrap();
+    approve_pairing(
+        &pool,
+        used_id,
+        &used_code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await
+    .unwrap();
+    finish_pairing(
+        &pool,
+        used_id,
+        &used_code,
+        TEST_PEPPER,
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+    )
+    .await
+    .unwrap();
+    let result = finish_pairing(
+        &pool,
+        used_id,
+        &used_code,
+        TEST_PEPPER,
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            result,
+            Err(wavis_backend::auth::pairing::PairingError::AlreadyUsed)
+        ),
+        "already-used pairing must reject a second finish with AlreadyUsed, got {result:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn approve_rejects_already_approved() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let approver = register_user(
+        &pool,
+        "double-approve-phrase",
+        "trusted-device",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let (pairing_id, code) = start_pairing(&pool, "device-x", TEST_PEPPER).await.unwrap();
+    approve_pairing(
+        &pool,
+        pairing_id,
+        &code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await
+    .unwrap();
+
+    let second = approve_pairing(
+        &pool,
+        pairing_id,
+        &code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            second,
+            Err(wavis_backend::auth::pairing::PairingError::AlreadyApproved)
+        ),
+        "a second approve on an already-approved pairing must fail with AlreadyApproved, got {second:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P0-2: finish_pairing is transactional — a downstream failure after used_at
+// is set must roll back, not leave the pairing half-consumed.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn finish_pairing_rolls_back_used_at_on_downstream_failure() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let approver = register_user(
+        &pool,
+        "rollback-approver-phrase",
+        "trusted-device",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let (pairing_id, code) = start_pairing(&pool, "device-y", TEST_PEPPER).await.unwrap();
+    approve_pairing(
+        &pool,
+        pairing_id,
+        &code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await
+    .unwrap();
+
+    // Delete the approving user out from under the pairing. approved_user_id
+    // has no FK (so the pairing row survives), but the devices.user_id FK
+    // will reject the INSERT in step 3b, forcing a downstream failure inside
+    // the finish_pairing transaction.
+    sqlx::query("DELETE FROM users WHERE user_id = $1")
+        .bind(approver.user_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let result = finish_pairing(
+        &pool,
+        pairing_id,
+        &code,
+        TEST_PEPPER,
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+    )
+    .await;
+    assert!(
+        matches!(
+            result,
+            Err(wavis_backend::auth::pairing::PairingError::DatabaseError(_))
+        ),
+        "finish_pairing should surface the downstream FK failure, got {result:?}"
+    );
+
+    let used_at: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT used_at FROM pairings WHERE pairing_id = $1")
+            .bind(pairing_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(
+        used_at.is_none(),
+        "used_at must be rolled back when a downstream step in finish_pairing fails"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// P1-3: finish_pairing / approve_pairing concurrency — exactly one winner.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn concurrent_finish_pairing_single_winner() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let approver = register_user(
+        &pool,
+        "concurrent-finish-approver",
+        "trusted-device",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let (pairing_id, code) = start_pairing(&pool, "device-z", TEST_PEPPER).await.unwrap();
+    approve_pairing(
+        &pool,
+        pairing_id,
+        &code,
+        approver.user_id,
+        approver.device_id,
+        TEST_PEPPER,
+    )
+    .await
+    .unwrap();
+
+    let devices_before: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM devices WHERE user_id = $1")
+        .bind(approver.user_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let refresh_before: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM refresh_tokens rt JOIN devices d ON rt.device_id = d.device_id WHERE d.user_id = $1",
+    )
+    .bind(approver.user_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+
+    let pool_a = pool.clone();
+    let pool_b = pool.clone();
+    let code_a = code.clone();
+    let code_b = code.clone();
+
+    let (result_a, result_b) = tokio::join!(
+        finish_pairing(
+            &pool_a,
+            pairing_id,
+            &code_a,
+            TEST_PEPPER,
+            TEST_SECRET,
+            TEST_ACCESS_TTL,
+            TEST_REFRESH_TTL_DAYS,
+            TEST_PEPPER,
+        ),
+        finish_pairing(
+            &pool_b,
+            pairing_id,
+            &code_b,
+            TEST_PEPPER,
+            TEST_SECRET,
+            TEST_ACCESS_TTL,
+            TEST_REFRESH_TTL_DAYS,
+            TEST_PEPPER,
+        )
+    );
+
+    let ok_count = [&result_a, &result_b].iter().filter(|r| r.is_ok()).count();
+    let already_used_count = [&result_a, &result_b]
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                Err(wavis_backend::auth::pairing::PairingError::AlreadyUsed)
+            )
+        })
+        .count();
+    assert_eq!(
+        ok_count, 1,
+        "exactly one concurrent finish must win: {result_a:?} / {result_b:?}"
+    );
+    assert_eq!(
+        already_used_count, 1,
+        "the loser must see AlreadyUsed, not a duplicate success: {result_a:?} / {result_b:?}"
+    );
+
+    let devices_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM devices WHERE user_id = $1")
+        .bind(approver.user_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        devices_after - devices_before,
+        1,
+        "a race must create exactly one device, never two"
+    );
+
+    let refresh_after: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM refresh_tokens rt JOIN devices d ON rt.device_id = d.device_id WHERE d.user_id = $1",
+    )
+    .bind(approver.user_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(
+        refresh_after - refresh_before,
+        1,
+        "a race must create exactly one new refresh token"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn concurrent_approve_single_winner() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let approver_a = register_user(
+        &pool,
+        "concurrent-approve-a",
+        "trusted-device-a",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+    let approver_b = register_user(
+        &pool,
+        "concurrent-approve-b",
+        "trusted-device-b",
+        TEST_SECRET,
+        TEST_ACCESS_TTL,
+        TEST_REFRESH_TTL_DAYS,
+        TEST_PEPPER,
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let (pairing_id, code) = start_pairing(&pool, "device-race", TEST_PEPPER)
+        .await
+        .unwrap();
+
+    let pool_a = pool.clone();
+    let pool_b = pool.clone();
+    let code_a = code.clone();
+    let code_b = code.clone();
+
+    let (result_a, result_b) = tokio::join!(
+        approve_pairing(
+            &pool_a,
+            pairing_id,
+            &code_a,
+            approver_a.user_id,
+            approver_a.device_id,
+            TEST_PEPPER,
+        ),
+        approve_pairing(
+            &pool_b,
+            pairing_id,
+            &code_b,
+            approver_b.user_id,
+            approver_b.device_id,
+            TEST_PEPPER,
+        )
+    );
+
+    let ok_count = [&result_a, &result_b].iter().filter(|r| r.is_ok()).count();
+    let already_approved_count = [&result_a, &result_b]
+        .iter()
+        .filter(|r| {
+            matches!(
+                r,
+                Err(wavis_backend::auth::pairing::PairingError::AlreadyApproved)
+            )
+        })
+        .count();
+    assert_eq!(
+        ok_count, 1,
+        "exactly one concurrent approve must win: {result_a:?} / {result_b:?}"
+    );
+    assert_eq!(
+        already_approved_count, 1,
+        "the loser must see AlreadyApproved: {result_a:?} / {result_b:?}"
+    );
+
+    let winner_user_id = if result_a.is_ok() {
+        approver_a.user_id
+    } else {
+        approver_b.user_id
+    };
+    let approved_user_id: uuid::Uuid =
+        sqlx::query_scalar("SELECT approved_user_id FROM pairings WHERE pairing_id = $1")
+            .bind(pairing_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        approved_user_id, winner_user_id,
+        "the persisted approver must match whichever call actually won"
+    );
+}

--- a/wavis-backend/tests/recovery_integration.rs
+++ b/wavis-backend/tests/recovery_integration.rs
@@ -1,8 +1,13 @@
+#![cfg(feature = "test-support")]
 //! Integration tests for account recovery domain layer.
 //!
 //! Tests Properties 5, 6, 17 from the user-identity-recovery spec.
 //! All tests require a running Postgres instance.
-//! Run with: `cargo test --test recovery_integration -- --ignored`
+//! Run with: `cargo test --features test-support --test recovery_integration -- --ignored`
+//!
+//! Gated on `test-support` (added for P1-6's handler-level anti-oracle test,
+//! which needs `MockSfuBridge` to build a full `AppState`) — matches the
+//! pattern in `bug_report_admin_integration.rs` / `channel_rest_integration.rs`.
 
 use axum::Router;
 use axum::body::Body;

--- a/wavis-backend/tests/recovery_integration.rs
+++ b/wavis-backend/tests/recovery_integration.rs
@@ -4,16 +4,33 @@
 //! All tests require a running Postgres instance.
 //! Run with: `cargo test --test recovery_integration -- --ignored`
 
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ConnectInfo;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use serde_json::{Value, json};
 use serial_test::serial;
 use sqlx::PgPool;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::sync::Arc;
+use tower::ServiceExt;
 use uuid::Uuid;
 
+use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
+use wavis_backend::app_state::AppState;
 use wavis_backend::auth::auth::{
     AuthError, DeviceRegistration, recover_account, register_user, rotate_phrase,
 };
+use wavis_backend::auth::auth_rate_limiter::{AuthRateLimiter, AuthRateLimiterConfig};
 use wavis_backend::auth::jwt::validate_access_token;
 use wavis_backend::auth::phrase::{self, PhraseConfig};
+use wavis_backend::auth::recovery_rate_limiter::{RecoveryRateLimiter, RecoveryRateLimiterConfig};
+use wavis_backend::auth::routes as auth_routes;
 use wavis_backend::channel::channel;
+use wavis_backend::ip::IpConfig;
+use wavis_backend::voice::mock_sfu_bridge::MockSfuBridge;
+use wavis_backend::voice::sfu_bridge::SfuRoomManager;
 
 const TEST_SECRET: &[u8] = b"test-secret-at-least-32-bytes!!!";
 const TEST_PEPPER: &[u8] = b"test-pepper-at-least-32-bytes!!!";
@@ -379,4 +396,149 @@ async fn prop17_channel_ownership_after_recovery() {
             "channel ownership must be preserved"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// P1-6: Recovery rate-limiter anti-oracle (handler-level, not domain-level).
+//
+// `POST /auth/recover` must never let an attacker distinguish "recovery_id
+// doesn't exist" from "recovery_id exists but budget exhausted" by watching
+// the rate limiter. The per-recovery_id attempt is only recorded when the ID
+// was found in the DB (success or PhraseVerificationFailed) — never for
+// RecoveryIdNotFound (auth/routes.rs recover(), lines ~403-429).
+// ---------------------------------------------------------------------------
+
+/// Build a minimal AppState backed by a real DB pool, matching main.rs wiring
+/// closely enough to exercise the `recover` handler's rate-limiter behavior.
+fn build_test_app_state(pool: PgPool) -> AppState {
+    use wavis_backend::channel::invite::{InviteStore, InviteStoreConfig};
+    use wavis_backend::diagnostics::bug_report::MockGitHubClient;
+    use wavis_backend::diagnostics::llm_client::NoOpLlmClient;
+
+    let mock = Arc::new(MockSfuBridge::new());
+    AppState::new(
+        mock as Arc<dyn SfuRoomManager>,
+        None,
+        "sfu://localhost".to_string(),
+        Arc::new(InviteStore::new(InviteStoreConfig::default())),
+        Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::default())),
+        IpConfig {
+            trust_proxy_headers: false,
+            trusted_proxy_cidrs: vec![],
+        },
+        Arc::new(b"dev-secret-32-bytes-minimum!!!XX".to_vec()),
+        None,
+        "wavis-backend".to_string(),
+        pool,
+        Arc::new(TEST_SECRET.to_vec()),
+        None,
+        Arc::new(AuthRateLimiter::new(AuthRateLimiterConfig::default())),
+        TEST_REFRESH_TTL_DAYS,
+        72,
+        Arc::new(TEST_PEPPER.to_vec()),
+        None,
+        Arc::new(phrase::generate_dummy_verifier(&test_phrase_config())),
+        Arc::new(b"test-pairing-pepper-32-bytes!!XX".to_vec()),
+        Arc::new(RecoveryRateLimiter::new(
+            RecoveryRateLimiterConfig::default(),
+        )),
+        Arc::new(test_phrase_config()),
+        Arc::new(TEST_ENCRYPTION_KEY.to_vec()),
+        24,
+        7,
+        Arc::new(MockGitHubClient::new()),
+        "owner/test-repo".to_string(),
+        Arc::new(NoOpLlmClient),
+    )
+}
+
+fn build_recover_router(state: AppState) -> Router {
+    Router::new()
+        .route("/auth/recover", post(auth_routes::recover))
+        .with_state(state)
+}
+
+fn with_connect_info(mut req: Request<Body>, ip: IpAddr) -> Request<Body> {
+    req.extensions_mut()
+        .insert(ConnectInfo(SocketAddr::new(ip, 12345)));
+    req
+}
+
+fn recover_request(ip: IpAddr, recovery_id: &str, phrase: &str) -> Request<Body> {
+    let body = json!({ "recovery_id": recovery_id, "phrase": phrase });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/auth/recover")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    with_connect_info(req, ip)
+}
+
+async fn send_recover(app: &Router, req: Request<Body>) -> (StatusCode, Value) {
+    let response = app.clone().oneshot(req).await.unwrap();
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), 1024 * 64)
+        .await
+        .unwrap();
+    let body: Value = if body_bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body_bytes).unwrap_or(Value::Null)
+    };
+    (status, body)
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn unknown_recovery_id_attempts_do_not_consume_per_rid_budget() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let phrase = "budget-anti-oracle-phrase";
+    let reg = register_test_user(&pool, phrase, "budget-device").await;
+
+    let app = build_recover_router(build_test_app_state(pool));
+    let ip = IpAddr::V4(Ipv4Addr::new(198, 51, 100, 7));
+
+    // 5 attempts against a recovery_id that does not exist. per_rid_max is 3,
+    // but since the ID is never found, the per-rid attempt must never be
+    // recorded — all 5 must return 401, none must ever hit 429.
+    for attempt in 1..=5 {
+        let (status, _body) = send_recover(
+            &app,
+            recover_request(ip, "wvs-XXXX-FAKE", "irrelevant-phrase"),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "unknown-recovery_id attempt {attempt} must be 401, never 429 (would leak that the ID is unknown but budget-exhausted)"
+        );
+    }
+
+    // Now spend the real recovery_id's budget (per_rid_max = 3) with a wrong
+    // phrase. Each of the first 3 must be 401 (found, phrase wrong) — proving
+    // the 5 unknown-ID attempts above left this budget untouched.
+    for attempt in 1..=3 {
+        let (status, _body) =
+            send_recover(&app, recover_request(ip, &reg.recovery_id, "wrong-phrase")).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "real recovery_id attempt {attempt}/3 must still be within budget (401), got {status}"
+        );
+    }
+
+    // The 4th attempt against the real ID must now be rate-limited — proving
+    // the budget is real (3, not inflated by the unknown-ID noise) and that
+    // it was consumed only by the real-ID attempts.
+    let (status, _body) =
+        send_recover(&app, recover_request(ip, &reg.recovery_id, "wrong-phrase")).await;
+    assert_eq!(
+        status,
+        StatusCode::TOO_MANY_REQUESTS,
+        "4th attempt against the real recovery_id must be 429 once its own budget (3) is exhausted"
+    );
 }


### PR DESCRIPTION
## Summary

Wave 1 of the combined test-audit backlog (own audit `auditoria-pruebas-2026-07-15.md` + external audit). Backend-only, security/authorization focused. No behavior changes to production logic except two log-redaction fixes noted below.

- **P0-2** — Deleted the two pairing-lockout "tests" in `auth/pairing.rs` that reimplemented `attempt_count >= 5` and asserted it against itself (0 calls to production code). Replaced with real Postgres integration tests in `pairing_integration.rs`: 5-failure lockout persists even against the *correct* code on attempt 6, `finish_pairing` rejects Expired/NotApproved/AlreadyUsed, and a forced downstream failure (FK violation) inside `finish_pairing`'s transaction rolls back `used_at`.
- **P1-3** — Concurrent `finish_pairing`/`approve_pairing` races: exactly one winner, loser gets `AlreadyUsed`/`AlreadyApproved`, never a duplicate device/token.
- **P1-1** — 8 concurrent registrations against a 1-slot alpha invite: exactly one admitted, no orphaned users/devices from the losers. Plus an expiry-boundary test.
- **P1-2** — `revoke_device`: revoking another user's device returns `NotOwned` with zero side effects (device/tokens untouched); missing device returns `NotFound`; `is_device_active` is indistinguishable between revoked and nonexistent.
- **P1-4** — `verify_dummy` (the anti-timing-oracle half for unknown recovery IDs) proven via proptest to never return `true`. AES-GCM error paths: short ciphertext, single-byte tamper, wrong key length (encrypt + decrypt).
- **P1-5** — Exhaustive `map_pairing_error`/`map_device_error` table tests against the security.md HTTP contract (401/403/404/409/429), plus a check that `DatabaseError`'s inner SQL detail never reaches the client body.
- **P1-6** — Recovery rate-limiter anti-oracle at the handler level (not just the limiter in isolation): 5 attempts against an unknown `recovery_id` never trip 429 and never touch the real ID's budget; the real ID's 3-attempt ceiling is then exhausted independently and correctly 429s on the 4th.
- **P2-11** — `recovery_id` was logged raw (`%body.recovery_id`) at `warn!` in 3 call sites in `auth/routes.rs`. Redacted with the existing `redact_token()` helper (same pattern already used for refresh tokens). While wiring the deny-list test for this, found and fixed a real gap in `no_sensitive_logs.rs`: it only ever matched a sensitive field name against the *same physical line* as the macro invocation token (`warn!(`), so any rustfmt-wrapped multi-line call — the common case — was never actually scanned. Rewrote it to accumulate full macro-invocation blocks (string/paren-aware, so literal parens inside log message text don't break block detection) before matching. Verified locally that reintroducing a raw `recovery_id` now fails the test with the exact violation.

## Production code touched (all minimal, test-driven)

- `auth/pairing.rs`: deleted the two tautological proptests (no production logic changed).
- `auth/routes.rs`: 3 lines, wrap `recovery_id` in `redact_token()` before logging.
- `tests/no_sensitive_logs.rs`: rewrote the scanner to be multi-line-aware (test infrastructure, not production code).

## Validation

- `cargo fmt --all --check`, `cargo clippy -p wavis-backend --features test-support -- -D warnings`, `node scripts/arch-check.mjs` all clean.
- All new/touched suites run against real Postgres (docker compose): `pairing_integration` (8/8), `auth_integration` (23/23), `device_integration` (6/6), `recovery_integration` (6/6), `no_sensitive_logs` (1/1), plus the full `auth::` lib unit-test module (93/93).
- Ran the exact CI "Targeted Backend: Auth" bucket locally (`auth_integration` + `ws_auth_integration` + `jwt_validation` + `device_integration` + `pairing_integration` + `recovery_integration`) to rule out cross-suite interference — all green.
- Sanity-checked the `no_sensitive_logs.rs` fix isn't a no-op: temporarily reverted one redaction, confirmed the test fails and points at the right block; reverted back, confirmed green.

Depends on Wave 0 (#295, now green) for CI to actually execute these suites — this PR's own CI run exercises them directly regardless since `wavis-backend/tests/**` changed.

https://claude.ai/code/session_01SweFhNT6BYwFzG4sXw4yAX