### PR TITLE
test(src-tauri): wave 3 backlog (share_sources, media, audio_capture_state, pw_capture_helper framing, screen_capture fallback)

### DIFF
--- a/clients/wavis-gui/src-tauri/Cargo.toml
+++ b/clients/wavis-gui/src-tauri/Cargo.toml
@@ -166,3 +166,4 @@ base64 = "0.22"
 
 [dev-dependencies]
 proptest = "1"
+tauri = { version = "2", features = ["test"] }

--- a/clients/wavis-gui/src-tauri/src/audio_capture/audio_capture_state.rs
+++ b/clients/wavis-gui/src-tauri/src/audio_capture/audio_capture_state.rs
@@ -267,3 +267,46 @@ pub(crate) struct MovedSinkInput {
     /// Original sink index (as string) for restore.
     pub(crate) original_sink: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// On every platform that tracks a real capture handle (Linux/Windows/macOS),
+    /// a freshly constructed state must be idle — no leftover session from a
+    /// previous run.
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
+    #[test]
+    fn audio_capture_state_starts_with_no_active_session() {
+        let state = AudioCaptureState::new();
+        assert!(
+            state.active.lock().unwrap().is_none(),
+            "AudioCaptureState::new() must start with no active capture session"
+        );
+    }
+
+    #[test]
+    fn audio_share_start_result_serializes_with_expected_field_names() {
+        let result = AudioShareStartResult {
+            loopback_exclusion_available: true,
+            real_output_device_id: Some("device-1".to_string()),
+            real_output_device_name: None,
+            requires_mute_for_echo_prevention: false,
+            capture_path: Some("wasapi".to_string()),
+            fallback_reason: None,
+        };
+
+        let value = serde_json::to_value(&result).unwrap();
+
+        assert_eq!(value["loopback_exclusion_available"], true);
+        assert_eq!(value["real_output_device_id"], "device-1");
+        assert_eq!(
+            value["real_output_device_name"],
+            serde_json::Value::Null,
+            "None fields must serialize to null, not be omitted (no skip_serializing_if)"
+        );
+        assert_eq!(value["requires_mute_for_echo_prevention"], false);
+        assert_eq!(value["capture_path"], "wasapi");
+        assert_eq!(value["fallback_reason"], serde_json::Value::Null);
+    }
+}

--- a/clients/wavis-gui/src-tauri/src/media.rs
+++ b/clients/wavis-gui/src-tauri/src/media.rs
@@ -2288,21 +2288,34 @@ pub fn media_set_screen_share_audio_volume(
     Ok(())
 }
 
+/// Enable or disable a participant's remote screen share audio in the native
+/// mix. Shared by attach/detach — narrow deps so it's testable without a real
+/// `MediaState` (no LiveKit connection needed for the always-exercised
+/// None-path; a `Some` connection would require a real LiveKit session).
+fn set_screen_share_audio_enabled_impl(
+    runtime: &Runtime,
+    lk: &Mutex<Option<Arc<RealLiveKitConnection>>>,
+    id: &str,
+    enabled: bool,
+) -> Result<(), String> {
+    // LiveKit SDK setters internally `tokio::task::spawn`, which panics when
+    // called from a thread without a Tokio runtime in TLS. This was the
+    // root cause of "watch another stream → app freezes → crash" on Linux.
+    let _enter = runtime.enter();
+    let lk_guard = lk.lock().map_err(|e| format!("lock: {e}"))?;
+    if let Some(conn) = lk_guard.as_ref() {
+        conn.set_screen_share_audio_enabled(id, enabled);
+    }
+    Ok(())
+}
+
 /// Allow a participant's remote screen share audio to enter the native mix.
 #[tauri::command]
 pub fn media_attach_screen_share_audio(
     id: String,
     state: State<'_, MediaState>,
 ) -> Result<(), String> {
-    // LiveKit SDK setters internally `tokio::task::spawn`, which panics when
-    // called from a thread without a Tokio runtime in TLS. This was the
-    // root cause of "watch another stream → app freezes → crash" on Linux.
-    let _enter = state.runtime.enter();
-    let lk_guard = state.lk.lock().map_err(|e| format!("lock: {e}"))?;
-    if let Some(conn) = lk_guard.as_ref() {
-        conn.set_screen_share_audio_enabled(&id, true);
-    }
-    Ok(())
+    set_screen_share_audio_enabled_impl(&state.runtime, &state.lk, &id, true)
 }
 
 /// Block a participant's remote screen share audio from the native mix.
@@ -2311,31 +2324,96 @@ pub fn media_detach_screen_share_audio(
     id: String,
     state: State<'_, MediaState>,
 ) -> Result<(), String> {
-    let _enter = state.runtime.enter();
-    let lk_guard = state.lk.lock().map_err(|e| format!("lock: {e}"))?;
-    if let Some(conn) = lk_guard.as_ref() {
-        conn.set_screen_share_audio_enabled(&id, false);
+    set_screen_share_audio_enabled_impl(&state.runtime, &state.lk, &id, false)
+}
+
+/// Clamp `level` to 0–100 and apply it to the playback buffer if one is
+/// active. Returns the clamped value actually applied (or that would have
+/// been applied, in the no-buffer case) for testability.
+fn set_master_volume_impl(playback_buffer: &Mutex<Option<AudioBuffer>>, level: u32) -> u8 {
+    let clamped = level.min(100) as u8;
+    if let Ok(pb) = playback_buffer.lock() {
+        if let Some(buf) = pb.as_ref() {
+            buf.set_volume(clamped);
+        }
     }
-    Ok(())
+    clamped
 }
 
 /// Set master volume (0–100).
 #[tauri::command]
 pub fn media_set_master_volume(level: u32, state: State<'_, MediaState>) -> Result<(), String> {
-    let clamped = level.min(100) as u8;
-    if let Ok(pb) = state.playback_buffer.lock() {
-        if let Some(buf) = pb.as_ref() {
-            buf.set_volume(clamped);
-        }
-    }
+    set_master_volume_impl(&state.playback_buffer, level);
     Ok(())
+}
+
+/// True if a live, available LiveKit connection is present.
+fn is_connected_impl(lk: &Mutex<Option<Arc<RealLiveKitConnection>>>) -> Result<bool, String> {
+    let lk_guard = lk.lock().map_err(|e| format!("lock: {e}"))?;
+    Ok(lk_guard.as_ref().is_some_and(|c| c.is_available()))
 }
 
 /// Check if native media is currently connected.
 #[tauri::command]
 pub fn media_is_connected(state: State<'_, MediaState>) -> Result<bool, String> {
-    let lk_guard = state.lk.lock().map_err(|e| format!("lock: {e}"))?;
-    Ok(lk_guard.as_ref().is_some_and(|c| c.is_available()))
+    is_connected_impl(&state.lk)
+}
+
+#[cfg(test)]
+mod media_state_command_tests {
+    use super::{
+        is_connected_impl, set_master_volume_impl, set_screen_share_audio_enabled_impl, Arc,
+        AudioBuffer, Mutex, RealLiveKitConnection,
+    };
+
+    // --- media_set_master_volume: pure clamp behavior ---
+
+    #[test]
+    fn set_master_volume_clamps_above_range() {
+        let playback: Mutex<Option<AudioBuffer>> = Mutex::new(None);
+        assert_eq!(set_master_volume_impl(&playback, 250), 100);
+    }
+
+    #[test]
+    fn set_master_volume_preserves_in_range_value() {
+        let playback: Mutex<Option<AudioBuffer>> = Mutex::new(None);
+        assert_eq!(set_master_volume_impl(&playback, 73), 73);
+    }
+
+    #[test]
+    fn set_master_volume_none_buffer_is_noop_without_panic() {
+        let playback: Mutex<Option<AudioBuffer>> = Mutex::new(None);
+        // Must not panic when there's no active playback buffer to apply to.
+        set_master_volume_impl(&playback, 50);
+    }
+
+    // --- media_attach/detach_screen_share_audio: None-path no-op ---
+    // The Some-path (a real LiveKit connection) is out of scope here — it
+    // would require a live LiveKit session, not just a constructed struct.
+
+    #[test]
+    fn attach_screen_share_audio_none_connection_is_noop_without_panic() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let lk: Mutex<Option<Arc<RealLiveKitConnection>>> = Mutex::new(None);
+        let result = set_screen_share_audio_enabled_impl(&runtime, &lk, "peer-1", true);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn detach_screen_share_audio_none_connection_is_noop_without_panic() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let lk: Mutex<Option<Arc<RealLiveKitConnection>>> = Mutex::new(None);
+        let result = set_screen_share_audio_enabled_impl(&runtime, &lk, "peer-1", false);
+        assert!(result.is_ok());
+    }
+
+    // --- media_is_connected: None-path ---
+
+    #[test]
+    fn is_connected_returns_false_when_no_connection() {
+        let lk: Mutex<Option<Arc<RealLiveKitConnection>>> = Mutex::new(None);
+        assert_eq!(is_connected_impl(&lk).unwrap(), false);
+    }
 }
 
 // ─── Screen Share IPC Commands (Linux only) ────────────────────────

--- a/clients/wavis-gui/src-tauri/src/screen_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture.rs
@@ -145,11 +145,25 @@ pub fn create_capture_backend(
     max_height: u32,
     max_fps: u32,
 ) -> Result<Box<dyn ScreenCapture>, CaptureError> {
+    create_capture_backend_with(
+        || Box::new(pipewire_capture::PipeWireCapture::new(max_width, max_height, max_fps)),
+        || Box::new(x11_capture::X11Capture::new()),
+    )
+}
+
+/// Fallback-chain logic behind [`create_capture_backend`], with the two
+/// concrete backends injected as factories so the chain (portal → X11 →
+/// `NoBackendAvailable`) is testable without real PipeWire/X11.
+#[cfg(target_os = "linux")]
+fn create_capture_backend_with(
+    make_pipewire: impl FnOnce() -> Box<dyn ScreenCapture>,
+    make_x11: impl FnOnce() -> Box<dyn ScreenCapture>,
+) -> Result<Box<dyn ScreenCapture>, CaptureError> {
     // Step 1: Try PipeWire/portal (primary path).
     log::info!("screen_capture: trying PipeWire/portal backend");
-    let pw = pipewire_capture::PipeWireCapture::new(max_width, max_height, max_fps);
+    let pw = make_pipewire();
     match pw.start() {
-        Ok(()) => return Ok(Box::new(pw)),
+        Ok(()) => return Ok(pw),
         Err(CaptureError::UserCancelled) => return Err(CaptureError::UserCancelled),
         Err(CaptureError::PortalUnavailable(msg)) => {
             log::info!("Portal unavailable ({msg}), trying X11 fallback");
@@ -159,9 +173,9 @@ pub fn create_capture_backend(
 
     // Step 2: Try X11/XWayland fallback.
     log::info!("screen_capture: trying X11 fallback backend");
-    let x11 = x11_capture::X11Capture::new();
+    let x11 = make_x11();
     match x11.start() {
-        Ok(()) => Ok(Box::new(x11)),
+        Ok(()) => Ok(x11),
         Err(CaptureError::X11Unavailable(msg)) => {
             // On pure Wayland without XWayland, provide a specific message
             // so the user understands the environment gap.
@@ -207,5 +221,215 @@ mod tests {
         let display = err.to_string();
         assert!(display.contains("xdg-desktop-portal"));
         assert!(display.contains("Wayland"));
+    }
+
+    /// Wave 3 item 5: `create_capture_backend`'s portal → X11 →
+    /// `NoBackendAvailable` fallback chain, exercised via
+    /// `create_capture_backend_with` and fake backends (no real
+    /// PipeWire/X11 needed).
+    #[cfg(target_os = "linux")]
+    mod fallback_chain_tests {
+        use super::*;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Mutex};
+
+        /// Fake `ScreenCapture` backend whose `start()` result is fixed at
+        /// construction and handed out exactly once — matching how
+        /// `create_capture_backend_with` calls `start()` a single time per
+        /// backend.
+        struct FakeCapture {
+            start_result: Mutex<Option<Result<(), CaptureError>>>,
+        }
+
+        impl FakeCapture {
+            fn new(result: Result<(), CaptureError>) -> Self {
+                Self {
+                    start_result: Mutex::new(Some(result)),
+                }
+            }
+        }
+
+        impl ScreenCapture for FakeCapture {
+            fn start(&self) -> Result<(), CaptureError> {
+                self.start_result
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("start() called more than once on FakeCapture")
+            }
+            fn stop(&self) {}
+            fn is_active(&self) -> bool {
+                false
+            }
+            fn on_frame(&self, _cb: Box<dyn Fn(CapturedFrame) + Send + 'static>) {}
+        }
+
+        // WAYLAND_DISPLAY is process-global; serialize the two tests that
+        // mutate it so they can't race each other.
+        static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+        #[test]
+        fn portal_success_short_circuits_without_trying_x11() {
+            let x11_tried = Arc::new(AtomicBool::new(false));
+            let x11_tried_clone = x11_tried.clone();
+
+            let result = create_capture_backend_with(
+                || Box::new(FakeCapture::new(Ok(()))),
+                move || {
+                    x11_tried_clone.store(true, Ordering::SeqCst);
+                    Box::new(FakeCapture::new(Ok(())))
+                },
+            );
+
+            assert!(result.is_ok());
+            assert!(
+                !x11_tried.load(Ordering::SeqCst),
+                "X11 must not be tried when portal succeeds"
+            );
+        }
+
+        #[test]
+        fn portal_user_cancelled_short_circuits_without_trying_x11() {
+            let x11_tried = Arc::new(AtomicBool::new(false));
+            let x11_tried_clone = x11_tried.clone();
+
+            let result = create_capture_backend_with(
+                || Box::new(FakeCapture::new(Err(CaptureError::UserCancelled))),
+                move || {
+                    x11_tried_clone.store(true, Ordering::SeqCst);
+                    Box::new(FakeCapture::new(Ok(())))
+                },
+            );
+
+            assert!(matches!(result, Err(CaptureError::UserCancelled)));
+            assert!(
+                !x11_tried.load(Ordering::SeqCst),
+                "X11 must not be tried after the user cancels the portal picker"
+            );
+        }
+
+        #[test]
+        fn portal_capture_start_failed_propagates_without_trying_x11() {
+            let x11_tried = Arc::new(AtomicBool::new(false));
+            let x11_tried_clone = x11_tried.clone();
+
+            let result = create_capture_backend_with(
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::CaptureStartFailed(
+                        "boom".into(),
+                    ))))
+                },
+                move || {
+                    x11_tried_clone.store(true, Ordering::SeqCst);
+                    Box::new(FakeCapture::new(Ok(())))
+                },
+            );
+
+            match result {
+                Err(CaptureError::CaptureStartFailed(msg)) => assert_eq!(msg, "boom"),
+                other => panic!("expected CaptureStartFailed(\"boom\"), got {other:?}"),
+            }
+            assert!(
+                !x11_tried.load(Ordering::SeqCst),
+                "a backend-specific portal failure must not fall through to X11"
+            );
+        }
+
+        #[test]
+        fn portal_unavailable_falls_through_to_x11_success() {
+            let result = create_capture_backend_with(
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::PortalUnavailable(
+                        "no portal".into(),
+                    ))))
+                },
+                || Box::new(FakeCapture::new(Ok(()))),
+            );
+
+            assert!(
+                result.is_ok(),
+                "X11 success after portal PortalUnavailable must return Ok"
+            );
+        }
+
+        #[test]
+        fn portal_and_x11_both_unavailable_without_wayland_uses_x11_message() {
+            let _guard = ENV_LOCK.lock().unwrap();
+            unsafe {
+                std::env::remove_var("WAYLAND_DISPLAY");
+            }
+
+            let result = create_capture_backend_with(
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::PortalUnavailable(
+                        "no portal".into(),
+                    ))))
+                },
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::X11Unavailable(
+                        "no display".into(),
+                    ))))
+                },
+            );
+
+            match result {
+                Err(CaptureError::NoBackendAvailable(msg)) => assert_eq!(msg, "no display"),
+                other => panic!("expected NoBackendAvailable(\"no display\"), got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn portal_and_x11_both_unavailable_with_wayland_uses_portal_specific_message() {
+            let _guard = ENV_LOCK.lock().unwrap();
+            unsafe {
+                std::env::set_var("WAYLAND_DISPLAY", "wayland-0");
+            }
+
+            let result = create_capture_backend_with(
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::PortalUnavailable(
+                        "no portal".into(),
+                    ))))
+                },
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::X11Unavailable(
+                        "no display".into(),
+                    ))))
+                },
+            );
+
+            unsafe {
+                std::env::remove_var("WAYLAND_DISPLAY");
+            }
+
+            match result {
+                Err(CaptureError::NoBackendAvailable(msg)) => {
+                    assert!(msg.contains("xdg-desktop-portal"));
+                    assert!(msg.contains("Wayland"));
+                }
+                other => panic!("expected a Wayland-specific NoBackendAvailable, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn x11_capture_start_failed_propagates() {
+            let result = create_capture_backend_with(
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::PortalUnavailable(
+                        "no portal".into(),
+                    ))))
+                },
+                || {
+                    Box::new(FakeCapture::new(Err(CaptureError::CaptureStartFailed(
+                        "x11 boom".into(),
+                    ))))
+                },
+            );
+
+            match result {
+                Err(CaptureError::CaptureStartFailed(msg)) => assert_eq!(msg, "x11 boom"),
+                other => panic!("expected CaptureStartFailed(\"x11 boom\"), got {other:?}"),
+            }
+        }
     }
 }

--- a/clients/wavis-gui/src-tauri/src/screen_capture/pipewire_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture/pipewire_capture.rs
@@ -26,6 +26,39 @@ struct EncodedFrame {
     jpeg_data: Vec<u8>,
 }
 
+/// Maximum accepted JPEG payload size in a `pw_capture_helper` frame header —
+/// guards against a corrupted stream (desynced framing) causing an
+/// unbounded allocation.
+const MAX_JPEG_LEN: u32 = 50_000_000;
+
+/// Decoded fields of the `pw_capture_helper` wire protocol's 12-byte frame
+/// header: `u32 LE width | u32 LE height | u32 LE jpeg_len` (see
+/// `bin/pw_capture_helper.rs`, which writes this exact layout to stdout).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FrameHeader {
+    width: u32,
+    height: u32,
+    jpeg_len: u32,
+}
+
+impl FrameHeader {
+    /// A header is valid only if every dimension/length is non-zero and the
+    /// JPEG length is within the sanity ceiling. All-zero or oversized
+    /// values indicate a desynced stream, not a real frame.
+    fn is_valid(&self) -> bool {
+        self.width != 0 && self.height != 0 && self.jpeg_len != 0 && self.jpeg_len <= MAX_JPEG_LEN
+    }
+}
+
+/// Decode (without validating) the 12-byte frame header.
+fn decode_frame_header(header: &[u8; 12]) -> FrameHeader {
+    FrameHeader {
+        width: u32::from_le_bytes([header[0], header[1], header[2], header[3]]),
+        height: u32::from_le_bytes([header[4], header[5], header[6], header[7]]),
+        jpeg_len: u32::from_le_bytes([header[8], header[9], header[10], header[11]]),
+    }
+}
+
 /// PipeWire/portal-based screen capture backend.
 ///
 /// Runs the PipeWire capture in a subprocess (`pw_capture_helper`) to avoid
@@ -209,21 +242,23 @@ impl PipeWireCapture {
                 break;
             }
 
-            let width = u32::from_le_bytes([header[0], header[1], header[2], header[3]]);
-            let height = u32::from_le_bytes([header[4], header[5], header[6], header[7]]);
-            let jpeg_len = u32::from_le_bytes([header[8], header[9], header[10], header[11]]);
-
             frame_count += 1;
+            let parsed = decode_frame_header(&header);
 
             // Sanity checks.
-            if width == 0 || height == 0 || jpeg_len == 0 || jpeg_len > 50_000_000 {
+            if !parsed.is_valid() {
                 eprintln!(
                     "wavis: pipewire_capture: frame #{frame_count}: invalid header: {}x{} jpeg_len={}",
-                    width, height, jpeg_len
+                    parsed.width, parsed.height, parsed.jpeg_len
                 );
                 active.store(false, Ordering::SeqCst);
                 break;
             }
+            let FrameHeader {
+                width,
+                height,
+                jpeg_len,
+            } = parsed;
 
             if frame_count <= 3 || frame_count.is_multiple_of(300) {
                 eprintln!(
@@ -459,5 +494,67 @@ impl ChildExt for Child {
                 }
             }
         }
+    }
+}
+
+// P2-7: pw_capture_helper wire protocol framing (see `bin/pw_capture_helper.rs`
+// header comment: `u32 LE width | u32 LE height | u32 LE jpeg_len | jpeg bytes`).
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Encode a header exactly as `pw_capture_helper` does: three little-endian
+    /// u32s written back to back (see bin/pw_capture_helper.rs ~line 891:
+    /// `w.to_le_bytes()` then `h.to_le_bytes()` then `len.to_le_bytes()`).
+    fn encode_header(width: u32, height: u32, jpeg_len: u32) -> [u8; 12] {
+        let mut buf = [0u8; 12];
+        buf[0..4].copy_from_slice(&width.to_le_bytes());
+        buf[4..8].copy_from_slice(&height.to_le_bytes());
+        buf[8..12].copy_from_slice(&jpeg_len.to_le_bytes());
+        buf
+    }
+
+    #[test]
+    fn decode_frame_header_round_trips_pw_capture_helper_encoding() {
+        let header_bytes = encode_header(1920, 1080, 123_456);
+        let decoded = decode_frame_header(&header_bytes);
+        assert_eq!(
+            decoded,
+            FrameHeader {
+                width: 1920,
+                height: 1080,
+                jpeg_len: 123_456,
+            }
+        );
+    }
+
+    #[test]
+    fn frame_header_rejects_zero_width() {
+        assert!(!decode_frame_header(&encode_header(0, 1080, 1000)).is_valid());
+    }
+
+    #[test]
+    fn frame_header_rejects_zero_height() {
+        assert!(!decode_frame_header(&encode_header(1920, 0, 1000)).is_valid());
+    }
+
+    #[test]
+    fn frame_header_rejects_zero_jpeg_len() {
+        assert!(!decode_frame_header(&encode_header(1920, 1080, 0)).is_valid());
+    }
+
+    #[test]
+    fn frame_header_rejects_jpeg_len_over_sanity_ceiling() {
+        assert!(!decode_frame_header(&encode_header(1920, 1080, MAX_JPEG_LEN + 1)).is_valid());
+    }
+
+    #[test]
+    fn frame_header_accepts_jpeg_len_at_sanity_ceiling() {
+        assert!(decode_frame_header(&encode_header(1920, 1080, MAX_JPEG_LEN)).is_valid());
+    }
+
+    #[test]
+    fn frame_header_accepts_typical_1080p_frame() {
+        assert!(decode_frame_header(&encode_header(1920, 1080, 200_000)).is_valid());
     }
 }

--- a/clients/wavis-gui/src-tauri/src/share_sources.rs
+++ b/clients/wavis-gui/src-tauri/src/share_sources.rs
@@ -165,36 +165,41 @@ pub struct ShareSelection {
     pub with_audio: bool,
 }
 
+/// Emit a share-picker event to the main window. Generic over the Tauri
+/// runtime so it can be exercised against `tauri::test::MockRuntime` without
+/// a real webview.
+fn emit_share_picker_event<R, E, S>(app: &E, event: &str, payload: S) -> Result<(), String>
+where
+    R: tauri::Runtime,
+    E: tauri::Emitter<R>,
+    S: serde::Serialize + Clone,
+{
+    app.emit_to("main", event, payload)
+        .map_err(|e| format!("failed to emit {event}: {e}"))
+}
+
 /// Relay the share picker selection to the main window.
 #[tauri::command]
 pub fn share_picker_select(app: tauri::AppHandle, selection: ShareSelection) -> Result<(), String> {
-    use tauri::Emitter;
-
-    app.emit_to("main", "share-picker:selected", &selection)
-        .map_err(|e| format!("failed to emit share-picker:selected: {e}"))
+    emit_share_picker_event(&app, "share-picker:selected", selection)
 }
 
 /// Relay the share picker cancellation to the main window.
 #[tauri::command]
 pub fn share_picker_cancel(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::Emitter;
-
-    app.emit_to("main", "share-picker:cancelled", ())
-        .map_err(|e| format!("failed to emit share-picker:cancelled: {e}"))
+    emit_share_picker_event(&app, "share-picker:cancelled", ())
 }
 
 /// Relay a request to use the native portal/system picker to the main window.
 #[tauri::command]
 pub fn share_picker_use_portal(app: tauri::AppHandle) -> Result<(), String> {
-    use tauri::Emitter;
-
-    app.emit_to("main", "share-picker:use-portal", ())
-        .map_err(|e| format!("failed to emit share-picker:use-portal: {e}"))
+    emit_share_picker_event(&app, "share-picker:use-portal", ())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine;
     use proptest::prelude::*;
 
     /// Strategy to generate a random `ShareSourceType`.
@@ -358,6 +363,162 @@ mod tests {
                 process_id,
             },
         )
+    }
+
+    // --- encode_thumbnail_jpeg ---
+
+    #[test]
+    fn encode_thumbnail_jpeg_rejects_mismatched_buffer_length() {
+        // 10x10 RGBA needs 400 bytes; give it far too few.
+        let rgba = vec![0u8; 10];
+        let result = encode_thumbnail_jpeg(&rgba, 10, 10);
+        assert!(
+            result.is_err(),
+            "a buffer too short for the declared dimensions must be rejected"
+        );
+    }
+
+    #[test]
+    fn encode_thumbnail_jpeg_downscales_large_frame_to_max_dim() {
+        let (width, height) = (640u32, 480u32);
+        let rgba = vec![200u8; (width * height * 4) as usize];
+
+        let b64 = encode_thumbnail_jpeg(&rgba, width, height)
+            .expect("encoding should succeed")
+            .expect("a large frame must produce a thumbnail");
+
+        let jpeg_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .expect("output must be valid base64");
+        let decoded = image::load_from_memory(&jpeg_bytes).expect("output must be a valid JPEG");
+
+        assert!(
+            decoded.width() <= THUMBNAIL_MAX_DIM && decoded.height() <= THUMBNAIL_MAX_DIM,
+            "downscaled thumbnail must fit within {THUMBNAIL_MAX_DIM}px, got {}x{}",
+            decoded.width(),
+            decoded.height()
+        );
+    }
+
+    #[test]
+    fn encode_thumbnail_jpeg_does_not_upscale_small_frame() {
+        let (width, height) = (100u32, 50u32);
+        let rgba = vec![64u8; (width * height * 4) as usize];
+
+        let b64 = encode_thumbnail_jpeg(&rgba, width, height)
+            .expect("encoding should succeed")
+            .expect("a small frame must still produce a thumbnail");
+
+        let jpeg_bytes = base64::engine::general_purpose::STANDARD
+            .decode(&b64)
+            .expect("output must be valid base64");
+        let decoded = image::load_from_memory(&jpeg_bytes).expect("output must be a valid JPEG");
+
+        assert_eq!(
+            (decoded.width(), decoded.height()),
+            (width, height),
+            "a frame already under THUMBNAIL_MAX_DIM must not be resized"
+        );
+    }
+
+    // --- share-picker:* events (P2-10 wave3, using tauri::test::MockRuntime) ---
+
+    #[test]
+    fn share_picker_select_emits_selected_event_with_payload() {
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let captured_clone = captured.clone();
+        app.listen_any("share-picker:selected", move |event| {
+            *captured_clone.lock().unwrap() = Some(event.payload().to_string());
+        });
+
+        let selection = ShareSelection {
+            mode: "window".to_string(),
+            source_id: "src-1".to_string(),
+            source_name: "Some Window".to_string(),
+            with_audio: true,
+        };
+
+        emit_share_picker_event(app.handle(), "share-picker:selected", selection.clone())
+            .expect("emit should succeed");
+
+        let payload_json = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("share-picker:selected listener must have fired");
+        let deserialized: ShareSelection = serde_json::from_str(&payload_json).unwrap();
+        assert_eq!(deserialized.mode, selection.mode);
+        assert_eq!(deserialized.source_id, selection.source_id);
+        assert_eq!(deserialized.source_name, selection.source_name);
+        assert_eq!(deserialized.with_audio, selection.with_audio);
+    }
+
+    #[test]
+    fn share_picker_cancel_emits_cancelled_event() {
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let fired = Arc::new(Mutex::new(false));
+        let fired_clone = fired.clone();
+        app.listen_any("share-picker:cancelled", move |_event| {
+            *fired_clone.lock().unwrap() = true;
+        });
+
+        emit_share_picker_event(app.handle(), "share-picker:cancelled", ())
+            .expect("emit should succeed");
+
+        assert!(
+            *fired.lock().unwrap(),
+            "share-picker:cancelled listener must have fired"
+        );
+    }
+
+    #[test]
+    fn share_picker_use_portal_emits_use_portal_event() {
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let fired = Arc::new(Mutex::new(false));
+        let fired_clone = fired.clone();
+        app.listen_any("share-picker:use-portal", move |_event| {
+            *fired_clone.lock().unwrap() = true;
+        });
+
+        emit_share_picker_event(app.handle(), "share-picker:use-portal", ())
+            .expect("emit should succeed");
+
+        assert!(
+            *fired.lock().unwrap(),
+            "share-picker:use-portal listener must have fired"
+        );
+    }
+
+    #[test]
+    fn share_picker_events_do_not_cross_fire() {
+        use std::sync::{Arc, Mutex};
+        use tauri::Listener;
+
+        let app = tauri::test::mock_app();
+        let cancelled_fired = Arc::new(Mutex::new(false));
+        let cancelled_clone = cancelled_fired.clone();
+        app.listen_any("share-picker:cancelled", move |_event| {
+            *cancelled_clone.lock().unwrap() = true;
+        });
+
+        // Emitting a *different* event name must not trigger the cancelled listener.
+        emit_share_picker_event(app.handle(), "share-picker:use-portal", ())
+            .expect("emit should succeed");
+
+        assert!(
+            !*cancelled_fired.lock().unwrap(),
+            "an unrelated event must not fire the cancelled listener"
+        );
     }
 
     proptest! {


### PR DESCRIPTION
## Summary

Wave 3 of the combined test-audit backlog (wave 0 = PR #295, wave 1 = PR #296, wave 2 = PR #302). Implements the src-tauri item set, with one correction to the original audit's file targeting (see P2-7 below).

**Windows-verified (compiled and run locally against the real `wavis-gui` target — see Test plan):**

- **share_sources.rs**: `encode_thumbnail_jpeg` unit tests (mismatched RGBA buffer length → `Err`; frame > `THUMBNAIL_MAX_DIM` → downscaled, decodable JPEG ≤320px; frame already under the limit → not upscaled). `share-picker:selected/cancelled/use-portal` Tauri events: extracted `emit_share_picker_event<R, E, S>` (generic over `tauri::Runtime`/`Emitter`) so the 3 commands are testable via `tauri::test::mock_app()` + `Listener::listen_any` without a real webview — added `tauri = { features = ["test"] }` to `[dev-dependencies]`.
- **media.rs**: extracted narrow-dependency impl fns for the 4 previously-untested commands — `set_screen_share_audio_enabled_impl` (shared by attach/detach), `set_master_volume_impl`, `is_connected_impl` — each taking only the specific `Mutex<...>`/`Runtime` field it needs instead of the whole unconstructable `MediaState` (which owns a real `Runtime` + `CpalAudioBackend` + `Mutex<Option<Arc<RealLiveKitConnection>>>`). Tests cover the clamp (250→100, 73→73) and the None-path no-op for all three connection-gated commands. **Descope, as anticipated in the plan**: the `Some`-connection path needs a real LiveKit session and is out of scope.
- **audio_capture_state.rs**: `AudioCaptureState::new()` starts idle (`active` is `None`) on every platform that tracks a real handle; `AudioShareStartResult`'s serde shape (field names, `None` → `null` not omitted).

**Linux-only — NOT verified by compilation on Windows (see risk note below):**

- **P2-7, corrected**: the audit named `external_share_helper/mod.rs`, but that module is an unrelated browser/HTTP-based screen-share helper with no `pw_capture_helper` IPC at all. The actual `pw_capture_helper` wire protocol (`u32 LE width | u32 LE height | u32 LE jpeg_len`) is parsed inline inside `screen_capture/pipewire_capture.rs`'s `read_frames`. Extracted the pure decode+validate step (`decode_frame_header` / `FrameHeader::is_valid`) and added a round-trip test against byte-for-byte the same encoding `bin/pw_capture_helper.rs` writes, plus boundary tests for each zero/oversized-length rejection case.
- **Item 5**: `create_capture_backend`'s portal → X11 → `NoBackendAvailable` fallback chain, extracted into `create_capture_backend_with(make_pipewire, make_x11)` with the two backends injected as factories. Tests use a `FakeCapture` (configurable `start()` result) to cover: portal success short-circuits (X11 never tried), `UserCancelled`/`CaptureStartFailed` propagate without trying X11, `PortalUnavailable` falls through to X11, and both the `WAYLAND_DISPLAY`-set and unset `NoBackendAvailable` message branches.

### Risk / what still needs a Linux check

`pipewire_capture.rs` and `screen_capture.rs` are `#[cfg(target_os = "linux")]`-only and this repo's CI never compiles `src-tauri` on Linux (same gap wave 0 documented for the ~171 pre-existing Windows tests). I could not compile-check these two files at all — `cargo fmt --all --check` confirms they're syntactically valid Rust, but not that they type-check or that the tests pass. Please run `cargo test -p wavis-gui` on a Linux dev machine before merging, or land this behind a follow-up Linux-GTK CI job.

## Test plan

- [x] `cargo fmt --all --check` — clean (includes the Linux-only files; confirms they parse)
- [x] `cargo clippy -p wavis-gui -- -D warnings` — clean
- [x] `node scripts/arch-check.mjs` — OK
- [x] `cargo test -p wavis-gui` (Windows, full suite) — 110 passed, 0 failed, including all new tests in `share_sources`, `media::media_state_command_tests`, and `audio_capture::audio_capture_state::tests`
- [ ] `cargo test -p wavis-gui` on Linux — **not run**, needs a Linux dev/CI check for `pipewire_capture.rs` + `screen_capture.rs`

Note on environment: building `wavis-gui` fresh failed in the dedicated worktree with missing vendored WebRTC C++ headers despite the files existing on disk — root cause was the worktree's longer path pushing deeply-nested LiveKit include paths past Windows' `MAX_PATH`. Validated instead via a temporary local branch in the main working tree (shorter path), which built and ran clean; the temporary branch was deleted after validation and the main tree was left exactly as found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013yWhb4z9bXJS9azZoERxEm