### PR TITLE
fix: seed alpha invite code in nightly-stress gui-surface job

### DIFF
--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -104,6 +104,12 @@ jobs:
       # landed; the backend won't start without these.
       GITHUB_BUG_REPORT_TOKEN: ci-dummy-token
       GITHUB_BUG_REPORT_REPO: ci-dummy/ci-dummy
+      # Required by gui-surface-test's register() since 024985e made invite
+      # codes mandatory; seeded into alpha_invites by the step below. No
+      # hyphens/lowercase: normalize_invite_code() strips '-' and uppercases
+      # before hashing, so the seeded hash must be computed on that same
+      # normalized form, not this literal string.
+      ALPHA_INVITE_CODE: NIGHTLYALPHA
 
     steps:
       - uses: actions/checkout@v5
@@ -114,7 +120,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends build-essential pkg-config libglib2.0-dev libasound2-dev libva-dev
+          sudo apt-get install -y --no-install-recommends build-essential pkg-config libglib2.0-dev libasound2-dev libva-dev postgresql-client
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@1.93.1
@@ -146,6 +152,16 @@ jobs:
           echo "backend failed to become ready within 60s"
           cat backend.log
           exit 1
+
+      # /auth/register requires a redeemable invite since 024985e ("adding
+      # one time invite codes"). ALPHA_INVITE_CODE_PEPPER isn't set above, so
+      # the backend falls back to its debug-build default (app_state.rs);
+      # hash the code with that same value. printf (not echo/heredoc) avoids
+      # a trailing newline that would change the HMAC input.
+      - name: Seed alpha invite code
+        run: |
+          HASH=$(printf '%s' "alpha-invite:v1:${ALPHA_INVITE_CODE}" | openssl dgst -sha256 -hmac 'dev-alpha-invite-pepper-32b!!XXX' -r | awk '{print $1}')
+          PGPASSWORD=wavis psql -h localhost -U wavis -d wavis -c "INSERT INTO alpha_invites (code_hash, max_redemptions) VALUES (decode('${HASH}','hex'), 1000);"
 
       - name: Run GUI surface tests
         run: cargo run -p gui-surface-test -- --url http://127.0.0.1:3000


### PR DESCRIPTION
## Summary
- Tonight's nightly-stress run (2026-07-16) had the "full stress run" job pass (confirming PR #288's fix held) but the "GUI surface tests" job failed for an unrelated, new reason.
- `024985e` ("adding one time invite codes", 2026-07-14) made `/auth/register` require a redeemable invite code. `gui-surface-test`'s client reads `ALPHA_INVITE_CODE` and hard-fails without it — all 44 registrations across the 17 scenarios failed instantly.
- Added an "Seed alpha invite code" step after the backend becomes ready: hashes `ALPHA_INVITE_CODE` with the debug-build default pepper (`dev-alpha-invite-pepper-32b!!XXX`, same as `app_state.rs`'s fallback) and inserts it into `alpha_invites`, mirroring the recipe already used for local e2e runs.
- Picked a hyphen-free, uppercase code (`NIGHTLYALPHA`) deliberately — `normalize_invite_code()` strips hyphens and uppercases before hashing, so a code containing hyphens would hash to something that doesn't match what the seed step inserts (caught this in verification: first attempt with a hyphenated code still 401'd).

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [x] Ran the fixed sequence against a real `cargo run -p wavis-backend` + throwaway Postgres container (not the persistent dev DB): seeded the invite with the exact commands now in the workflow, then ran `cargo run -p gui-surface-test` — **17/17 scenarios pass** (was 0/17 before the fix).
- [ ] Confirm tomorrow's (2026-07-17) scheduled run is green once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHQsvYBT8ZbBHCS85oMnLv