### PR TITLE
fix(dev): pin livekit-server to v1.9.3 in docker-compose to match prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,16 @@ services:
 
   livekit:
     container_name: wavis-livekit
-    image: livekit/livekit-server:latest
+    # Pinned to match deploy/docker-compose.livekit.yml's production version —
+    # keep these two in sync, don't let this float independently. A floating
+    # :latest here previously drifted to v1.9.11 while prod stayed on v1.9.3,
+    # producing a "publisher data channel 'DATA_TRACK_LOSSY' closed
+    # unexpectedly" error on every single join (RTP audio/video unaffected,
+    # but noisy — verified 2026-07-16: reproduces 2/2 joins against v1.9.11,
+    # 0/2 against v1.9.3, real decoded audio confirmed working on both
+    # versions either way). Bump this deliberately alongside prod's pin when
+    # that's next upgraded and retested — not sooner, and not to :latest.
+    image: livekit/livekit-server:v1.9.3
     cap_add:
       - NET_ADMIN
     entrypoint: /bin/sh


### PR DESCRIPTION
## Summary

Pins the dev `docker-compose.yml` LiveKit server image to `v1.9.3`, matching the production pin in `deploy/docker-compose.livekit.yml`, instead of a floating `:latest`.

## Why

`:latest` drifted to v1.9.11 while prod stayed on v1.9.3, producing a `publisher data channel 'DATA_TRACK_LOSSY' closed unexpectedly` error on **every** local join. RTP audio/video is unaffected (real decoded audio confirmed working on both versions), but the noise pollutes every join log and doesn't reproduce prod behavior.

Verified 2026-07-16:
- v1.9.11: reproduces 2/2 joins
- v1.9.3: 0/2 joins

## Notes

- The inline comment instructs keeping this pin in sync with prod's pin — bump deliberately alongside prod when it's next upgraded and retested, never back to `:latest`.
- Found while investigating #148 (first-join no sound); this does not close that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHXMDZDuKrXUCTktwRG4dY
