### PR TITLE
test(harnesses): wave 5 backlog (stress config + gui-surface-test runner/results)

### DIFF
--- a/.github/workflows/workspace-ci.yml
+++ b/.github/workflows/workspace-ci.yml
@@ -7,6 +7,7 @@ on:
       - 'wavis-backend/**'
       - 'shared/**'
       - 'clients/**'
+      - 'tools/**'
       - '.github/workflows/workspace-ci.yml'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -15,6 +16,7 @@ on:
       - 'wavis-backend/**'
       - 'shared/**'
       - 'clients/**'
+      - 'tools/**'
       - '.github/workflows/workspace-ci.yml'
       - 'Cargo.toml'
       - 'Cargo.lock'
@@ -61,6 +63,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       shared: ${{ steps.filter.outputs.shared }}
       clients: ${{ steps.filter.outputs.clients }}
+      tools: ${{ steps.filter.outputs.tools }}
       gui: ${{ steps.filter.outputs.gui }}
       tauri: ${{ steps.filter.outputs.tauri }}
       cargo-root: ${{ steps.filter.outputs.cargo-root }}
@@ -95,6 +98,13 @@ jobs:
             clients:
               - 'clients/**'
               - '!clients/wavis-gui/**'
+            # tools/stress (stress-harness) and tools/gui-surface-test are
+            # workspace members compiled/tested via $CI_PACKAGES but had no
+            # path filter of their own, so PRs touching only tools/** never
+            # triggered this workflow at all — silent phantom coverage at
+            # the trigger level, not just the feature-gate level (see P0-1).
+            tools:
+              - 'tools/**'
             gui:
               - 'clients/wavis-gui/**'
             tauri:
@@ -203,6 +213,7 @@ jobs:
       needs.changes.outputs.backend == 'true' ||
       needs.changes.outputs.shared == 'true' ||
       needs.changes.outputs.clients == 'true' ||
+      needs.changes.outputs.tools == 'true' ||
       needs.changes.outputs.cargo-root == 'true'
 
     steps:
@@ -265,7 +276,11 @@ jobs:
 
       # cargo test builds implicitly — no separate cargo build step needed.
       - name: Full workspace tests
-        if: github.ref == 'refs/heads/main' || needs.changes.outputs.core == 'true' || needs.changes.outputs.shared == 'true'
+        if: >-
+          github.ref == 'refs/heads/main' ||
+          needs.changes.outputs.core == 'true' ||
+          needs.changes.outputs.shared == 'true' ||
+          needs.changes.outputs.tools == 'true'
         run: cargo test $CI_PACKAGES
 
       # Backend changed in a path no granular bucket covers (chat, diagnostics,

--- a/tools/gui-surface-test/src/main.rs
+++ b/tools/gui-surface-test/src/main.rs
@@ -78,16 +78,7 @@ async fn main() {
 }
 
 fn print_summary(results: &[crate::results::ScenarioResult]) {
-    let mut passed = 0usize;
-    let mut failed = 0usize;
-
-    for r in results {
-        if r.passed {
-            passed += 1;
-        } else {
-            failed += 1;
-        }
-    }
+    let summary = crate::results::summarize(results);
 
     println!("\n══════════════════════════════════════════════════════════════");
     println!("  Wavis GUI Surface Test — Final Report");
@@ -111,14 +102,15 @@ fn print_summary(results: &[crate::results::ScenarioResult]) {
     println!("──────────────────────────────────────────────────────────────");
     println!(
         "  Results:  {} passed  |  {} failed  |  {} total",
-        passed,
-        failed,
-        results.len(),
+        summary.passed, summary.failed, summary.total,
     );
     println!("──────────────────────────────────────────────────────────────");
 
-    if failed > 0 {
-        println!("\n  ✗ {} scenario(s) FAILED — see failures above.", failed);
+    if summary.should_exit_nonzero() {
+        println!(
+            "\n  ✗ {} scenario(s) FAILED — see failures above.",
+            summary.failed
+        );
         std::process::exit(1);
     } else {
         println!("\n  ✓ All scenarios passed.");

--- a/tools/gui-surface-test/src/results.rs
+++ b/tools/gui-surface-test/src/results.rs
@@ -14,3 +14,84 @@ pub struct ScenarioResult {
     pub duration: Duration,
     pub failures: Vec<AssertionFailure>,
 }
+
+/// Aggregate pass/fail counts across a full run's results.
+///
+/// Extracted out of `main::print_summary` (which also calls
+/// `std::process::exit`, making the counting logic itself untestable in
+/// place) so the pass/fail arithmetic and the process-exit decision it
+/// drives can be verified independently of terminating the process.
+pub struct RunSummary {
+    pub passed: usize,
+    pub failed: usize,
+    pub total: usize,
+}
+
+impl RunSummary {
+    pub fn should_exit_nonzero(&self) -> bool {
+        self.failed > 0
+    }
+}
+
+pub fn summarize(results: &[ScenarioResult]) -> RunSummary {
+    let passed = results.iter().filter(|r| r.passed).count();
+    let failed = results.len() - passed;
+    RunSummary {
+        passed,
+        failed,
+        total: results.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn result(name: &str, passed: bool) -> ScenarioResult {
+        ScenarioResult {
+            name: name.to_string(),
+            passed,
+            duration: Duration::from_millis(0),
+            failures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn empty_results_summarize_to_all_zero_and_do_not_fail_the_run() {
+        let summary = summarize(&[]);
+        assert_eq!(summary.passed, 0);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.total, 0);
+        assert!(!summary.should_exit_nonzero());
+    }
+
+    #[test]
+    fn all_passed_counts_correctly_and_does_not_fail_the_run() {
+        let results = vec![result("a", true), result("b", true), result("c", true)];
+        let summary = summarize(&results);
+        assert_eq!(summary.passed, 3);
+        assert_eq!(summary.failed, 0);
+        assert_eq!(summary.total, 3);
+        assert!(!summary.should_exit_nonzero());
+    }
+
+    #[test]
+    fn a_single_failure_among_passes_is_counted_and_fails_the_run() {
+        let results = vec![result("a", true), result("b", false), result("c", true)];
+        let summary = summarize(&results);
+        assert_eq!(summary.passed, 2);
+        assert_eq!(summary.failed, 1);
+        assert_eq!(summary.total, 3);
+        assert!(summary.should_exit_nonzero());
+    }
+
+    #[test]
+    fn all_failed_counts_correctly_and_fails_the_run() {
+        let results = vec![result("a", false), result("b", false)];
+        let summary = summarize(&results);
+        assert_eq!(summary.passed, 0);
+        assert_eq!(summary.failed, 2);
+        assert_eq!(summary.total, 2);
+        assert!(summary.should_exit_nonzero());
+    }
+}

--- a/tools/gui-surface-test/src/runner.rs
+++ b/tools/gui-surface-test/src/runner.rs
@@ -79,3 +79,87 @@ impl ScenarioRunner {
         results
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use super::*;
+    use crate::results::AssertionFailure;
+
+    /// Records its own name into a shared log when run, so tests can assert
+    /// both "did every scenario execute" and "in what order".
+    struct RecordingScenario {
+        name: String,
+        invocations: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl Scenario for RecordingScenario {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn run(&self, _ctx: &TestContext) -> ScenarioResult {
+            self.invocations.lock().unwrap().push(self.name.clone());
+            ScenarioResult {
+                name: self.name.clone(),
+                passed: true,
+                duration: Duration::from_millis(0),
+                failures: Vec::<AssertionFailure>::new(),
+            }
+        }
+    }
+
+    /// A TestContext whose base_url nothing listens on, so reset_rate_limits'
+    /// internal HTTP call always hits a connection error — reset_rate_limits
+    /// swallows that (it returns `()`, not a `Result`), so this exercises the
+    /// real failure path without needing a mock server or a production seam.
+    fn unreachable_ctx() -> TestContext {
+        TestContext {
+            base_url: "http://127.0.0.1:1".to_string(),
+            metrics_token: "unused".to_string(),
+            http_client: reqwest::Client::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_all_executes_every_scenario_in_order_even_when_reset_rate_limits_fails() {
+        let invocations = Arc::new(Mutex::new(Vec::new()));
+        let scenarios: Vec<Box<dyn Scenario>> = vec![
+            Box::new(RecordingScenario {
+                name: "scenario-a".to_string(),
+                invocations: invocations.clone(),
+            }),
+            Box::new(RecordingScenario {
+                name: "scenario-b".to_string(),
+                invocations: invocations.clone(),
+            }),
+        ];
+        let runner = ScenarioRunner::new(scenarios);
+        let ctx = unreachable_ctx();
+
+        let results = runner.run_all(&ctx).await;
+
+        assert_eq!(results.len(), 2, "both scenarios must produce a result");
+        assert_eq!(results[0].name, "scenario-a");
+        assert_eq!(results[1].name, "scenario-b");
+        assert_eq!(
+            *invocations.lock().unwrap(),
+            vec!["scenario-a".to_string(), "scenario-b".to_string()],
+            "both scenarios must actually run, in registration order, despite \
+             every reset_rate_limits call failing"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_all_returns_empty_for_no_scenarios_without_calling_reset() {
+        let runner = ScenarioRunner::new(Vec::new());
+        let ctx = unreachable_ctx();
+
+        let results = runner.run_all(&ctx).await;
+
+        assert!(results.is_empty());
+    }
+}

--- a/tools/stress/src/config.rs
+++ b/tools/stress/src/config.rs
@@ -81,6 +81,92 @@ impl ScaleConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_all_dimensions_positive(cfg: &ScaleConfig) {
+        assert!(cfg.concurrent_clients > 0, "concurrent_clients must be > 0");
+        assert!(cfg.actions_per_client > 0, "actions_per_client must be > 0");
+        assert!(cfg.total_actions > 0, "total_actions must be > 0");
+        assert!(
+            cfg.rss_growth_threshold_pct > 0.0,
+            "rss_growth_threshold_pct must be > 0"
+        );
+        assert!(
+            cfg.cpu_spike_threshold_x > 0.0,
+            "cpu_spike_threshold_x must be > 0"
+        );
+        assert!(
+            cfg.cpu_spike_max_duration_secs > 0,
+            "cpu_spike_max_duration_secs must be > 0"
+        );
+        assert!(cfg.repetitions > 0, "repetitions must be > 0");
+        assert!(cfg.thresholds.join_p95 > Duration::ZERO);
+        assert!(cfg.thresholds.join_p99 > Duration::ZERO);
+        assert!(cfg.thresholds.message_p95 > Duration::ZERO);
+        assert!(cfg.thresholds.message_p99 > Duration::ZERO);
+        assert!(cfg.thresholds.flood_healthy_p95 > Duration::ZERO);
+    }
+
+    #[test]
+    fn ci_dimensions_are_all_positive() {
+        assert_all_dimensions_positive(&ScaleConfig::ci());
+    }
+
+    #[test]
+    fn local_dimensions_are_all_positive() {
+        assert_all_dimensions_positive(&ScaleConfig::local());
+    }
+
+    #[test]
+    fn p99_latency_is_never_tighter_than_p95() {
+        for cfg in [ScaleConfig::ci(), ScaleConfig::local()] {
+            assert!(cfg.thresholds.join_p99 >= cfg.thresholds.join_p95);
+            assert!(cfg.thresholds.message_p99 >= cfg.thresholds.message_p95);
+        }
+    }
+
+    /// local() is meant to be a strictly larger run than ci() in every scaled
+    /// dimension — a local run that's smaller than what CI does would defeat
+    /// the point of "thorough local validation".
+    #[test]
+    fn local_scales_up_from_ci_in_every_client_load_dimension() {
+        let ci = ScaleConfig::ci();
+        let local = ScaleConfig::local();
+
+        assert!(local.concurrent_clients >= ci.concurrent_clients);
+        assert!(local.actions_per_client >= ci.actions_per_client);
+        assert!(local.total_actions >= ci.total_actions);
+        assert!(local.repetitions >= ci.repetitions);
+    }
+
+    /// Non-scaling fields (RSS/CPU thresholds, latency budgets) are inherited
+    /// verbatim from ci() via `..Self::ci()` — local() doesn't independently
+    /// tune them. This pins that intent so a future edit that accidentally
+    /// diverges them gets a visible test failure instead of silent drift.
+    #[test]
+    fn local_inherits_non_scaling_thresholds_from_ci() {
+        let ci = ScaleConfig::ci();
+        let local = ScaleConfig::local();
+
+        assert_eq!(local.rss_growth_threshold_pct, ci.rss_growth_threshold_pct);
+        assert_eq!(local.cpu_spike_threshold_x, ci.cpu_spike_threshold_x);
+        assert_eq!(
+            local.cpu_spike_max_duration_secs,
+            ci.cpu_spike_max_duration_secs
+        );
+        assert_eq!(local.thresholds.join_p95, ci.thresholds.join_p95);
+        assert_eq!(local.thresholds.join_p99, ci.thresholds.join_p99);
+        assert_eq!(local.thresholds.message_p95, ci.thresholds.message_p95);
+        assert_eq!(local.thresholds.message_p99, ci.thresholds.message_p99);
+        assert_eq!(
+            local.thresholds.flood_healthy_p95,
+            ci.thresholds.flood_healthy_p95
+        );
+    }
+}
+
 /// Backend capabilities that may or may not be available depending on build configuration.
 /// Scenarios declare which capabilities they require; missing ones cause the scenario to be
 /// skipped rather than failed.


### PR DESCRIPTION
## Summary

Wave 5 of the combined test-audit backlog (see `Documents/Wavis/auditoria-pruebas-2026-07-15.md`). Waves 0-4 are open as drafts against `pre-dev` (#295, #296, #302, #304, #307); this wave is independent (only `tools/stress` and `tools/gui-surface-test`, no overlap).

- **`tools/stress/src/config.rs`** — `ScaleConfig::ci()`/`local()` had zero tests. Added: every numeric dimension is positive; `local()` scales up from `ci()` in every client-load dimension (concurrent_clients, actions_per_client, total_actions, repetitions — never smaller, which would defeat "thorough local validation"); non-scaling fields (RSS/CPU/latency thresholds) are pinned as inherited verbatim via `..Self::ci()`; p99 latency budgets are never tighter than p95.

  **Found, not fixed:** grepped every scenario file — `total_actions` and `actions_per_client` are declared on `ScaleConfig` but never actually read anywhere (only `concurrent_clients`, `repetitions`, and `thresholds` are consumed). `local()`'s `total_actions: 20000` doesn't match `concurrent_clients * actions_per_client` (1000 × 200 = 200,000), unlike `ci()` where it does (100 × 50 = 5,000). I did not add a product-consistency test since that would assert a false premise, and didn't "fix" the value either since the field is inert (harmless dead config, not a bug affecting any current test run) — flagging here rather than silently changing behavior nobody asked to change.

- **`tools/gui-surface-test/src/runner.rs`** — `reset_rate_limits` already swallows HTTP failures (returns `()`, not a `Result`), so `run_all` structurally cannot stop early because of a reset failure. No production seam was needed to test this: a `TestContext` pointed at an unreachable address (`http://127.0.0.1:1`, fails fast via connection-refused, no mock server needed) plus two recording fake `Scenario` impls prove every scenario still runs, in registration order, regardless.

- **`tools/gui-surface-test/src/results.rs`** — pure data, nothing to unit test directly (per the plan's own "ambiguous in recon" note). The real untested logic — pass/fail counting and the exit-code decision — lived inline in `main.rs`'s `print_summary`, which also calls `std::process::exit`, making it untestable in place (would kill the test process). Extracted into `results::summarize()` + `RunSummary::should_exit_nonzero()`, wired `print_summary` to use it for both the printed counts and the exit decision.

Every new assertion was verified against an injected regression first (loop stopping after one scenario in `run_all`, `should_exit_nonzero` hardcoded to `false`) and confirmed to fail before being reverted — see commit message for exact failures observed.

## Bonus finding: `tools/**` never triggered this workflow at all

While validating this PR, its own CI came back with only 2 unrelated checks (gitleaks, enforce-hierarchy) — `workspace-ci.yml` hadn't run at all. Root cause, two layers: (1) the workflow's top-level `on.push.paths`/`on.pull_request.paths` never listed `tools/**`, so the workflow never even started for a tools-only change; (2) even if it had, the `rust-test` job and its "Full workspace tests" step (which already runs `cargo test -p stress-harness -p gui-surface-test` as part of `$CI_PACKAGES`) were gated on backend/shared/clients/cargo-root only — no `tools` bucket existed in the change-detection filter.

Net effect: these two crates' tests (50 pre-existing + 6 new here) have likely never run against a tools-only PR — same class of finding as P0-1 (CI phantom coverage) from the original audit, one level up the stack (missing trigger path, not a missing feature flag). Fixed in the second commit: added `tools/**` to both trigger path lists, a new `tools` filter/output, and included it in both the job-level and step-level `if` conditions. Verified live on this exact PR — pushing that fix (itself a change to `.github/workflows/workspace-ci.yml`, already in the file's own trigger list) caused the workflow to run for the first time on this PR, with "Full workspace tests" passing and all the backend-specific targeted steps correctly staying skipped (only `tools/**` changed).

## Test plan

- [x] `cargo test -p stress-harness` — 55/55 passing (5 new + 50 pre-existing)
- [x] `cargo test -p gui-surface-test` — 6/6 passing (all new; crate had zero tests before)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p stress-harness -p gui-surface-test --all-targets -- -D warnings` — clean
- [x] `node scripts/arch-check.mjs` — OK
- [x] Fail-before-pass demonstrated for the `run_all` continuation test and the `RunSummary::should_exit_nonzero` test
- [x] CI's own "Rust tests (workspace)" job now runs and passes on this PR (previously didn't run at all) — verified live via `gh run watch`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_013yWhb4z9bXJS9azZoERxEm