### PR TITLE
test(backend): wave 2 state/voice backlog (P1-7..P1-10, P2-1..P2-6, EC2 seam)

### DIFF
--- a/clients/shared/src/resampler.rs
+++ b/clients/shared/src/resampler.rs
@@ -111,4 +111,125 @@ mod tests {
             );
         }
     }
+
+    // -----------------------------------------------------------------------
+    // P2-6: round-trip tone fidelity (48kHz -> 44.1kHz -> 48kHz)
+    // -----------------------------------------------------------------------
+
+    /// Feed `input` through `resampler` in fixed-size chunks (as `resample()`
+    /// requires) and concatenate the output. Drops a trailing partial chunk.
+    fn process_all(resampler: &mut SincFixedIn<f32>, input: &[f32]) -> Vec<f32> {
+        let chunk = resampler.input_frames_next();
+        let mut out = Vec::new();
+        let mut offset = 0;
+        while offset + chunk <= input.len() {
+            out.extend(resample(resampler, &input[offset..offset + chunk]).unwrap());
+            offset += chunk;
+        }
+        out
+    }
+
+    /// Pearson correlation coefficient between two equal-length-or-truncated
+    /// signals. 1.0 = perfectly correlated shape, 0.0 = uncorrelated.
+    fn pearson_correlation(a: &[f32], b: &[f32]) -> f64 {
+        let n = a.len().min(b.len());
+        let mean_a: f64 = a[..n].iter().map(|&v| v as f64).sum::<f64>() / n as f64;
+        let mean_b: f64 = b[..n].iter().map(|&v| v as f64).sum::<f64>() / n as f64;
+
+        let (mut num, mut den_a, mut den_b) = (0.0f64, 0.0f64, 0.0f64);
+        for i in 0..n {
+            let da = a[i] as f64 - mean_a;
+            let db = b[i] as f64 - mean_b;
+            num += da * db;
+            den_a += da * da;
+            den_b += db * db;
+        }
+        if den_a <= 0.0 || den_b <= 0.0 {
+            return 0.0;
+        }
+        num / (den_a.sqrt() * den_b.sqrt())
+    }
+
+    /// A single down+up conversion round trip should reproduce a steady tone
+    /// almost exactly: same frequency/shape, near-identical amplitude, just
+    /// shifted by the sinc filters' combined (unknown but small) group delay.
+    /// This exercises the full resample() call path end to end, unlike the
+    /// proportionality property above which only checks output length.
+    #[test]
+    fn resample_roundtrip_preserves_tone_fidelity() {
+        let source_rate = 48_000u32;
+        let intermediate_rate = 44_100u32;
+        let freq_hz = 440.0f64;
+        let total_samples = source_rate as usize / 2; // 500ms
+
+        let input: Vec<f32> = (0..total_samples)
+            .map(|i| {
+                let t = i as f64 / source_rate as f64;
+                (2.0 * std::f64::consts::PI * freq_hz * t).sin() as f32
+            })
+            .collect();
+
+        let mut down = create_resampler(source_rate, intermediate_rate).unwrap();
+        let downsampled = process_all(&mut down, &input);
+
+        let mut up = create_resampler(intermediate_rate, source_rate).unwrap();
+        let roundtrip = process_all(&mut up, &downsampled);
+
+        // Skip a generous margin at the head to clear both filters' transient
+        // response, then compare a steady-state window against the original.
+        let skip = source_rate as usize / 8; // 125ms — far more than the sinc
+                                             // filters' combined group delay.
+        let compare_len = source_rate as usize / 8; // 125ms comparison window
+        assert!(
+            skip + compare_len <= input.len() && skip + compare_len <= roundtrip.len(),
+            "test signal too short for the configured skip/compare window"
+        );
+        let reference = &input[skip..skip + compare_len];
+
+        // The two-stage resample introduces an unknown but small integer
+        // sample delay; search a generous window for the best alignment
+        // rather than computing the exact combined filter group delay.
+        let search_radius: isize = 1000;
+        let mut best_corr = f64::MIN;
+        let mut best_lag: isize = 0;
+        for lag in -search_radius..=search_radius {
+            let start = skip as isize + lag;
+            if start < 0 {
+                continue;
+            }
+            let start = start as usize;
+            if start + compare_len > roundtrip.len() {
+                continue;
+            }
+            let corr = pearson_correlation(reference, &roundtrip[start..start + compare_len]);
+            if corr > best_corr {
+                best_corr = corr;
+                best_lag = lag;
+            }
+        }
+
+        // A 256-tap sinc filter with a Blackman-Harris2 window should
+        // reproduce a single steady tone almost losslessly after a down+up
+        // round trip. 0.98 leaves headroom for stopband ripple/rounding
+        // while still failing on a broken resampler (wrong ratio, aliasing,
+        // dropped/duplicated samples, silence).
+        assert!(
+            best_corr > 0.98,
+            "round-trip tone correlation too low: {best_corr} (best lag {best_lag} samples)"
+        );
+
+        // Correlation alone is scale-invariant (it would pass even if the
+        // signal were, say, halved in amplitude), so also check the
+        // round trip didn't materially change the signal's energy.
+        let best_start = (skip as isize + best_lag) as usize;
+        let aligned = &roundtrip[best_start..best_start + compare_len];
+        let rms = |s: &[f32]| -> f64 {
+            (s.iter().map(|&v| (v as f64).powi(2)).sum::<f64>() / s.len() as f64).sqrt()
+        };
+        let rms_ratio = rms(aligned) / rms(reference);
+        assert!(
+            (0.85..=1.15).contains(&rms_ratio),
+            "round-trip RMS amplitude drifted too far: ratio={rms_ratio}"
+        );
+    }
 }

--- a/wavis-backend/src/abuse/join_rate_limiter.rs
+++ b/wavis-backend/src/abuse/join_rate_limiter.rs
@@ -575,4 +575,35 @@ mod tests {
         let t1 = t0 + window + Duration::from_millis(20);
         assert!(rl.check_join(ip(1), None, "room", "conn", t1).is_ok());
     }
+
+    // --- P2-4: prune_stale removes expired entries (memory-bound invariant) ---
+
+    #[test]
+    fn prune_removes_expired_entries_and_returns_count() {
+        let window = Duration::from_secs(10);
+        let cfg = isolated_config(9999, window, Duration::from_secs(60));
+        let rl = JoinRateLimiter::new(cfg);
+        let now = Instant::now();
+
+        // Touches ip_total, room_attempts, and connection_attempts (code is None,
+        // ip_failed only touched on a failed attempt).
+        rl.record_attempt(ip(1), None, "room-1", "conn-1", false, now);
+
+        // record_attempt already pruned internally at `now`, and every window is
+        // fresh (count == 1, no cooldown), so nothing is stale yet.
+        assert_eq!(rl.prune_all(now), 0);
+
+        // Advance well past the window: all touched windows are now empty and
+        // none entered cooldown (threshold 9999 was never hit), so they qualify
+        // as stale and must be pruned.
+        let later = now + window + Duration::from_secs(1);
+        assert_eq!(
+            rl.prune_all(later),
+            3,
+            "ip_total, room_attempts, and connection_attempts entries must be pruned"
+        );
+
+        // A second sweep finds nothing left to prune.
+        assert_eq!(rl.prune_all(later), 0);
+    }
 }

--- a/wavis-backend/src/app_state.rs
+++ b/wavis-backend/src/app_state.rs
@@ -40,7 +40,9 @@ use crate::diagnostics::bug_report_rate_limiter::{
     BugReportRateLimiter, BugReportRateLimiterConfig,
 };
 use crate::diagnostics::llm_client::LlmClient;
+#[cfg(not(windows))]
 use crate::ec2_control::Ec2InstanceController;
+use crate::ec2_control::InstanceController;
 use crate::ip::IpConfig;
 use crate::state::InMemoryRoomState;
 use crate::voice::sfu_bridge::{SfuHealth, SfuRoomManager, SfuSignalingProxy};
@@ -77,7 +79,7 @@ pub struct AppState {
     /// SFU server URL sent to clients in MediaToken payloads.
     pub sfu_url: String,
     /// Optional EC2 controller for the LiveKit instance. Absent in local dev.
-    pub ec2_controller: Option<Arc<Ec2InstanceController>>,
+    pub ec2_controller: Option<Arc<dyn InstanceController>>,
     /// Set when idle shutdown is deferred until the last active room closes.
     pub pending_shutdown: Arc<AtomicBool>,
     /// Invite code store — tracks active invite codes and enforces limits.
@@ -248,7 +250,7 @@ impl AppState {
         #[cfg(not(windows))]
         let ec2_controller = std::env::var("LIVEKIT_EC2_INSTANCE_ID")
             .ok()
-            .map(|id| Arc::new(Ec2InstanceController::new(id)));
+            .map(|id| Arc::new(Ec2InstanceController::new(id)) as Arc<dyn InstanceController>);
 
         #[cfg(windows)]
         let ec2_controller = None;

--- a/wavis-backend/src/auth/auth_rate_limiter.rs
+++ b/wavis-backend/src/auth/auth_rate_limiter.rs
@@ -150,6 +150,39 @@ mod tests {
         assert!(limiter.seconds_until_refresh(ip, now).is_none());
     }
 
+    // --- P2-4: prune_stale removes expired entries (memory-bound invariant) ---
+
+    #[test]
+    fn prune_removes_expired_entries_and_returns_count() {
+        let config = AuthRateLimiterConfig {
+            register_max_per_ip: 5,
+            register_window_secs: 10,
+            refresh_max_per_ip: 5,
+            refresh_window_secs: 10,
+        };
+        let limiter = AuthRateLimiter::new(config);
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let now = Instant::now();
+
+        limiter.record_register(ip, now);
+        limiter.record_refresh(ip, now);
+
+        // Immediately after recording, both windows still hold a live timestamp.
+        assert_eq!(limiter.prune_stale(now), 0);
+
+        // Advance past both windows: count(now) becomes 0 for each, so both
+        // per-IP entries qualify for removal.
+        let later = now + Duration::from_secs(11);
+        assert_eq!(
+            limiter.prune_stale(later),
+            2,
+            "both the register and refresh entries for this IP must be pruned"
+        );
+
+        // Second sweep finds nothing left to prune.
+        assert_eq!(limiter.prune_stale(later), 0);
+    }
+
     // Feature: device-auth, Property 10: Auth rate limiter ceiling
     // **Validates: Requirements 1.5, 2.6**
     proptest! {

--- a/wavis-backend/src/connections.rs
+++ b/wavis-backend/src/connections.rs
@@ -70,3 +70,61 @@ impl ConnectionManager for LiveConnections {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn register_replaces_stale_sender() {
+        let conns = LiveConnections::new();
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
+        conns.register("peer1".to_string(), tx1);
+        conns.register("peer1".to_string(), tx2);
+
+        conns.send_to("peer1", &SignalingMessage::PeerLeft);
+
+        assert!(
+            rx1.try_recv().is_err(),
+            "the replaced sender must not receive further messages"
+        );
+        assert!(
+            rx2.try_recv().is_ok(),
+            "the new sender must receive messages sent after registration"
+        );
+    }
+
+    #[test]
+    fn send_to_closed_channel_is_noop() {
+        let conns = LiveConnections::new();
+        let (tx, rx) = mpsc::unbounded_channel();
+        conns.register("peer1".to_string(), tx);
+        drop(rx);
+
+        // Must not panic even though the receiver end is gone.
+        conns.send_to("peer1", &SignalingMessage::PeerLeft);
+    }
+
+    #[test]
+    fn send_to_unknown_peer_is_noop() {
+        let conns = LiveConnections::new();
+        // Must not panic for a peer that was never registered.
+        conns.send_to("ghost-peer", &SignalingMessage::PeerLeft);
+    }
+
+    #[test]
+    fn unregister_is_idempotent() {
+        let conns = LiveConnections::new();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        conns.register("peer1".to_string(), tx);
+        conns.unregister("peer1");
+        conns.unregister("peer1"); // second call must not panic
+
+        conns.send_to("peer1", &SignalingMessage::PeerLeft);
+        assert!(
+            rx.try_recv().is_err(),
+            "unregistered peer must not receive messages"
+        );
+    }
+}

--- a/wavis-backend/src/ec2_control.rs
+++ b/wavis-backend/src/ec2_control.rs
@@ -1,6 +1,7 @@
 #[cfg(not(windows))]
 use anyhow::Context;
 use anyhow::anyhow;
+use async_trait::async_trait;
 #[cfg(not(windows))]
 use aws_config::BehaviorVersion;
 #[cfg(not(windows))]
@@ -12,6 +13,16 @@ use aws_sdk_ec2::types::InstanceStateName;
 #[cfg(not(windows))]
 use tokio::sync::OnceCell;
 
+/// Seam over EC2 instance control so `trigger_ec2_stop`'s success/failure
+/// branches are testable without a real AWS instance. `Ec2InstanceController`
+/// is the only production implementation; tests substitute a fake.
+#[async_trait]
+pub trait InstanceController: Send + Sync {
+    async fn start_instance(&self) -> Result<(), anyhow::Error>;
+    async fn stop_instance(&self) -> Result<(), anyhow::Error>;
+    async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error>;
+}
+
 #[cfg(not(windows))]
 pub struct Ec2InstanceController {
     client: OnceCell<Client>,
@@ -19,7 +30,13 @@ pub struct Ec2InstanceController {
     region: Option<String>,
 }
 
+// On native Windows builds, `AppState::new` never constructs an EC2 controller
+// (see app_state.rs — `ec2_controller` is hardcoded `None`, since production
+// servers are Linux-only). This variant exists only so the crate compiles
+// uniformly across platforms and is exercised directly by a unit test below,
+// not by any production path — hence `allow(dead_code)` here specifically.
 #[cfg(windows)]
+#[allow(dead_code)]
 pub struct Ec2InstanceController {
     instance_id: String,
 }
@@ -44,6 +61,7 @@ impl Ec2InstanceController {
     }
 
     #[cfg(windows)]
+    #[allow(dead_code)]
     pub fn new(instance_id: String) -> Self {
         Self { instance_id }
     }
@@ -61,9 +79,12 @@ impl Ec2InstanceController {
             })
             .await
     }
+}
 
+#[async_trait]
+impl InstanceController for Ec2InstanceController {
     #[cfg(not(windows))]
-    pub async fn start_instance(&self) -> Result<(), anyhow::Error> {
+    async fn start_instance(&self) -> Result<(), anyhow::Error> {
         self.client()
             .await
             .start_instances()
@@ -76,7 +97,7 @@ impl Ec2InstanceController {
     }
 
     #[cfg(windows)]
-    pub async fn start_instance(&self) -> Result<(), anyhow::Error> {
+    async fn start_instance(&self) -> Result<(), anyhow::Error> {
         Err(anyhow!(
             "EC2 control is not available on Windows builds for instance {}",
             self.instance_id
@@ -84,7 +105,7 @@ impl Ec2InstanceController {
     }
 
     #[cfg(not(windows))]
-    pub async fn stop_instance(&self) -> Result<(), anyhow::Error> {
+    async fn stop_instance(&self) -> Result<(), anyhow::Error> {
         self.client()
             .await
             .stop_instances()
@@ -97,7 +118,7 @@ impl Ec2InstanceController {
     }
 
     #[cfg(windows)]
-    pub async fn stop_instance(&self) -> Result<(), anyhow::Error> {
+    async fn stop_instance(&self) -> Result<(), anyhow::Error> {
         Err(anyhow!(
             "EC2 control is not available on Windows builds for instance {}",
             self.instance_id
@@ -105,7 +126,7 @@ impl Ec2InstanceController {
     }
 
     #[cfg(not(windows))]
-    pub async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
+    async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
         let output = self
             .client()
             .await
@@ -137,7 +158,7 @@ impl Ec2InstanceController {
     }
 
     #[cfg(windows)]
-    pub async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
+    async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
         Err(anyhow!(
             "EC2 control is not available on Windows builds for instance {}",
             self.instance_id
@@ -161,5 +182,151 @@ pub async fn trigger_ec2_stop(app_state: &crate::app_state::AppState) {
             crate::voice::sfu_bridge::SfuHealth::Unavailable(
                 "EC2 stopped by idle scheduler".to_string(),
             );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
+    use crate::app_state::AppState;
+    use crate::auth::auth_rate_limiter::{AuthRateLimiter, AuthRateLimiterConfig};
+    use crate::channel::invite::{InviteStore, InviteStoreConfig};
+    use crate::diagnostics::bug_report::MockGitHubClient;
+    use crate::diagnostics::llm_client::NoOpLlmClient;
+    use crate::ip::IpConfig;
+    use crate::voice::mock_sfu_bridge::MockSfuBridge;
+    use crate::voice::sfu_bridge::{SfuHealth, SfuRoomManager, SfuSignalingProxy};
+    use std::sync::Arc;
+
+    /// A fake `InstanceController` whose `stop_instance` result is configurable.
+    /// `trigger_ec2_stop` never calls start_instance/describe_state, so those
+    /// are stubbed with an arbitrary Ok result to satisfy the trait.
+    struct FakeInstanceController {
+        stop_result: Result<(), String>,
+    }
+
+    #[async_trait]
+    impl InstanceController for FakeInstanceController {
+        async fn start_instance(&self) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+
+        async fn stop_instance(&self) -> Result<(), anyhow::Error> {
+            self.stop_result.clone().map_err(|e| anyhow!(e))
+        }
+
+        async fn describe_state(&self) -> Result<Ec2InstanceState, anyhow::Error> {
+            Ok(Ec2InstanceState::Running)
+        }
+    }
+
+    /// Build a minimal AppState for trigger_ec2_stop tests. Never touches the
+    /// DB, so a lazy (never-connecting) pool is enough.
+    fn build_test_app_state(ec2_controller: Option<Arc<dyn InstanceController>>) -> AppState {
+        let mock = Arc::new(MockSfuBridge::new());
+        let mut app_state = AppState::new(
+            mock.clone() as Arc<dyn SfuRoomManager>,
+            Some(mock as Arc<dyn SfuSignalingProxy>),
+            "sfu://localhost".to_string(),
+            Arc::new(InviteStore::new(InviteStoreConfig::default())),
+            Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::default())),
+            IpConfig {
+                trust_proxy_headers: false,
+                trusted_proxy_cidrs: vec![],
+            },
+            Arc::new(b"dev-secret-32-bytes-minimum!!!XX".to_vec()),
+            None,
+            "wavis-backend".to_string(),
+            sqlx::postgres::PgPoolOptions::new()
+                .connect_lazy("postgres://dummy")
+                .unwrap(),
+            Arc::new(b"test-auth-secret-at-least-32-bytes!!".to_vec()),
+            None,
+            Arc::new(AuthRateLimiter::new(AuthRateLimiterConfig::default())),
+            30,
+            72,
+            Arc::new(b"test-pepper-at-least-32-bytes!!!!!!".to_vec()),
+            None,
+            Arc::new(crate::auth::phrase::generate_dummy_verifier(
+                &crate::auth::phrase::PhraseConfig::default(),
+            )),
+            Arc::new(b"test-pairing-pepper-32-bytes!!XX".to_vec()),
+            Arc::new(
+                crate::auth::recovery_rate_limiter::RecoveryRateLimiter::new(
+                    crate::auth::recovery_rate_limiter::RecoveryRateLimiterConfig::default(),
+                ),
+            ),
+            Arc::new(crate::auth::phrase::PhraseConfig::default()),
+            Arc::new(vec![0u8; 32]),
+            24,
+            7,
+            Arc::new(MockGitHubClient::new()),
+            "owner/test-repo".to_string(),
+            Arc::new(NoOpLlmClient),
+        );
+        app_state.ec2_controller = ec2_controller;
+        app_state
+    }
+
+    #[tokio::test]
+    async fn trigger_ec2_stop_ok_marks_sfu_unavailable() {
+        let controller = FakeInstanceController {
+            stop_result: Ok(()),
+        };
+        let app_state =
+            build_test_app_state(Some(Arc::new(controller) as Arc<dyn InstanceController>));
+        *app_state.sfu_health_status.write().await = SfuHealth::Available;
+
+        trigger_ec2_stop(&app_state).await;
+
+        assert_eq!(
+            *app_state.sfu_health_status.read().await,
+            SfuHealth::Unavailable("EC2 stopped by idle scheduler".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn trigger_ec2_stop_err_leaves_health_unchanged() {
+        let controller = FakeInstanceController {
+            stop_result: Err("AWS API unreachable".to_string()),
+        };
+        let app_state =
+            build_test_app_state(Some(Arc::new(controller) as Arc<dyn InstanceController>));
+        *app_state.sfu_health_status.write().await = SfuHealth::Available;
+
+        trigger_ec2_stop(&app_state).await;
+
+        assert_eq!(
+            *app_state.sfu_health_status.read().await,
+            SfuHealth::Available,
+            "a stop_instance failure must leave SFU health untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn trigger_ec2_stop_with_no_controller_is_noop() {
+        let app_state = build_test_app_state(None);
+        *app_state.sfu_health_status.write().await = SfuHealth::Available;
+
+        trigger_ec2_stop(&app_state).await;
+
+        assert_eq!(
+            *app_state.sfu_health_status.read().await,
+            SfuHealth::Available,
+            "with no EC2 controller configured, trigger_ec2_stop must be a no-op"
+        );
+    }
+
+    /// The real, Windows-native `Ec2InstanceController` always fails, so it
+    /// exercises the same error path without needing a fake — the seam exists
+    /// for the Ok path above, not because this type can't be tested directly.
+    /// Windows-only: on other platforms `Ec2InstanceController` makes real AWS
+    /// SDK calls, which would make this test network-dependent.
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn real_windows_controller_stop_instance_always_errs() {
+        let controller = Ec2InstanceController::new("i-test".to_string());
+        assert!(controller.stop_instance().await.is_err());
     }
 }

--- a/wavis-backend/src/state.rs
+++ b/wavis-backend/src/state.rs
@@ -1184,4 +1184,189 @@ mod tests {
             }
         }
     }
+
+    // --- P1-8: viewer identity accounting (record_viewer_identity / take_viewer_identities) ---
+
+    #[test]
+    fn viewer_identity_same_window_replaces_not_duplicates() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        assert!(info.record_viewer_identity("peer1", "peer1-vw-w1"));
+        // A re-issued identity for the same window (same `-vw-{windowId}` suffix,
+        // even with a different prefix) replaces the old entry instead of adding one.
+        assert!(info.record_viewer_identity("peer1", "peer2-vw-w1"));
+        let entries = info.viewer_identities.get("peer1").unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries.contains("peer2-vw-w1"));
+        assert!(!entries.contains("peer1-vw-w1"));
+    }
+
+    #[test]
+    fn viewer_identity_cap_rejects_at_limit() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        for i in 0..MAX_VIEWER_IDENTITIES_PER_PEER {
+            assert!(info.record_viewer_identity("peer1", &format!("peer1-vw-w{i}")));
+        }
+        assert_eq!(
+            info.viewer_identities.get("peer1").unwrap().len(),
+            MAX_VIEWER_IDENTITIES_PER_PEER
+        );
+
+        assert!(!info.record_viewer_identity("peer1", "peer1-vw-overflow"));
+        assert_eq!(
+            info.viewer_identities.get("peer1").unwrap().len(),
+            MAX_VIEWER_IDENTITIES_PER_PEER,
+            "a rejected insert at the cap must not grow the set"
+        );
+    }
+
+    #[test]
+    fn take_viewer_identities_drains_all() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.record_viewer_identity("peer1", "peer1-vw-w1");
+        info.record_viewer_identity("peer1", "peer1-vw-w2");
+
+        let mut taken = info.take_viewer_identities("peer1");
+        taken.sort();
+        assert_eq!(
+            taken,
+            vec!["peer1-vw-w1".to_string(), "peer1-vw-w2".to_string()]
+        );
+
+        assert!(
+            info.take_viewer_identities("peer1").is_empty(),
+            "second take must return nothing left to drain"
+        );
+    }
+
+    #[test]
+    fn viewer_identity_without_window_suffix_does_not_clobber_others() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.record_viewer_identity("peer1", "peer1-vw-w1");
+        // No "-vw-" substring at all: must be added alongside, not treated as a
+        // same-window re-issue of the existing entry.
+        assert!(info.record_viewer_identity("peer1", "peer1-plain"));
+
+        let entries = info.viewer_identities.get("peer1").unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.contains("peer1-vw-w1"));
+        assert!(entries.contains("peer1-plain"));
+    }
+
+    // --- P1-9: preemptive media-token refresh sweep ---
+
+    #[test]
+    fn refresh_lists_only_stale_unconnected_peers() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.record_token_issued("peer1");
+        info.record_token_issued("peer2");
+        info.mark_media_connected("peer2");
+
+        // Threshold 0: elapsed-since-issue is always >= 0, so only connectedness
+        // discriminates the result.
+        assert_eq!(
+            info.peers_needing_token_refresh(0),
+            vec!["peer1".to_string()]
+        );
+    }
+
+    #[test]
+    fn connected_peer_never_needs_refresh() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.record_token_issued("peer1");
+        info.mark_media_connected("peer1");
+        assert!(info.peers_needing_token_refresh(0).is_empty());
+
+        info.mark_media_disconnected("peer1");
+        assert_eq!(
+            info.peers_needing_token_refresh(0),
+            vec!["peer1".to_string()],
+            "losing media connection must re-arm the refresh sweep"
+        );
+    }
+
+    #[test]
+    fn reissue_resets_refresh_clock() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.record_token_issued("peer1");
+        let first = *info.token_issued_at.get("peer1").unwrap();
+
+        info.record_token_issued("peer1");
+        let second = *info.token_issued_at.get("peer1").unwrap();
+
+        assert!(
+            second >= first,
+            "reissuing must refresh the stored issued_at timestamp"
+        );
+        // Immediately after reissue, a threshold well above the test's wall-clock
+        // cost must not flag the peer as stale.
+        assert!(info.peers_needing_token_refresh(60).is_empty());
+    }
+
+    #[test]
+    fn rooms_needing_token_refresh_groups_by_room_and_skips_rooms_without_candidates() {
+        let state = InMemoryRoomState::new();
+
+        let stale_handle = SfuRoomHandle("stale-handle".to_string());
+        state.create_room(
+            "room-stale".to_string(),
+            RoomInfo::new_sfu(6, stale_handle.clone()),
+        );
+        state.update_room_info("room-stale", |info| {
+            info.record_token_issued("peer1");
+        });
+
+        // Only peer is media-connected: no candidates, so the room is omitted.
+        let connected_handle = SfuRoomHandle("connected-handle".to_string());
+        state.create_room(
+            "room-connected".to_string(),
+            RoomInfo::new_sfu(6, connected_handle),
+        );
+        state.update_room_info("room-connected", |info| {
+            info.record_token_issued("peer2");
+            info.mark_media_connected("peer2");
+        });
+
+        // P2P room has no sfu_handle: always excluded regardless of staleness.
+        state.create_room("room-p2p".to_string(), RoomInfo::new_p2p());
+        state.update_room_info("room-p2p", |info| {
+            info.record_token_issued("peer3");
+        });
+
+        let result = state.rooms_needing_token_refresh(0);
+        assert_eq!(
+            result.len(),
+            1,
+            "only the room with a stale unconnected peer should be listed"
+        );
+        let (room_id, handle, peers) = &result[0];
+        assert_eq!(room_id, "room-stale");
+        assert_eq!(handle, &stale_handle);
+        assert_eq!(peers, &vec!["peer1".to_string()]);
+    }
+
+    // --- P2-2: revocation TTL boundary (is_participant_revoked lazy cleanup) ---
+
+    #[test]
+    fn revocation_expires_after_ttl_window() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.add_revoked_participant("peer1", Instant::now());
+
+        // A zero-width TTL window means any elapsed time (even a few nanoseconds)
+        // is already past the window, so the entry must read as not-revoked...
+        assert!(!info.is_participant_revoked("peer1", Duration::ZERO));
+        // ...and must be purged by the same call, not merely skipped.
+        assert!(
+            !info.revoked_participants.contains_key("peer1"),
+            "expired entry must be purged by the lazy cleanup, not just skipped"
+        );
+    }
+
+    #[test]
+    fn revocation_within_ttl_window_returns_true_and_is_not_purged() {
+        let mut info = RoomInfo::new_sfu(6, SfuRoomHandle("h".to_string()));
+        info.add_revoked_participant("peer1", Instant::now());
+
+        assert!(info.is_participant_revoked("peer1", Duration::from_secs(60)));
+        assert!(info.revoked_participants.contains_key("peer1"));
+    }
 }

--- a/wavis-backend/src/voice/sfu_sdp.rs
+++ b/wavis-backend/src/voice/sfu_sdp.rs
@@ -82,3 +82,124 @@ pub async fn handle_sfu_ice(
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voice::mock_sfu_bridge::MockSfuBridge;
+    use crate::voice::sfu_bridge::SfuError;
+    use async_trait::async_trait;
+
+    /// Signaling proxy that always fails, to exercise the error-wrapping path.
+    /// `MockSfuBridge` always succeeds on forward_offer/forward_ice_candidate,
+    /// so it can't express this case.
+    struct FailingSfuProxy;
+
+    #[async_trait]
+    impl SfuSignalingProxy for FailingSfuProxy {
+        async fn forward_offer(
+            &self,
+            _handle: &SfuRoomHandle,
+            _participant_id: &str,
+            _sdp: &str,
+        ) -> Result<String, SfuError> {
+            Err(SfuError::Unavailable("sfu offline".to_string()))
+        }
+
+        async fn forward_ice_candidate(
+            &self,
+            _handle: &SfuRoomHandle,
+            _participant_id: &str,
+            _candidate: &IceCandidate,
+        ) -> Result<(), SfuError> {
+            Err(SfuError::Unavailable("sfu offline".to_string()))
+        }
+
+        async fn poll_sfu_ice_candidates(
+            &self,
+            _handle: &SfuRoomHandle,
+            _participant_id: &str,
+        ) -> Result<Vec<IceCandidate>, SfuError> {
+            Ok(vec![])
+        }
+    }
+
+    fn test_ice_candidate() -> IceCandidate {
+        IceCandidate {
+            candidate: "candidate:1 1 UDP 1 127.0.0.1 1 typ host".to_string(),
+            sdp_mid: "0".to_string(),
+            sdp_mline_index: 0,
+        }
+    }
+
+    #[tokio::test]
+    async fn offer_success_returns_sdp_answer() {
+        let bridge = MockSfuBridge::new();
+        let handle = SfuRoomHandle("room-1".to_string());
+
+        let result = handle_sfu_offer(&bridge, &handle, "peer1", "offer-sdp").await;
+
+        match result {
+            SfuRelayResult::SdpAnswer {
+                peer_id,
+                answer_sdp,
+            } => {
+                assert_eq!(peer_id, "peer1");
+                assert_eq!(answer_sdp, "mock-answer-sdp");
+            }
+            other => panic!("expected SdpAnswer, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn offer_error_wraps_into_error_signal() {
+        let bridge = FailingSfuProxy;
+        let handle = SfuRoomHandle("room-1".to_string());
+
+        let result = handle_sfu_offer(&bridge, &handle, "peer1", "offer-sdp").await;
+
+        match result {
+            SfuRelayResult::Error { peer_id, error } => {
+                assert_eq!(peer_id, "peer1");
+                match error {
+                    SignalingMessage::Error(payload) => {
+                        assert!(payload.message.contains("SFU offer failed"));
+                    }
+                    other => panic!("expected SignalingMessage::Error, got {other:?}"),
+                }
+            }
+            other => panic!("expected SfuRelayResult::Error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ice_success_returns_forwarded() {
+        let bridge = MockSfuBridge::new();
+        let handle = SfuRoomHandle("room-1".to_string());
+
+        let result = handle_sfu_ice(&bridge, &handle, "peer1", &test_ice_candidate()).await;
+
+        assert!(matches!(result, SfuRelayResult::IceForwarded));
+    }
+
+    #[tokio::test]
+    async fn ice_error_wraps_into_error_signal() {
+        let bridge = FailingSfuProxy;
+        let handle = SfuRoomHandle("room-1".to_string());
+
+        let result = handle_sfu_ice(&bridge, &handle, "peer1", &test_ice_candidate()).await;
+
+        match result {
+            SfuRelayResult::Error { peer_id, error } => {
+                assert_eq!(peer_id, "peer1");
+                match error {
+                    SignalingMessage::Error(payload) => {
+                        assert!(payload.message.contains("SFU ICE forward failed"));
+                    }
+                    other => panic!("expected SignalingMessage::Error, got {other:?}"),
+                }
+            }
+            other => panic!("expected SfuRelayResult::Error, got {other:?}"),
+        }
+    }
+}

--- a/wavis-backend/tests/channel_rest_integration.rs
+++ b/wavis-backend/tests/channel_rest_integration.rs
@@ -336,6 +336,55 @@ async fn test_27_1_create_channel_no_auth() {
 }
 
 // ===========================================================================
+// P2-5: malformed Authorization header variants (auth/extractor.rs)
+// Rejection must stay opaque — every malformed-header shape must produce the
+// exact same 401 the extractor gives for a missing header, never a distinct
+// error that could leak which check failed.
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_malformed_authorization_header_variants_all_401() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+    let app = build_channel_router(build_test_app_state(pool));
+
+    fn post_channels_with_header(header_value: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/channels")
+            .header("content-type", "application/json");
+        if let Some(v) = header_value {
+            builder = builder.header("authorization", v);
+        }
+        builder.body(Body::from(r#"{"name":"x"}"#)).unwrap()
+    }
+
+    let (status_missing, body_missing) = send_json(&app, post_channels_with_header(None)).await;
+    assert_eq!(status_missing, StatusCode::UNAUTHORIZED);
+    assert_eq!(body_missing["error"], "authentication failed");
+
+    let variants = [
+        ("non-Bearer scheme", "Basic dXNlcjpwYXNz"),
+        ("lowercase bearer", "bearer some.jwt.token"),
+        ("Bearer with no trailing space", "Bearer"),
+        ("Bearer with empty token", "Bearer "),
+    ];
+
+    for (label, header_value) in variants {
+        let (status, body) = send_json(&app, post_channels_with_header(Some(header_value))).await;
+        assert_eq!(
+            status, status_missing,
+            "{label}: status must match the missing-header case"
+        );
+        assert_eq!(
+            body, body_missing,
+            "{label}: body must be identical to the missing-header case"
+        );
+    }
+}
+
+// ===========================================================================
 // 27.2 List channels
 // ===========================================================================
 

--- a/wavis-backend/tests/voice_orchestration_integration.rs
+++ b/wavis-backend/tests/voice_orchestration_integration.rs
@@ -392,6 +392,7 @@ use wavis_backend::channel::invite::{InviteStore, InviteStoreConfig};
 use wavis_backend::channel::routes as channel_routes;
 use wavis_backend::ip::IpConfig;
 use wavis_backend::voice::sfu_bridge::SfuRoomManager;
+use wavis_backend::ws::ws_session::SignalingSession;
 
 const TEST_AUTH_SECRET: &[u8] = b"test-auth-secret-at-least-32-bytes!!";
 
@@ -2135,4 +2136,215 @@ async fn example_voice_query_non_member_forbidden() {
 
     let response = app.oneshot(req).await.unwrap();
     assert_eq!(response.status().as_u16(), 403, "non-member must get 403");
+}
+
+// ===========================================================================
+// P1-10: teardown idempotency + active_room_map guard
+// ===========================================================================
+
+#[tokio::test]
+#[ignore] // requires Postgres
+async fn stale_session_cleanup_does_not_remove_recreated_room_mapping() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let owner = register_test_user(&pool).await;
+    let member = register_test_user(&pool).await;
+    let channel_id = create_test_channel(&pool, owner, "p1-10-mapping-guard").await;
+    add_member(&pool, channel_id, owner, member).await;
+
+    let app_state = build_test_app_state(pool.clone());
+    let token_mode = TokenMode::Custom {
+        jwt_secret: b"dev-secret-32-bytes-minimum!!!XX",
+        issuer: "wavis-backend",
+        ttl_secs: 3600,
+    };
+
+    // Session A (owner) joins — creates room R1, active_room_map[channel] = R1.
+    let join_a = voice_orchestrator::join_voice(
+        &app_state.db_pool,
+        &app_state.room_state,
+        &app_state.active_room_map,
+        app_state.sfu_room_manager.as_ref(),
+        &token_mode,
+        &app_state.sfu_url,
+        &channel_id.to_string(),
+        &owner,
+        "peer-A",
+        "SessionA",
+        None,
+        false,
+        6,
+    )
+    .await
+    .expect("A join_voice should succeed");
+    let room_id_1 = join_a.room_id.clone();
+
+    assert_eq!(
+        app_state.active_room_map.read().await.get(&channel_id),
+        Some(&room_id_1)
+    );
+
+    // Simulate A's last-leave having already run the low-level peer removal
+    // (what cleanup_connection does before its deferred artifacts step) —
+    // this destroys R1 in room_state (A was the sole peer) while
+    // active_room_map[channel] still points at it.
+    app_state.room_state.remove_peer("peer-A");
+    assert!(
+        app_state.room_state.get_room_info(&room_id_1).is_none(),
+        "precondition: R1 must be gone from room_state after its last peer leaves"
+    );
+    assert_eq!(
+        app_state.active_room_map.read().await.get(&channel_id),
+        Some(&room_id_1),
+        "precondition: the map entry must still be stale-pointing at R1"
+    );
+
+    // Session B (a different user) joins the same channel before A's
+    // cleanup runs. ensure_active_room finds the stale mapping, evicts it,
+    // and creates a fresh room R2.
+    let join_b = voice_orchestrator::join_voice(
+        &app_state.db_pool,
+        &app_state.room_state,
+        &app_state.active_room_map,
+        app_state.sfu_room_manager.as_ref(),
+        &token_mode,
+        &app_state.sfu_url,
+        &channel_id.to_string(),
+        &member,
+        "peer-B",
+        "SessionB",
+        None,
+        false,
+        6,
+    )
+    .await
+    .expect("B join_voice should succeed");
+    let room_id_2 = join_b.room_id.clone();
+    assert_ne!(
+        room_id_1, room_id_2,
+        "B must land in a freshly created room"
+    );
+    assert_eq!(
+        app_state.active_room_map.read().await.get(&channel_id),
+        Some(&room_id_2),
+        "map must now point at B's room"
+    );
+
+    // Give B's (new) room an invite, to prove A's deferred cleanup — which
+    // targets A's own stale room_id — cannot sweep it away.
+    app_state
+        .invite_store
+        .generate(
+            &room_id_2,
+            &member.to_string(),
+            None,
+            std::time::Instant::now(),
+        )
+        .expect("invite generation should succeed");
+    assert_eq!(app_state.invite_store.room_invite_count(&room_id_2), 1);
+
+    // Now run A's deferred cleanup.
+    let mut session_a = SignalingSession::new(
+        "peer-A".to_string(),
+        room_id_1.clone(),
+        join_a.participant_role,
+        Some(owner.to_string()),
+        Some(channel_id.to_string()),
+    );
+    session_a.cleanup_connection(&app_state, "peer-A").await;
+
+    // The guard (cleanup_room_artifacts' map check) must have refused to
+    // clear a mapping that no longer points at A's room.
+    assert_eq!(
+        app_state.active_room_map.read().await.get(&channel_id),
+        Some(&room_id_2),
+        "A's stale cleanup must not remove the mapping to B's live room"
+    );
+
+    // B's room and invite are untouched.
+    let room_2_info = app_state
+        .room_state
+        .get_room_info(&room_id_2)
+        .expect("B's room must still exist");
+    assert_eq!(room_2_info.participants.len(), 1);
+    assert_eq!(room_2_info.participants[0].participant_id, "peer-B");
+    assert_eq!(app_state.invite_store.room_invite_count(&room_id_2), 1);
+}
+
+#[tokio::test]
+#[ignore] // requires Postgres
+async fn double_cleanup_is_noop() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let owner = register_test_user(&pool).await;
+    let channel_id = create_test_channel(&pool, owner, "p1-10-double-cleanup").await;
+
+    let app_state = build_test_app_state(pool.clone());
+    let token_mode = TokenMode::Custom {
+        jwt_secret: b"dev-secret-32-bytes-minimum!!!XX",
+        issuer: "wavis-backend",
+        ttl_secs: 3600,
+    };
+
+    let join_a = voice_orchestrator::join_voice(
+        &app_state.db_pool,
+        &app_state.room_state,
+        &app_state.active_room_map,
+        app_state.sfu_room_manager.as_ref(),
+        &token_mode,
+        &app_state.sfu_url,
+        &channel_id.to_string(),
+        &owner,
+        "peer-A",
+        "SessionA",
+        None,
+        false,
+        6,
+    )
+    .await
+    .expect("A join_voice should succeed");
+    let room_id = join_a.room_id.clone();
+
+    let mut session_a = SignalingSession::new(
+        "peer-A".to_string(),
+        room_id.clone(),
+        join_a.participant_role,
+        Some(owner.to_string()),
+        Some(channel_id.to_string()),
+    );
+
+    session_a.cleanup_connection(&app_state, "peer-A").await;
+
+    // First cleanup: last peer left, room destroyed, map entry cleared.
+    assert!(app_state.room_state.get_room_info(&room_id).is_none());
+    assert!(
+        app_state
+            .active_room_map
+            .read()
+            .await
+            .get(&channel_id)
+            .is_none()
+    );
+    let invites_after_first = app_state.invite_store.room_invite_count(&room_id);
+
+    // Second cleanup on the same session must be a complete no-op — the
+    // `cleanup_complete` guard short-circuits before touching anything.
+    session_a.cleanup_connection(&app_state, "peer-A").await;
+
+    assert!(app_state.room_state.get_room_info(&room_id).is_none());
+    assert!(
+        app_state
+            .active_room_map
+            .read()
+            .await
+            .get(&channel_id)
+            .is_none()
+    );
+    assert_eq!(
+        app_state.invite_store.room_invite_count(&room_id),
+        invites_after_first,
+        "second cleanup must not touch invite state"
+    );
 }

--- a/wavis-backend/tests/voice_ws_integration.rs
+++ b/wavis-backend/tests/voice_ws_integration.rs
@@ -1010,6 +1010,125 @@ async fn test_28_13_room_cleanup_on_last_leave() {
     );
 }
 
+// ===========================================================================
+// P1-7: session displacement (second JoinVoice for the same user)
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn second_join_voice_same_user_displaces_first_and_frees_slot() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let owner = register_test_user(&pool).await;
+    let channel_id = create_test_channel(&pool, owner, "voice-displacement").await;
+
+    let (addr, state) = start_server(pool).await;
+    let token = sign_test_token(&state.db_pool, &owner).await;
+
+    // Connection A: first session for the user.
+    let (mut sink_a, mut stream_a) = ws_connect(addr).await;
+    ws_auth(&mut sink_a, &mut stream_a, &token).await;
+    let joined_a = ws_join_voice(
+        &mut sink_a,
+        &mut stream_a,
+        &channel_id.to_string(),
+        "SessionA",
+    )
+    .await;
+    let room_id = joined_a["roomId"].as_str().unwrap().to_string();
+    let peer_a_id = joined_a["peerId"].as_str().unwrap().to_string();
+
+    // Give A a hidden viewer identity (as a screen-share viewer window would
+    // register via RequestViewerToken — exercised directly against state
+    // here since the wire path requires real LiveKit credentials this test
+    // server doesn't configure), so displacement's cleanup of it is
+    // observable rather than vacuously true.
+    state.room_state.update_room_info(&room_id, |info| {
+        info.record_viewer_identity(&peer_a_id, &format!("{peer_a_id}-vw-w1"));
+    });
+    assert!(
+        state
+            .room_state
+            .get_room_info(&room_id)
+            .unwrap()
+            .viewer_identities
+            .get(&peer_a_id)
+            .is_some_and(|ids| !ids.is_empty()),
+        "precondition: A must hold a registered viewer identity before displacement"
+    );
+
+    // Connection B: same user, same channel, second WebSocket session.
+    let (mut sink_b, mut stream_b) = ws_connect(addr).await;
+    ws_auth(&mut sink_b, &mut stream_b, &token).await;
+    ws_send(
+        &mut sink_b,
+        json!({
+            "type": "join_voice",
+            "channelId": channel_id.to_string(),
+            "displayName": "SessionB"
+        }),
+    )
+    .await;
+
+    // A must be told it was displaced.
+    let displaced = recv_type(&mut stream_a, "session_displaced").await;
+    assert_eq!(
+        displaced["reason"].as_str().unwrap(),
+        "another session connected"
+    );
+
+    // B completes its join normally.
+    let joined_b = recv_type(&mut stream_b, "joined").await;
+    let _media_token_b = recv_type(&mut stream_b, "media_token").await;
+    let peer_b_id = joined_b["peerId"].as_str().unwrap().to_string();
+    assert_eq!(joined_b["roomId"].as_str().unwrap(), room_id);
+
+    // The room did not grow to 2 — A's slot was freed, not left occupied
+    // alongside B's.
+    assert_eq!(
+        joined_b["peerCount"].as_u64().unwrap(),
+        1,
+        "displacement must free A's slot, not add a second occupant"
+    );
+
+    // A's viewer identities were reclaimed by the eviction.
+    let room_after = state.room_state.get_room_info(&room_id).unwrap();
+    assert!(
+        room_after
+            .viewer_identities
+            .get(&peer_a_id)
+            .is_none_or(|ids| ids.is_empty()),
+        "A's viewer identities must be cleared on displacement"
+    );
+
+    // The room itself was NOT destroyed by the eviction (it uses
+    // remove_peer_preserve_room, not remove_peer) — it still exists with B
+    // as the sole occupant.
+    let (status, body) = rest_get(addr, &format!("/channels/{channel_id}/voice"), &token).await;
+    assert_eq!(status, 200);
+    assert!(
+        body["active"].as_bool().unwrap(),
+        "room must survive the displacement"
+    );
+    assert_eq!(body["participant_count"].as_u64().unwrap(), 1);
+
+    // If B observes A's departure (legitimate — A really did leave the
+    // room), it must never be a spurious report about B's own new peer id.
+    if let Some(left) = try_recv_type(&mut stream_b, "participant_left", 500).await {
+        assert_ne!(
+            left["participantId"].as_str().unwrap(),
+            peer_b_id,
+            "must never report B's own peer id as having left"
+        );
+        assert_eq!(
+            left["participantId"].as_str().unwrap(),
+            peer_a_id,
+            "any participant_left B observes here must be about the evicted A"
+        );
+    }
+}
+
 #[tokio::test]
 #[ignore]
 async fn passthrough_permission_allows_member_link_but_not_member_toggle() {


### PR DESCRIPTION
## Summary

Wave 2 of the combined test-audit backlog (own audit 2026-07-15 + external audit; wave 0 = PR #295, wave 1 = PR #296). Implements the "Backend estado/voz + cliente Rust" set: P1-7..P1-10, P2-1..P2-6, plus an EC2 controller seam needed to test `trigger_ec2_stop`.

- **P1-7** — session displacement: second `JoinVoice` for the same `user_id` evicts the stale session (`SessionDisplaced` delivered before close), frees its room slot (peer count stays 1, not 2), clears its hidden viewer identities, and leaves the room + new session intact.
- **P1-8** — viewer identity accounting: same-window re-issue replaces (not duplicates), cap rejects at `MAX_VIEWER_IDENTITIES_PER_PEER`, `take_viewer_identities` drains fully.
- **P1-9** — preemptive media-token refresh sweep: only stale+unconnected peers are listed, connected peers never flagged even at zero threshold, re-issuing resets the clock.
- **P1-10** — teardown idempotency + `active_room_map` guard: a stale session's deferred cleanup must not clobber a mapping a concurrent join already repointed at a freshly recreated room (the existing guard in `cleanup_room_artifacts` was previously untested); double `cleanup_connection` is a no-op.
- **P2-1** — `connections.rs`: register replaces a stale sender, `send_to` on a closed/unknown peer is a no-op, unregister is idempotent.
- **P2-2** — revocation TTL boundary: lazy cleanup purges expired entries and returns `false`.
- **P2-3** — `sfu_sdp.rs`: bridge errors on offer/ICE forwarding wrap into `SignalingMessage::Error`.
- **P2-4** — `prune_stale`/`prune_all` remove expired entries in both `abuse/join_rate_limiter.rs` and `auth/auth_rate_limiter.rs`.
- **P2-5** — malformed `Authorization` header variants (missing, non-Bearer scheme, lowercase `bearer`, empty token) all produce an identical opaque 401.
- **P2-6** — resampler round-trip tone fidelity: 440Hz sine through 48k→44.1k→48k, correlation + RMS checks against a justified tolerance (not just output-length proportionality, which was already covered).

### Production seam (justified)

`trigger_ec2_stop`'s Ok/Err branches were untestable without a real AWS EC2 instance. Added `trait InstanceController { start_instance, stop_instance, describe_state }`, implemented it for `Ec2InstanceController` (moved the existing per-platform method bodies into the impl block, no behavior change), and changed `AppState.ec2_controller` to `Option<Arc<dyn InstanceController>>`. Both call sites (`main.rs` scheduler, `ws_session.rs` last-room-close hook via `trigger_ec2_stop`, and the cold-start path in `ws_dispatch.rs`) needed no logic changes — they already called through `Arc<...>`.

On native Windows builds `AppState::new` still never constructs a real `Ec2InstanceController` (unchanged — production servers are Linux-only), so on Windows the struct is now unreachable from the bin target's production path; marked `#[allow(dead_code)]` with a comment explaining why, exercised directly by a Windows-only unit test instead (`real_windows_controller_stop_instance_always_errs`, confirming the existing "always fails" stub behavior is unchanged).

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p wavis-backend -p wavis-client-shared -- -D warnings` — clean
- [x] `node scripts/arch-check.mjs` — OK
- [x] `cargo test -p wavis-backend --lib` — 502 passed, 0 failed
- [x] `cargo test -p wavis-backend --features test-support --test channel_rest_integration --test voice_ws_integration --test voice_orchestration_integration -- --ignored --test-threads=1` (local Postgres) — 46 + 15 + 24 passed, 0 failed, no regressions in the untouched tests in these files
- [x] `cargo test -p wavis-client-shared --features resampler --lib` — 121 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yWhb4z9bXJS9azZoERxEm