### PR TITLE
invite gen

### DIFF
--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -104,6 +104,12 @@ jobs:
       # landed; the backend won't start without these.
       GITHUB_BUG_REPORT_TOKEN: ci-dummy-token
       GITHUB_BUG_REPORT_REPO: ci-dummy/ci-dummy
+      # Required by gui-surface-test's register() since 024985e made invite
+      # codes mandatory; seeded into alpha_invites by the step below. No
+      # hyphens/lowercase: normalize_invite_code() strips '-' and uppercases
+      # before hashing, so the seeded hash must be computed on that same
+      # normalized form, not this literal string.
+      ALPHA_INVITE_CODE: NIGHTLYALPHA
 
     steps:
       - uses: actions/checkout@v5
@@ -114,7 +120,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends build-essential pkg-config libglib2.0-dev libasound2-dev libva-dev
+          sudo apt-get install -y --no-install-recommends build-essential pkg-config libglib2.0-dev libasound2-dev libva-dev postgresql-client
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@1.93.1
@@ -146,6 +152,16 @@ jobs:
           echo "backend failed to become ready within 60s"
           cat backend.log
           exit 1
+
+      # /auth/register requires a redeemable invite since 024985e ("adding
+      # one time invite codes"). ALPHA_INVITE_CODE_PEPPER isn't set above, so
+      # the backend falls back to its debug-build default (app_state.rs);
+      # hash the code with that same value. printf (not echo/heredoc) avoids
+      # a trailing newline that would change the HMAC input.
+      - name: Seed alpha invite code
+        run: |
+          HASH=$(printf '%s' "alpha-invite:v1:${ALPHA_INVITE_CODE}" | openssl dgst -sha256 -hmac 'dev-alpha-invite-pepper-32b!!XXX' -r | awk '{print $1}')
+          PGPASSWORD=wavis psql -h localhost -U wavis -d wavis -c "INSERT INTO alpha_invites (code_hash, max_redemptions) VALUES (decode('${HASH}','hex'), 1000);"
 
       - name: Run GUI surface tests
         run: cargo run -p gui-surface-test -- --url http://127.0.0.1:3000

--- a/.github/workflows/workspace-ci.yml
+++ b/.github/workflows/workspace-ci.yml
@@ -75,10 +75,18 @@ jobs:
       screen: ${{ steps.filter.outputs.screen }}
       core: ${{ steps.filter.outputs.core }}
     steps:
+      # Keep change detection independent of GitHub's PR-files API. Integration
+      # PRs have repeatedly received GitHub's HTML "Unicorn" error page from
+      # that endpoint, which otherwise fails this job before any tests can run.
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # An empty token makes paths-filter use the checked-out git history
+          # for pull requests instead of calling the PR-files REST endpoint.
+          token: ''
           filters: |
             backend:
               - 'wavis-backend/**'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9843,6 +9843,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "chrono",
+ "clap 4.5.60",
  "dotenvy",
  "futures-util",
  "hex",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,16 @@ services:
 
   livekit:
     container_name: wavis-livekit
-    image: livekit/livekit-server:latest
+    # Pinned to match deploy/docker-compose.livekit.yml's production version —
+    # keep these two in sync, don't let this float independently. A floating
+    # :latest here previously drifted to v1.9.11 while prod stayed on v1.9.3,
+    # producing a "publisher data channel 'DATA_TRACK_LOSSY' closed
+    # unexpectedly" error on every single join (RTP audio/video unaffected,
+    # but noisy — verified 2026-07-16: reproduces 2/2 joins against v1.9.11,
+    # 0/2 against v1.9.3, real decoded audio confirmed working on both
+    # versions either way). Bump this deliberately alongside prod's pin when
+    # that's next upgraded and retested — not sooner, and not to :latest.
+    image: livekit/livekit-server:v1.9.3
     cap_add:
       - NET_ADMIN
     entrypoint: /bin/sh

--- a/docs/alpha-invite-operations.md
+++ b/docs/alpha-invite-operations.md
@@ -1,0 +1,98 @@
+# Closed-Alpha Invite Operations
+
+The `alpha-invite-admin` binary creates and manages per-user registration
+invites without exposing an administrative HTTP endpoint. It connects directly
+to Postgres, stores only an HMAC-SHA256 hash, and prints a newly generated raw
+code once after the database insert succeeds.
+
+## Prerequisites
+
+Run the backend migrations before using the tool. The operator environment must
+have network access to Postgres and these variables:
+
+- `DATABASE_URL`: the target Postgres connection string.
+- `ALPHA_INVITE_CODE_PEPPER`: the same value used by the target backend. It
+  must be at least 32 bytes and is needed only by `create`.
+
+Keep both values in environment variables. Do not pass them as command-line
+arguments, commit them, or paste them into tickets and logs.
+
+The tool also loads a `.env` file from the working directory if present, the
+same way the backend does. If `DATABASE_URL` is not exported, a repo-root
+`.env` can silently point the command at a development database — confirm
+which database you are targeting before creating or disabling invites.
+
+## Create an invite
+
+Labels are operator metadata, can be reused, and are never presented to the
+registrant. A new invite allows one redemption and has no expiry unless the
+optional flags are supplied.
+
+### Bash
+
+```bash
+export DATABASE_URL='postgres://...'
+export ALPHA_INVITE_CODE_PEPPER='the-same-32-byte-minimum-backend-pepper'
+
+cargo run -p wavis-backend --bin alpha-invite-admin -- create \
+  --label 'person@example.com' \
+  --expires-at '2030-08-01T23:59:59Z' \
+  --max-redemptions 1
+```
+
+### PowerShell
+
+```powershell
+$env:DATABASE_URL = 'postgres://...'
+$env:ALPHA_INVITE_CODE_PEPPER = 'the-same-32-byte-minimum-backend-pepper'
+
+cargo run -p wavis-backend --bin alpha-invite-admin -- create --label 'person@example.com' --expires-at '2030-08-01T23:59:59Z' --max-redemptions 1
+```
+
+The response contains an `invite_id` and one `invite_code` line. Record the
+UUID for later operations and send the raw code immediately through an approved
+private channel. The raw code cannot be inspected or recovered later. Avoid
+placing it in issue trackers, shared documents, shell history, or application
+logs.
+
+## Inspect invites
+
+Listing never returns raw codes or hashes. Omit `--label` to list every invite,
+or supply an exact label to narrow the result.
+
+```bash
+cargo run -p wavis-backend --bin alpha-invite-admin -- list
+cargo run -p wavis-backend --bin alpha-invite-admin -- list --label 'person@example.com'
+```
+
+```powershell
+cargo run -p wavis-backend --bin alpha-invite-admin -- list
+cargo run -p wavis-backend --bin alpha-invite-admin -- list --label 'person@example.com'
+```
+
+The status is one of `active`, `disabled`, `expired`, or `exhausted`.
+`remaining` is the maximum count minus recorded redemptions.
+
+## Disable an invite
+
+Use the UUID returned by `create` or `list`. Disabling is idempotent: repeating
+the command leaves the original disable time unchanged.
+
+```bash
+cargo run -p wavis-backend --bin alpha-invite-admin -- disable \
+  --id '00000000-0000-0000-0000-000000000000'
+```
+
+```powershell
+cargo run -p wavis-backend --bin alpha-invite-admin -- disable --id '00000000-0000-0000-0000-000000000000'
+```
+
+If a raw code is lost or may have been exposed, disable its UUID and create a
+replacement. There is no code-recovery operation by design.
+
+## Shared dev and CI invite
+
+`scripts/seed-alpha-invite.py` remains available for the existing fixed-code
+dev/CI bootstrap flow. It accepts a caller-provided raw code and is not the
+per-user issuance workflow. Use `alpha-invite-admin create` for all individual
+alpha invitations.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,10 +67,17 @@ Rust-based interactive WebSocket test client (async, tokio). Same idea as `ws-te
 $env:WS_URL = "ws://localhost:3000/ws"   # optional, defaults to localhost
 cargo run -p ws-sfu-test
 ```
-# Alpha Invite Seeding
+## Alpha Invite Operations
+
+Use the Rust operator CLI for per-user invite creation, inspection, and
+disabling. The complete Bash and PowerShell runbook is in
+[`docs/alpha-invite-operations.md`](../docs/alpha-invite-operations.md).
+
+### Shared dev/CI seeding
 
 Closed-alpha registration stores only HMAC hashes of invite codes. Use the
-seed helper to create a dev/CI invite without hand-computing the hash:
+legacy seed helper only for a fixed dev/CI invite without hand-computing the
+hash:
 
 ```bash
 ALPHA_INVITE_CODE='example-alpha-code' \
@@ -80,4 +87,5 @@ python3 scripts/seed-alpha-invite.py --execute
 ```
 
 The default `max_redemptions` is `1000000` so shared dev/CI smoke invites do
-not silently exhaust. Use `--max-redemptions 1` for one-time invites.
+not silently exhaust. Do not use this caller-supplied-code flow for per-user
+invitations; use `alpha-invite-admin create` instead.

--- a/wavis-backend/Cargo.toml
+++ b/wavis-backend/Cargo.toml
@@ -16,6 +16,10 @@ test-support = []
 name = "wavis-backend"
 path = "src/main.rs"
 
+[[bin]]
+name = "alpha-invite-admin"
+path = "src/bin/alpha-invite-admin.rs"
+
 [lib]
 name = "wavis_backend"
 path = "src/lib.rs"
@@ -48,6 +52,7 @@ aes-gcm = "0.10"
 reqwest = { version = "0.12", features = ["json"] }
 zeroize = { version = "1", features = ["derive"] }
 dotenvy = "0.15"
+clap = { version = "4", features = ["derive"] }
 
 [target.'cfg(not(windows))'.dependencies]
 aws-config = { version = "1", features = ["behavior-version-latest"] }

--- a/wavis-backend/Dockerfile
+++ b/wavis-backend/Dockerfile
@@ -22,7 +22,7 @@ COPY wavis-backend/migrations/ wavis-backend/migrations/
 # fails to parse ("workspace.lints was not defined"). Keep in sync with the root manifest.
 RUN printf '[workspace]\nresolver = "3"\nmembers = ["shared", "wavis-backend"]\n\n[workspace.lints.rust]\nunused_must_use = "deny"\n\n[workspace.lints.clippy]\ndbg_macro = "deny"\ntodo = "deny"\nunimplemented = "deny"\nmem_forget = "deny"\n' > Cargo.toml
 
-RUN cargo build --release -p wavis-backend
+RUN cargo build --release -p wavis-backend --bin wavis-backend
 
 FROM debian:bookworm-slim AS runtime
 

--- a/wavis-backend/migrations/020_add_alpha_invite_labels.sql
+++ b/wavis-backend/migrations/020_add_alpha_invite_labels.sql
@@ -1,0 +1,4 @@
+ALTER TABLE alpha_invites
+    ADD COLUMN IF NOT EXISTS label TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_alpha_invites_label ON alpha_invites (label);

--- a/wavis-backend/src/auth/alpha_invite.rs
+++ b/wavis-backend/src/auth/alpha_invite.rs
@@ -3,10 +3,14 @@
 //! Raw invite codes are never persisted. The database stores only HMAC-SHA256
 //! hashes computed with a dedicated server-side pepper.
 
+use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
+use rand::RngCore;
 use sha2::Sha256;
-use sqlx::{Postgres, Transaction};
+use sqlx::{PgPool, Postgres, Transaction};
 use uuid::Uuid;
+
+use crate::redaction::Sensitive;
 
 type HmacSha256 = Hmac<Sha256>;
 type AlphaInviteRow = (
@@ -18,6 +22,22 @@ type AlphaInviteRow = (
 );
 
 const HASH_DOMAIN: &[u8] = b"alpha-invite:v1:";
+const GENERATED_CODE_BYTES: usize = 16;
+const MAX_LABEL_CHARS: usize = 100;
+
+// The admin items below (`#[allow(dead_code)]`) are used only by the
+// `alpha-invite-admin` bin through the library target. `main.rs` compiles this
+// module directly via `mod`, so the server binary sees them as dead code.
+#[allow(dead_code)]
+type AlphaInviteAdminRow = (
+    Uuid,
+    Option<String>,
+    DateTime<Utc>,
+    Option<DateTime<Utc>>,
+    Option<DateTime<Utc>>,
+    i32,
+    i32,
+);
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum AlphaInviteError {
@@ -25,6 +45,230 @@ pub enum AlphaInviteError {
     Invalid,
     #[error("database error: {0}")]
     DatabaseError(String),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum AlphaInviteAdminError {
+    #[error("invite label must contain 1 to 100 characters and no control characters")]
+    InvalidLabel,
+    #[error("invite expiry must be in the future")]
+    InvalidExpiry,
+    #[error("maximum redemptions must be positive")]
+    InvalidMaxRedemptions,
+    #[error("invite pepper must be at least 32 bytes")]
+    PepperTooShort,
+    #[error("generated invite code could not be hashed")]
+    CodeGenerationFailed,
+    #[error("invite not found")]
+    NotFound,
+    #[error("database operation failed: {0}")]
+    DatabaseError(String),
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlphaInviteStatus {
+    Active,
+    Disabled,
+    Expired,
+    Exhausted,
+}
+
+#[allow(dead_code)]
+impl AlphaInviteStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "active",
+            Self::Disabled => "disabled",
+            Self::Expired => "expired",
+            Self::Exhausted => "exhausted",
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlphaInviteAdminRecord {
+    pub invite_id: Uuid,
+    pub label: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub disabled_at: Option<DateTime<Utc>>,
+    pub max_redemptions: i32,
+    pub redemption_count: i32,
+}
+
+#[allow(dead_code)]
+impl AlphaInviteAdminRecord {
+    pub fn status_at(&self, now: DateTime<Utc>) -> AlphaInviteStatus {
+        if self.disabled_at.is_some() {
+            AlphaInviteStatus::Disabled
+        } else if self.expires_at.is_some_and(|expires_at| now >= expires_at) {
+            AlphaInviteStatus::Expired
+        } else if self.redemption_count >= self.max_redemptions {
+            AlphaInviteStatus::Exhausted
+        } else {
+            AlphaInviteStatus::Active
+        }
+    }
+
+    pub fn remaining_redemptions(&self) -> i32 {
+        self.max_redemptions.saturating_sub(self.redemption_count)
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct CreatedAlphaInvite {
+    pub invite: AlphaInviteAdminRecord,
+    pub raw_code: Sensitive<String>,
+}
+
+#[allow(dead_code)]
+fn record_from_row(row: AlphaInviteAdminRow) -> AlphaInviteAdminRecord {
+    AlphaInviteAdminRecord {
+        invite_id: row.0,
+        label: row.1,
+        created_at: row.2,
+        expires_at: row.3,
+        disabled_at: row.4,
+        max_redemptions: row.5,
+        redemption_count: row.6,
+    }
+}
+
+pub fn validate_alpha_invite_label(label: &str) -> Result<String, AlphaInviteAdminError> {
+    let label = label.trim();
+    let length = label.chars().count();
+    if length == 0 || length > MAX_LABEL_CHARS || label.chars().any(char::is_control) {
+        return Err(AlphaInviteAdminError::InvalidLabel);
+    }
+    Ok(label.to_string())
+}
+
+/// Generate a normalization-safe invite code containing 128 bits of entropy.
+fn generate_raw_alpha_invite_code() -> String {
+    let mut bytes = [0u8; GENERATED_CODE_BYTES];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let encoded = hex::encode_upper(bytes);
+    let mut grouped = String::with_capacity(encoded.len() + encoded.len() / 4 - 1);
+    for (index, character) in encoded.chars().enumerate() {
+        if index > 0 && index % 4 == 0 {
+            grouped.push('-');
+        }
+        grouped.push(character);
+    }
+    grouped
+}
+
+fn validate_create_options(
+    label: &str,
+    expires_at: Option<DateTime<Utc>>,
+    max_redemptions: i32,
+    pepper_length: usize,
+    now: DateTime<Utc>,
+) -> Result<String, AlphaInviteAdminError> {
+    let label = validate_alpha_invite_label(label)?;
+    if max_redemptions <= 0 {
+        return Err(AlphaInviteAdminError::InvalidMaxRedemptions);
+    }
+    if expires_at.is_some_and(|expiry| expiry <= now) {
+        return Err(AlphaInviteAdminError::InvalidExpiry);
+    }
+    if pepper_length < 32 {
+        return Err(AlphaInviteAdminError::PepperTooShort);
+    }
+    Ok(label)
+}
+
+#[allow(dead_code)]
+pub async fn create_alpha_invite(
+    pool: &PgPool,
+    label: &str,
+    expires_at: Option<DateTime<Utc>>,
+    max_redemptions: i32,
+    pepper: &Sensitive<Vec<u8>>,
+) -> Result<CreatedAlphaInvite, AlphaInviteAdminError> {
+    let label = validate_create_options(
+        label,
+        expires_at,
+        max_redemptions,
+        pepper.inner().len(),
+        Utc::now(),
+    )?;
+
+    let raw_code = generate_raw_alpha_invite_code();
+    let code_hash = hash_invite_code(&raw_code, pepper.inner())
+        .map_err(|_| AlphaInviteAdminError::CodeGenerationFailed)?;
+    let row: AlphaInviteAdminRow = sqlx::query_as(
+        "INSERT INTO alpha_invites (code_hash, label, expires_at, max_redemptions) \
+         VALUES ($1, $2, $3, $4) \
+         RETURNING invite_id, label, created_at, expires_at, disabled_at, \
+                   max_redemptions, redemption_count",
+    )
+    .bind(code_hash)
+    .bind(label)
+    .bind(expires_at)
+    .bind(max_redemptions)
+    .fetch_one(pool)
+    .await
+    .map_err(|error| AlphaInviteAdminError::DatabaseError(error.to_string()))?;
+
+    Ok(CreatedAlphaInvite {
+        invite: record_from_row(row),
+        raw_code: Sensitive(raw_code),
+    })
+}
+
+#[allow(dead_code)]
+pub async fn list_alpha_invites(
+    pool: &PgPool,
+    label: Option<&str>,
+) -> Result<Vec<AlphaInviteAdminRecord>, AlphaInviteAdminError> {
+    let rows: Vec<AlphaInviteAdminRow> = if let Some(label) = label {
+        let label = validate_alpha_invite_label(label)?;
+        sqlx::query_as(
+            "SELECT invite_id, label, created_at, expires_at, disabled_at, \
+                    max_redemptions, redemption_count \
+             FROM alpha_invites WHERE label = $1 \
+             ORDER BY created_at DESC, invite_id DESC",
+        )
+        .bind(label)
+        .fetch_all(pool)
+        .await
+    } else {
+        sqlx::query_as(
+            "SELECT invite_id, label, created_at, expires_at, disabled_at, \
+                    max_redemptions, redemption_count \
+             FROM alpha_invites ORDER BY created_at DESC, invite_id DESC",
+        )
+        .fetch_all(pool)
+        .await
+    }
+    .map_err(|error| AlphaInviteAdminError::DatabaseError(error.to_string()))?;
+
+    Ok(rows.into_iter().map(record_from_row).collect())
+}
+
+#[allow(dead_code)]
+pub async fn disable_alpha_invite(
+    pool: &PgPool,
+    invite_id: Uuid,
+) -> Result<AlphaInviteAdminRecord, AlphaInviteAdminError> {
+    let row: Option<AlphaInviteAdminRow> = sqlx::query_as(
+        "UPDATE alpha_invites SET disabled_at = COALESCE(disabled_at, now()) \
+         WHERE invite_id = $1 \
+         RETURNING invite_id, label, created_at, expires_at, disabled_at, \
+                   max_redemptions, redemption_count",
+    )
+    .bind(invite_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(|error| AlphaInviteAdminError::DatabaseError(error.to_string()))?;
+
+    row.map(record_from_row)
+        .ok_or(AlphaInviteAdminError::NotFound)
 }
 
 pub fn normalize_invite_code(code: &str) -> Result<String, AlphaInviteError> {
@@ -115,7 +359,7 @@ pub async fn record_redemption(
 
 #[cfg(test)]
 mod tests {
-    use super::{AlphaInviteError, hash_invite_code, normalize_invite_code};
+    use super::*;
 
     const PEPPER: &[u8] = b"test-alpha-invite-pepper-32b!!!!";
 
@@ -147,5 +391,84 @@ mod tests {
         let a = hash_invite_code("alpha-code-1", PEPPER).unwrap();
         let b = hash_invite_code("alpha-code-2", PEPPER).unwrap();
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn generated_codes_preserve_128_bits_through_normalization() {
+        let code = Sensitive(generate_raw_alpha_invite_code());
+        let normalized = normalize_invite_code(code.inner()).unwrap();
+
+        assert_eq!(normalized.len(), GENERATED_CODE_BYTES * 2);
+        assert!(
+            normalized
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        );
+        assert!(
+            normalized
+                .chars()
+                .all(|character| !character.is_ascii_lowercase())
+        );
+        assert_eq!(code.inner().matches('-').count(), 7);
+    }
+
+    #[test]
+    fn invite_labels_are_trimmed_and_bounded() {
+        assert_eq!(
+            validate_alpha_invite_label("  person@example.com  ").unwrap(),
+            "person@example.com"
+        );
+        assert_eq!(
+            validate_alpha_invite_label(" \t\n ").unwrap_err(),
+            AlphaInviteAdminError::InvalidLabel
+        );
+        assert_eq!(
+            validate_alpha_invite_label(&"a".repeat(MAX_LABEL_CHARS + 1)).unwrap_err(),
+            AlphaInviteAdminError::InvalidLabel
+        );
+        assert_eq!(
+            validate_alpha_invite_label("line\nbreak").unwrap_err(),
+            AlphaInviteAdminError::InvalidLabel
+        );
+    }
+
+    #[test]
+    fn creation_options_reject_unsafe_values() {
+        let now = Utc::now();
+        assert_eq!(
+            validate_create_options("person", None, 0, 32, now).unwrap_err(),
+            AlphaInviteAdminError::InvalidMaxRedemptions
+        );
+        assert_eq!(
+            validate_create_options("person", Some(now), 1, 32, now).unwrap_err(),
+            AlphaInviteAdminError::InvalidExpiry
+        );
+        assert_eq!(
+            validate_create_options("person", None, 1, 31, now).unwrap_err(),
+            AlphaInviteAdminError::PepperTooShort
+        );
+    }
+
+    #[test]
+    fn invite_status_has_safe_precedence_and_remaining_count() {
+        let now = Utc::now();
+        let mut invite = AlphaInviteAdminRecord {
+            invite_id: Uuid::nil(),
+            label: Some("person".to_string()),
+            created_at: now,
+            expires_at: None,
+            disabled_at: None,
+            max_redemptions: 2,
+            redemption_count: 1,
+        };
+        assert_eq!(invite.status_at(now), AlphaInviteStatus::Active);
+        assert_eq!(invite.remaining_redemptions(), 1);
+
+        invite.redemption_count = 2;
+        assert_eq!(invite.status_at(now), AlphaInviteStatus::Exhausted);
+        invite.expires_at = Some(now);
+        assert_eq!(invite.status_at(now), AlphaInviteStatus::Expired);
+        invite.disabled_at = Some(now);
+        assert_eq!(invite.status_at(now), AlphaInviteStatus::Disabled);
     }
 }

--- a/wavis-backend/src/bin/alpha-invite-admin.rs
+++ b/wavis-backend/src/bin/alpha-invite-admin.rs
@@ -1,0 +1,257 @@
+use std::env;
+use std::io::{self, Write};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use clap::{Parser, Subcommand};
+use sqlx::postgres::PgPoolOptions;
+use uuid::Uuid;
+use wavis_backend::auth::alpha_invite::{
+    AlphaInviteAdminRecord, CreatedAlphaInvite, create_alpha_invite, disable_alpha_invite,
+    list_alpha_invites,
+};
+use wavis_backend::redaction::Sensitive;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "alpha-invite-admin",
+    about = "Manage closed-alpha registration invites directly in Postgres"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Generate and persist a new invite, printing its raw code once.
+    Create {
+        #[arg(long)]
+        label: String,
+        #[arg(long, value_parser = parse_rfc3339)]
+        expires_at: Option<DateTime<Utc>>,
+        #[arg(long, default_value_t = 1)]
+        max_redemptions: i32,
+    },
+    /// List invite metadata without exposing codes or hashes.
+    List {
+        #[arg(long)]
+        label: Option<String>,
+    },
+    /// Disable an invite by UUID. Repeated calls preserve the first disable time.
+    Disable {
+        #[arg(long)]
+        id: Uuid,
+    },
+}
+
+fn parse_rfc3339(value: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|timestamp| timestamp.with_timezone(&Utc))
+        .map_err(|_| "expected an RFC 3339 timestamp such as 2026-12-31T23:59:59Z".to_string())
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let _ = dotenvy::dotenv();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(io::stderr)
+        .try_init();
+
+    let cli = Cli::parse();
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+
+    match run(cli, &mut output).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(error = %error, "alpha invite admin command failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run(cli: Cli, output: &mut impl Write) -> Result<()> {
+    let database_url = Sensitive(
+        env::var("DATABASE_URL").context("DATABASE_URL must be set for alpha invite operations")?,
+    );
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(database_url.inner())
+        .await
+        .context("failed to connect to Postgres")?;
+
+    match cli.command {
+        Command::Create {
+            label,
+            expires_at,
+            max_redemptions,
+        } => {
+            let pepper = Sensitive(
+                env::var("ALPHA_INVITE_CODE_PEPPER")
+                    .context("ALPHA_INVITE_CODE_PEPPER must be set when creating an invite")?
+                    .into_bytes(),
+            );
+            let created =
+                create_alpha_invite(&pool, &label, expires_at, max_redemptions, &pepper).await?;
+            write_created_invite(output, &created)?;
+        }
+        Command::List { label } => {
+            let invites = list_alpha_invites(&pool, label.as_deref()).await?;
+            write_invite_list(output, &invites, Utc::now())?;
+        }
+        Command::Disable { id } => {
+            let invite = disable_alpha_invite(&pool, id).await?;
+            write_disabled_invite(output, &invite)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn write_created_invite(output: &mut impl Write, created: &CreatedAlphaInvite) -> io::Result<()> {
+    writeln!(output, "invite_id\t{}", created.invite.invite_id)?;
+    writeln!(
+        output,
+        "label\t{}",
+        display_label(created.invite.label.as_deref())
+    )?;
+    writeln!(output, "invite_code\t{}", created.raw_code.inner())?;
+    writeln!(
+        output,
+        "expires_at\t{}",
+        display_timestamp(created.invite.expires_at)
+    )?;
+    writeln!(
+        output,
+        "max_redemptions\t{}",
+        created.invite.max_redemptions
+    )
+}
+
+fn write_invite_list(
+    output: &mut impl Write,
+    invites: &[AlphaInviteAdminRecord],
+    now: DateTime<Utc>,
+) -> io::Result<()> {
+    writeln!(
+        output,
+        "invite_id\tlabel\tstatus\tcreated_at\texpires_at\tdisabled_at\tredemptions\tmax_redemptions\tremaining"
+    )?;
+    for invite in invites {
+        writeln!(
+            output,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+            invite.invite_id,
+            display_label(invite.label.as_deref()),
+            invite.status_at(now).as_str(),
+            invite.created_at.to_rfc3339(),
+            display_timestamp(invite.expires_at),
+            display_timestamp(invite.disabled_at),
+            invite.redemption_count,
+            invite.max_redemptions,
+            invite.remaining_redemptions(),
+        )?;
+    }
+    Ok(())
+}
+
+fn write_disabled_invite(
+    output: &mut impl Write,
+    invite: &AlphaInviteAdminRecord,
+) -> io::Result<()> {
+    writeln!(output, "invite_id\t{}", invite.invite_id)?;
+    writeln!(output, "status\t{}", invite.status_at(Utc::now()).as_str())?;
+    writeln!(
+        output,
+        "disabled_at\t{}",
+        display_timestamp(invite.disabled_at)
+    )
+}
+
+fn display_label(label: Option<&str>) -> String {
+    label
+        .unwrap_or("(unlabeled)")
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn display_timestamp(timestamp: Option<DateTime<Utc>>) -> String {
+    timestamp.map_or_else(|| "-".to_string(), |value| value.to_rfc3339())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wavis_backend::auth::alpha_invite::AlphaInviteStatus;
+
+    fn record() -> AlphaInviteAdminRecord {
+        AlphaInviteAdminRecord {
+            invite_id: Uuid::nil(),
+            label: Some("person@example.com".to_string()),
+            created_at: DateTime::parse_from_rfc3339("2026-07-16T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            expires_at: None,
+            disabled_at: None,
+            max_redemptions: 1,
+            redemption_count: 0,
+        }
+    }
+
+    #[test]
+    fn create_output_reveals_raw_code_exactly_once() {
+        let raw_code = "ABCD-EF01-2345-6789-ABCD-EF01-2345-6789";
+        let created = CreatedAlphaInvite {
+            invite: record(),
+            raw_code: Sensitive(raw_code.to_string()),
+        };
+        let mut output = Vec::new();
+
+        write_created_invite(&mut output, &created).unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert_eq!(output.matches(raw_code).count(), 1);
+        assert_eq!(format!("{:?}", created.raw_code), "[REDACTED]");
+        assert_eq!(format!("{}", created.raw_code), "[REDACTED]");
+        assert!(!format!("{created:?}").contains(raw_code));
+    }
+
+    #[test]
+    fn list_and_disable_output_never_contain_secret_material() {
+        let invite = record();
+        let now = invite.created_at;
+        let mut list_output = Vec::new();
+        let mut disable_output = Vec::new();
+
+        write_invite_list(&mut list_output, std::slice::from_ref(&invite), now).unwrap();
+        write_disabled_invite(&mut disable_output, &invite).unwrap();
+
+        let combined = format!(
+            "{}{}",
+            String::from_utf8(list_output).unwrap(),
+            String::from_utf8(disable_output).unwrap()
+        );
+        assert!(!combined.contains("invite_code"));
+        assert!(!combined.contains("code_hash"));
+        assert!(!combined.contains("ABCD-EF01-2345-6789"));
+        assert_eq!(invite.status_at(now), AlphaInviteStatus::Active);
+    }
+
+    #[test]
+    fn legacy_control_characters_cannot_inject_output_rows() {
+        assert_eq!(
+            display_label(Some("legacy\tlabel\nvalue")),
+            "legacy label value"
+        );
+    }
+}

--- a/wavis-backend/tests/auth_integration.rs
+++ b/wavis-backend/tests/auth_integration.rs
@@ -11,7 +11,10 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 // Re-export domain types for use in subsequent test tasks (11.2–11.5).
-use wavis_backend::auth::alpha_invite::hash_invite_code;
+use wavis_backend::auth::alpha_invite::{
+    AlphaInviteStatus, create_alpha_invite, disable_alpha_invite, hash_invite_code,
+    list_alpha_invites,
+};
 #[allow(unused_imports)]
 use wavis_backend::auth::auth::{
     self, AuthError, DeviceRegistration, TokenPair, generate_refresh_token, hash_refresh_token,
@@ -19,6 +22,7 @@ use wavis_backend::auth::auth::{
     validate_refresh_ttl,
 };
 use wavis_backend::auth::jwt::{sign_access_token, validate_access_token};
+use wavis_backend::redaction::Sensitive;
 
 /// Get a test database pool. Reads DATABASE_URL from env,
 /// falling back to a local default for convenience.
@@ -1450,4 +1454,152 @@ async fn alpha_invite_registration_exhausts_limited_invite() {
     .await;
 
     assert!(matches!(result, Err(AuthError::InviteInvalid)));
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn generated_alpha_invite_is_hash_only_and_redeemable() {
+    let pool = test_pool().await;
+    truncate_auth_tables(&pool).await;
+
+    let expires_at = chrono::DateTime::parse_from_rfc3339("2099-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let admin_pepper = Sensitive(test_alpha_invite_pepper());
+    let created = create_alpha_invite(
+        &pool,
+        "person@example.com",
+        Some(expires_at),
+        2,
+        &admin_pepper,
+    )
+    .await
+    .unwrap();
+    let raw_code = created.raw_code.inner().clone();
+    let expected_hash = hash_invite_code(&raw_code, &test_alpha_invite_pepper()).unwrap();
+
+    let stored: (
+        Vec<u8>,
+        Option<String>,
+        Option<chrono::DateTime<chrono::Utc>>,
+        i32,
+        i32,
+    ) = sqlx::query_as(
+        "SELECT code_hash, label, expires_at, max_redemptions, redemption_count \
+             FROM alpha_invites WHERE invite_id = $1",
+    )
+    .bind(created.invite.invite_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(stored.0, expected_hash);
+    assert_eq!(stored.1.as_deref(), Some("person@example.com"));
+    assert_eq!(stored.2, Some(expires_at));
+    assert_eq!(stored.3, 2);
+    assert_eq!(stored.4, 0);
+
+    let persisted_json: String = sqlx::query_scalar(
+        "SELECT to_jsonb(invite_row)::text FROM alpha_invites invite_row WHERE invite_id = $1",
+    )
+    .bind(created.invite.invite_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(!persisted_json.contains(&raw_code));
+
+    let secret = test_auth_secret();
+    let refresh_pepper = test_pepper();
+    let phrase_config = test_phrase_config();
+    let registration = auth::register_user_with_invite(
+        &pool,
+        "generated-invite-test-phrase",
+        "generated-invite-user",
+        &raw_code,
+        &secret,
+        900,
+        30,
+        &refresh_pepper,
+        &test_alpha_invite_pepper(),
+        &phrase_config,
+        TEST_ENCRYPTION_KEY,
+    )
+    .await
+    .unwrap();
+
+    let invites = list_alpha_invites(&pool, Some("person@example.com"))
+        .await
+        .unwrap();
+    assert_eq!(invites.len(), 1);
+    assert_eq!(invites[0].redemption_count, 1);
+    assert_eq!(invites[0].remaining_redemptions(), 1);
+    assert_eq!(
+        invites[0].status_at(chrono::Utc::now()),
+        AlphaInviteStatus::Active
+    );
+
+    let audit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM alpha_invite_redemptions \
+         WHERE invite_id = $1 AND user_id = $2 AND device_id = $3",
+    )
+    .bind(created.invite.invite_id)
+    .bind(registration.user_id)
+    .bind(registration.device_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(audit_count, 1);
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn admin_disabled_invite_is_idempotent_and_leaves_no_auth_rows() {
+    let pool = test_pool().await;
+    truncate_auth_tables(&pool).await;
+
+    let admin_pepper = Sensitive(test_alpha_invite_pepper());
+    let created = create_alpha_invite(&pool, "disabled-person", None, 1, &admin_pepper)
+        .await
+        .unwrap();
+    let raw_code = created.raw_code.inner().clone();
+    let first_disable = disable_alpha_invite(&pool, created.invite.invite_id)
+        .await
+        .unwrap();
+    let second_disable = disable_alpha_invite(&pool, created.invite.invite_id)
+        .await
+        .unwrap();
+
+    assert_eq!(first_disable.disabled_at, second_disable.disabled_at);
+    assert_eq!(
+        second_disable.status_at(chrono::Utc::now()),
+        AlphaInviteStatus::Disabled
+    );
+
+    let result = auth::register_user_with_invite(
+        &pool,
+        "disabled-invite-test-phrase",
+        "disabled-invite-user",
+        &raw_code,
+        &test_auth_secret(),
+        900,
+        30,
+        &test_pepper(),
+        &test_alpha_invite_pepper(),
+        &test_phrase_config(),
+        TEST_ENCRYPTION_KEY,
+    )
+    .await;
+    assert!(matches!(result, Err(AuthError::InviteInvalid)));
+
+    for table in [
+        "users",
+        "devices",
+        "refresh_tokens",
+        "alpha_invite_redemptions",
+    ] {
+        let query = format!("SELECT COUNT(*) FROM {table}");
+        let count: i64 = sqlx::query_scalar(&query).fetch_one(&pool).await.unwrap();
+        assert_eq!(count, 0, "disabled invite left partial rows in {table}");
+    }
 }


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Dependency update
- [ ] Documentation / config only

---

## Security Checklist

> Complete this section for any PR that touches signaling or token paths:
> `domain/jwt.rs`, `domain/livekit_bridge.rs`, `domain/relay.rs`,
> `domain/sfu_relay.rs`, `handlers/ws.rs`

If this PR does **not** touch any of those files, check this box and skip the rest:
- [ ] This PR does not touch signaling or token paths — checklist not applicable

Otherwise, confirm each item below:

### Sensitive Data Logging (Req 5.1–5.4)
- [ ] No JWT strings, raw tokens, or MediaToken values are passed to log macros
- [ ] No invite code values are passed to log macros (lengths/counts are OK)
- [ ] No SDP content is passed to log macros (lengths/types are OK)
- [ ] No ICE candidate strings are passed to log macros (counts/types are OK)
- [ ] `cargo test --test no_sensitive_logs` passes locally (also enforced by CI: `backend-ci.yml`)

### Message Size Limits (Req 3.5, 3.8)
- [ ] SDP payloads are validated against `MAX_SDP_BYTES` (64 KB) before forwarding
- [ ] ICE candidate payloads are validated against `MAX_ICE_CANDIDATE_BYTES` (2 KB) before forwarding
- [ ] Oversized payloads return a descriptive error and are not forwarded

### Server-Enforced Identity (Req 2.3, 2.4)
- [ ] All post-join message dispatch uses `session.participant_id` as sender identity
- [ ] No client-supplied identity fields are trusted for routing or authorization

### Domain-Enforced Action Authorization (Req 3.1, 3.2, 3.6)
- [ ] Action messages (kick, mute) are rejected in P2P rooms
- [ ] Host-only actions check `session.role == Host` in the handler (Tier 1)
- [ ] Domain functions (`handle_kick`, etc.) independently validate role (Tier 2 / defense in depth)
- [ ] Action messages are never forwarded through the relay path

### Token Scope and Lifetime (Req 1.1–1.7)
- [ ] MediaTokens include `iss` and `aud` claims
- [ ] Token TTL is ≤ 600s (default) — no unbounded lifetimes
- [ ] `validate_media_token` checks both `iss` and `aud`
- [ ] Revoked participants are blocked from token re-issuance within the TTL window

---

## Tests

- [ ] `cargo test -p wavis-backend` passes
- [ ] New property tests added for any new correctness properties
- [ ] No tests were deleted or disabled to make the build pass
