### PR TITLE
fix: play disconnect sound on server-down/500/400 and LiveKit-only disconnects

### DIFF
--- a/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
@@ -602,3 +602,34 @@ export async function clearNetworkConditions() {
     // No qdisc present — already clear.
   }
 }
+
+/* ─── Backend outage simulation (wavis-backend container) ──────────────
+ * Unlike the netem helpers above (which degrade the LiveKit media leg),
+ * this fully stops the signaling/REST backend to simulate a real "server
+ * down" outage — used by zz-disconnect-sound.spec.mjs. `docker stop` (not
+ * `pause`) is deliberate: `pause` freezes the process via the cgroup
+ * freezer but leaves existing sockets open and silent, so the GUI's
+ * WebSocket would never see a close event and could hang far longer than
+ * intended; `stop` tears the process down, so the OS immediately refuses/
+ * resets connections the way a genuinely dead backend would.
+ */
+const BACKEND_CONTAINER = 'wavis-backend';
+
+/** Stops the backend container. */
+export async function stopBackendContainer() {
+  await execFileAsync('docker', ['stop', BACKEND_CONTAINER]);
+}
+
+/**
+ * Restarts the backend container and waits for /health to respond again.
+ * Safe to call unconditionally (e.g. in a finally) — `docker start` on an
+ * already-running container is a no-op.
+ */
+export async function startBackendContainer(healthTimeoutMs = 30_000) {
+  try {
+    await execFileAsync('docker', ['start', BACKEND_CONTAINER]);
+  } catch {
+    // Already running.
+  }
+  await waitForBackendHealth(healthTimeoutMs);
+}

--- a/clients/wavis-gui/e2e-tooling/tests/zz-disconnect-sound.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/zz-disconnect-sound.spec.mjs
@@ -27,6 +27,7 @@ import {
   leaveRoomIfActive,
   stopBackendContainer,
   startBackendContainer,
+  visibleText,
 } from './live-backend-helpers.mjs';
 
 test('a real backend outage plays the disconnect sound once the reconnect budget is exhausted', async ({
@@ -57,7 +58,7 @@ test('a real backend outage plays the disconnect sound once the reconnect budget
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  await expect(main.getByText('LIVE', { exact: true })).toBeVisible();
+  await expect(visibleText(main, 'LIVE')).toBeVisible();
 
   try {
     await stopBackendContainer();
@@ -76,7 +77,7 @@ test('a real backend outage plays the disconnect sound once the reconnect budget
       })
       .toBe(true);
 
-    await expect(main.getByText('Connection lost', { exact: true })).toBeVisible();
+    await expect(visibleText(main, 'Connection lost')).toBeVisible();
 
     // Exactly one disconnect sound — not one per failed reconnect attempt.
     expect(soundRequests.filter((url) => url.includes('leave'))).toHaveLength(1);
@@ -86,7 +87,7 @@ test('a real backend outage plays the disconnect sound once the reconnect budget
     // input to send /leave through), but it renders its own /leave button —
     // use that instead of leaveRoomIfActive's CLI-command path so the
     // session doesn't restore mid-room for the next spec run.
-    const leaveButton = main.getByText('/leave', { exact: true });
+    const leaveButton = visibleText(main, '/leave');
     if (await leaveButton.isVisible().catch(() => false)) {
       await leaveButton.click();
     }

--- a/clients/wavis-gui/e2e-tooling/tests/zz-disconnect-sound.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/zz-disconnect-sound.spec.mjs
@@ -1,0 +1,95 @@
+// Live-backend proof for issue #200: the local disconnect sound
+// ('leave.mp3') must fire for the person actually disconnecting on a real
+// "server down" outage, not just on a voluntary leave/kick/session-displace.
+//
+// Named zz- (same convention as zz-network-quality.spec.mjs) so it runs
+// last in the suite's alphabetical single-worker order — it fully stops
+// the shared backend container for several minutes, which would break any
+// other spec running concurrently or afterward if the restart step failed.
+//
+// Real timing, not shortened: websocket.ts's reconnect budget is
+// maxReconnectAttempt=10 with exponential backoff capped at 30s (~181s
+// worst case) before reconnectExhausted flips true, plus one periodic-retry
+// attempt (up to 30s more) before voice-room.ts's give-up branch actually
+// fires — there is no test-only override for this today (see the fix's
+// commit history: an earlier, faster-looking version of this logic was
+// itself a bug). This spec waits out the real budget rather than risk
+// re-introducing that bug via a shortcut.
+import { test, expect } from '../fixtures.mjs';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  seedChannelWithInvite,
+  registerAndLoginViaUi,
+  joinChannelViaUi,
+  enterChannelRoom,
+  joinDefaultSubRoomViaUi,
+  leaveRoomIfActive,
+  stopBackendContainer,
+  startBackendContainer,
+} from './live-backend-helpers.mjs';
+
+test('a real backend outage plays the disconnect sound once the reconnect budget is exhausted', async ({
+  app,
+}) => {
+  test.setTimeout(360_000);
+
+  await waitForBackendHealth();
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-disconnect-sound-${suffix}`;
+  const { invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  await leaveRoomIfActive(main);
+  const pathname = new URL(main.url()).pathname;
+  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
+  }
+
+  const soundRequests = [];
+  main.on('request', (req) => {
+    const url = req.url();
+    if (url.includes('/sounds/')) soundRequests.push(url);
+  });
+
+  await joinChannelViaUi(main, invite.code);
+  await enterChannelRoom(main, channelName);
+  await joinDefaultSubRoomViaUi(main);
+
+  await expect(main.getByText('LIVE', { exact: true })).toBeVisible();
+
+  try {
+    await stopBackendContainer();
+
+    // The disconnect sound is a real Web Audio fetch()+decodeAudioData()
+    // call (see notification-sounds.ts) — there is no product-side test
+    // hook for "a sound played" (unlike __wavisVoiceStats), so this
+    // observes the same /sounds/leave.mp3 fetch the manual live-proof run
+    // did, via Playwright's own request log.
+    await expect
+      .poll(() => soundRequests.some((url) => url.includes('leave')), {
+        timeout: 330_000,
+        intervals: [5_000],
+        message:
+          'expected /sounds/leave.mp3 to be fetched once the WS reconnect-give-up path fires',
+      })
+      .toBe(true);
+
+    await expect(main.getByText('Connection lost', { exact: true })).toBeVisible();
+
+    // Exactly one disconnect sound — not one per failed reconnect attempt.
+    expect(soundRequests.filter((url) => url.includes('leave'))).toHaveLength(1);
+  } finally {
+    await startBackendContainer();
+    // The "Connection lost" screen replaces the normal room UI (no CLI
+    // input to send /leave through), but it renders its own /leave button —
+    // use that instead of leaveRoomIfActive's CLI-command path so the
+    // session doesn't restore mid-room for the next spec run.
+    const leaveButton = main.getByText('/leave', { exact: true });
+    if (await leaveButton.isVisible().catch(() => false)) {
+      await leaveButton.click();
+    }
+    await leaveRoomIfActive(main);
+  }
+});

--- a/clients/wavis-gui/e2e-tooling/tests/zz-disconnect-sound.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/zz-disconnect-sound.spec.mjs
@@ -15,7 +15,7 @@
 // commit history: an earlier, faster-looking version of this logic was
 // itself a bug). This spec waits out the real budget rather than risk
 // re-introducing that bug via a shortcut.
-import { test, expect } from '../fixtures.mjs';
+import { test, expect } from './fixtures.mjs';
 import {
   SERVER_URL,
   waitForBackendHealth,

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -1681,14 +1681,34 @@ describe('VoiceRoom room-scoped join/leave sounds', () => {
 
     if (lastSignalingClient) {
       lastSignalingClient.status = 'disconnected';
-      lastSignalingClient.reconnectTimer = null;
-      lastSignalingClient.periodicRetryTimer = null;
+      lastSignalingClient.reconnectExhausted = true;
     }
     statusChangeHandler!('disconnected');
     await tick();
 
     expect(playNotificationSoundCalls).toEqual(['leave']);
     expect(getState().machineState).toBe('idle');
+  });
+
+  it('does not give up while a reconnect is merely pending between attempts (reconnectExhausted still false)', async () => {
+    await driveToActive('ch-sounds', 'room-sounds', false);
+
+    statusChangeHandler!('disconnected');
+    await tick();
+    expect(getState().machineState).toBe('reconnecting');
+
+    // A real SignalingClient's reconnectTimer is transiently null between one
+    // failed attempt and the next being scheduled — that alone must NOT be
+    // read as "exhausted" (see websocket.ts's reconnectExhausted flag).
+    if (lastSignalingClient) {
+      lastSignalingClient.status = 'disconnected';
+      lastSignalingClient.reconnectExhausted = false;
+    }
+    statusChangeHandler!('disconnected');
+    await tick();
+
+    expect(playNotificationSoundCalls).toEqual([]);
+    expect(getState().machineState).toBe('reconnecting');
   });
 
   it('does not play leave sound for initial connection failure before room membership', async () => {

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -2738,6 +2738,56 @@ describe('Edge case unit tests', () => {
 
       leaveRoom();
     });
+
+    it('plays one leave sound when media_token arrives while retries are already exhausted, even though signaling stays active', async () => {
+      resetAll();
+      mockMaxRetries = 1; // exhaust after 1 failure
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      lastLkModule!.callbacks.onMediaFailed('test failure');
+      await tick();
+
+      expect(latestState!.mediaReconnectFailures).toBe(1);
+      expect(latestState!.mediaState).toBe('failed');
+      // Not yet — onMediaFailed alone only marks the media state as failed.
+      expect(playNotificationSoundCalls).toEqual([]);
+
+      // Backend pushes a fresh media_token, but the retry budget is spent —
+      // this is a pure LiveKit/media-layer give-up: the WS signaling session
+      // (machineState) is never touched, so nothing else would ever play
+      // the disconnect sound for this scenario.
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu2', token: 'tok2' });
+      await tick();
+      await tick(); // extra tick for async getReconnectConfig
+
+      expect(getState().machineState).toBe('active');
+      expect(playNotificationSoundCalls).toEqual(['leave']);
+
+      leaveRoom();
+    });
+
+    it('plays one leave sound when reconnectMedia() itself exhausts the retry budget', async () => {
+      resetAll();
+      mockMaxRetries = 1; // exhaust after 1 failure
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      lastLkModule!.callbacks.onMediaFailed('test failure');
+      await tick();
+
+      expect(latestState!.mediaReconnectFailures).toBe(1);
+      expect(playNotificationSoundCalls).toEqual([]);
+
+      await reconnectMedia();
+
+      expect(getState().machineState).toBe('active');
+      expect(playNotificationSoundCalls).toEqual(['leave']);
+
+      leaveRoom();
+    });
   });
 
   // ─── 11.2: Screen share edge cases ──────────────────────────────

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-media.test.ts
@@ -2810,6 +2810,100 @@ describe('Edge case unit tests', () => {
     });
   });
 
+  describe('11.1b: media_token request timeout (no response from backend)', () => {
+    it('retries reconnectMedia when no media_token ever arrives for a pending request', async () => {
+      resetAll();
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      lastLkModule!.callbacks.onMediaConnected();
+      await tick();
+
+      sentMessages = [];
+      vi.useFakeTimers();
+      try {
+        lastLkModule!.callbacks.onMediaDisconnected();
+        await vi.advanceTimersByTimeAsync(0); // flush reconnectMedia()'s awaited getReconnectConfig()
+
+        expect(sentMessages.filter((m) => m.type === 'join_voice')).toHaveLength(1);
+        expect(latestState!.mediaReconnectFailures).toBe(0);
+
+        // No media_token ever arrives — advance past the request timeout.
+        await vi.advanceTimersByTimeAsync(15_100);
+
+        expect(latestState!.mediaReconnectFailures).toBe(1);
+        expect(sentMessages.filter((m) => m.type === 'join_voice')).toHaveLength(2);
+      } finally {
+        vi.useRealTimers();
+        leaveRoom();
+      }
+    });
+
+    it('eventually plays the disconnect sound if media_token requests keep timing out', async () => {
+      resetAll();
+      mockMaxRetries = 1;
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      lastLkModule!.callbacks.onMediaConnected();
+      await tick();
+
+      playNotificationSoundCalls = [];
+      vi.useFakeTimers();
+      try {
+        lastLkModule!.callbacks.onMediaDisconnected();
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(playNotificationSoundCalls).toEqual([]);
+
+        // The one retry attempt the exhausted budget (mockMaxRetries=1)
+        // allows also never gets a response — the timeout handler's own
+        // reconnectMedia() call hits the exhausted branch directly.
+        await vi.advanceTimersByTimeAsync(15_100);
+
+        expect(getState().mediaState).toBe('failed');
+        expect(playNotificationSoundCalls).toEqual(['leave']);
+      } finally {
+        vi.useRealTimers();
+        leaveRoom();
+      }
+    });
+
+    it('a media_token that arrives in time clears the pending timeout (no spurious retry)', async () => {
+      resetAll();
+      await driveToActive();
+
+      messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu', token: 'tok' });
+      await tick();
+      lastLkModule!.callbacks.onMediaConnected();
+      await tick();
+
+      sentMessages = [];
+      vi.useFakeTimers();
+      try {
+        lastLkModule!.callbacks.onMediaDisconnected();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(sentMessages.filter((m) => m.type === 'join_voice')).toHaveLength(1);
+
+        // Backend responds well within the timeout window.
+        messageHandler!({ type: 'media_token', sfuUrl: 'wss://sfu2', token: 'tok2' });
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Advancing past where the (now-cleared) timeout would have fired
+        // must NOT trigger a spurious extra retry or failure count.
+        await vi.advanceTimersByTimeAsync(15_100);
+
+        expect(latestState!.mediaReconnectFailures).toBe(0);
+        expect(sentMessages.filter((m) => m.type === 'join_voice')).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+        leaveRoom();
+      }
+    });
+  });
+
   // ─── 11.2: Screen share edge cases ──────────────────────────────
 
   describe('11.2: Screen share edge cases', () => {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -1407,6 +1407,16 @@ const PERIODIC_MEDIA_RETRY_MS = 30_000;
 let periodicMediaRetryTimer: ReturnType<typeof setInterval> | null = null;
 const COLD_START_RETRY_MS = 30_000;
 let coldStartRetryTimer: ReturnType<typeof setTimeout> | null = null;
+/**
+ * sendJoinVoiceRequest() is fire-and-forget — it has no built-in way to
+ * notice a response never arrives (e.g. the backend can't reach its own
+ * SFU dependency and never replies with media_token). Without this guard,
+ * mediaReconnectFailures never increments past its current value and
+ * reconnectMedia()'s retry-budget check never gets a second attempt to
+ * run, let alone exhaust — media sits in 'disconnected' silently forever.
+ */
+const MEDIA_TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+let mediaTokenRequestTimer: ReturnType<typeof setTimeout> | null = null;
 let backgroundLeaveTimer: ReturnType<typeof setTimeout> | null = null;
 const MAX_AUTH_REFRESH_RETRIES = 2;
 let authRefreshRetries = 0;
@@ -1699,6 +1709,7 @@ function cleanupPublishedMediaForSessionEnd(): void {
   pendingWasapiResume = null;
   stopColdStartRetry();
   stopPeriodicMediaRetry();
+  clearMediaTokenRequestTimeout();
   setActiveLiveKitModule(null);
 }
 
@@ -2434,6 +2445,37 @@ function stopColdStartRetry(): void {
   }
 }
 
+function clearMediaTokenRequestTimeout(): void {
+  if (mediaTokenRequestTimer) {
+    clearTimeout(mediaTokenRequestTimer);
+    mediaTokenRequestTimer = null;
+  }
+}
+
+/**
+ * Starts (restarts) the "did the backend ever answer our join_voice" guard.
+ * Call this right after sendJoinVoiceRequest(). If no media_token arrives
+ * before this fires, the attempt counts as failed and reconnectMedia() runs
+ * again — same retry budget/give-up path as an explicit onMediaFailed.
+ */
+function scheduleMediaTokenRequestTimeout(): void {
+  clearMediaTokenRequestTimeout();
+  mediaTokenRequestTimer = setTimeout(() => {
+    mediaTokenRequestTimer = null;
+    if (state.machineState === 'idle') return;
+    console.warn(LOG, 'media_token request timed out — no response from backend');
+    state.mediaReconnectFailures += 1;
+    appendEvent({
+      id: makeEventId(),
+      timestamp: timestamp(),
+      type: 'system',
+      message: 'media reconnect timed out waiting for a fresh media token',
+    });
+    notify();
+    void reconnectMedia();
+  }, MEDIA_TOKEN_REQUEST_TIMEOUT_MS);
+}
+
 function clearBackgroundLeaveTimer(): void {
   if (backgroundLeaveTimer) {
     clearTimeout(backgroundLeaveTimer);
@@ -2493,6 +2535,7 @@ function connectMedia(
     state.mediaError = null;
     state.mediaReconnectFailures = 0;
     stopPeriodicMediaRetry();
+    clearMediaTokenRequestTimeout();
     const self = selfParticipant();
     if (self) {
       markParticipantMediaConnected(self.id, true, { playJoinSound: options.playJoinSound });
@@ -4022,6 +4065,10 @@ function dispatchMessage(raw: unknown): void {
     }
 
     case 'media_token': {
+      // The backend answered our join_voice request (whatever the payload
+      // turns out to contain below) — the "did it ever respond" guard no
+      // longer applies to this attempt.
+      clearMediaTokenRequestTimeout();
       const token = msg.token;
       const sfuUrl = msg.sfuUrl;
       // ice_config lives on the Joined payload, not MediaToken — fall back to what was stored from 'joined'.
@@ -4623,6 +4670,7 @@ export async function reconnectMedia(): Promise<void> {
 
   // Re-send JoinVoice to request new media_token
   sendJoinVoiceRequest();
+  scheduleMediaTokenRequestTimeout();
 }
 
 export function resetMediaReconnectFailures(): void {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -4304,14 +4304,12 @@ export function initSession(
         notify();
       } else if (state.machineState === 'reconnecting') {
         // Already reconnecting and got another disconnect.
-        // Only give up if the WS has exhausted all reconnect attempts
-        // (both fast retries and periodic retry).
-        if (
-          client &&
-          client.status === 'disconnected' &&
-          !client['reconnectTimer'] &&
-          !client['periodicRetryTimer']
-        ) {
+        // Only give up once the fast-retry budget is truly spent and a
+        // periodic-retry attempt has also failed — NOT merely "no reconnect
+        // timer is pending right now" (a timer handle is transiently null
+        // between one attempt ending and the next being scheduled, which
+        // would declare defeat after a single failed attempt).
+        if (client && client.status === 'disconnected' && client.reconnectExhausted) {
           // Unregister hotkey when giving up on reconnection (R22.7)
           if (registeredHotkey) {
             unregisterMuteHotkey(registeredHotkey).catch(() => {});

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -4107,6 +4107,7 @@ function dispatchMessage(raw: unknown): void {
               type: 'system',
               message: 'media_token ignored — retries exhausted, periodic retry active',
             });
+            playLocalDisconnectSoundOnce();
             notify();
           }
         });
@@ -4326,6 +4327,8 @@ export function initSession(
           state.lastRateLimitError = null;
           playLocalDisconnectSoundOnce();
           cleanupPublishedMediaForSessionEnd();
+          client.disconnect();
+          client = null;
           state.machineState = 'idle';
           notify();
         }
@@ -4599,6 +4602,7 @@ export async function reconnectMedia(): Promise<void> {
       message: `media reconnect retries exhausted (${config.maxRetries}) — periodic retry active`,
     });
     startPeriodicMediaRetry();
+    playLocalDisconnectSoundOnce();
     notify();
     return;
   }

--- a/clients/wavis-gui/src/shared/__tests__/websocket.test.ts
+++ b/clients/wavis-gui/src/shared/__tests__/websocket.test.ts
@@ -352,21 +352,32 @@ describe('reconnect backoff', () => {
     expect(client['reconnectTimer']).toBeNull();
   });
 
-  it('reconnectTimer and periodicRetryTimer are both falsy in the onStatusChange callback exactly when fast-retry exhausts', async () => {
-    // This is the exact condition voice-room.ts's reconnect-give-up branch
-    // checks (`!client['reconnectTimer'] && !client['periodicRetryTimer']`)
-    // to decide the session is truly lost and play the disconnect sound.
+  it('reconnectExhausted stays false after a single failed reconnect attempt', async () => {
+    // Regression guard: an earlier version of this fix read
+    // `!reconnectTimer && !periodicRetryTimer` as "give up", but a timer
+    // handle is transiently null between one failed attempt ending and the
+    // next being scheduled — that condition is briefly true after the very
+    // FIRST failed attempt too, which would make voice-room.ts announce
+    // "connection lost" after ~1s instead of after the real ~181s+ budget.
     const client = new SignalingClient();
-    const snapshotsAtDisconnect: Array<{ reconnectTimer: unknown; periodicRetryTimer: unknown }> =
-      [];
-    client.onStatusChange((status) => {
-      if (status === 'disconnected') {
-        snapshotsAtDisconnect.push({
-          reconnectTimer: client['reconnectTimer'],
-          periodicRetryTimer: client['periodicRetryTimer'],
-        });
-      }
-    });
+    client.connect('ws://localhost/ws');
+    lastWsInstance!.simulate('open');
+
+    // First disconnect — schedules the first fast-retry attempt.
+    lastWsInstance!.readyState = WebSocket.CLOSED;
+    lastWsInstance!.onclose?.();
+    expect(client.reconnectExhausted).toBe(false);
+
+    // Let that attempt fire and fail (mock WS never opens on its own).
+    await vi.advanceTimersByTimeAsync(1100);
+    lastWsInstance!.readyState = WebSocket.CLOSED;
+    lastWsInstance!.onclose?.();
+
+    expect(client.reconnectExhausted).toBe(false);
+  });
+
+  it('reconnectExhausted becomes true once the fast-retry budget (maxReconnectAttempt) is spent', async () => {
+    const client = new SignalingClient();
     client.connect('ws://localhost/ws');
     lastWsInstance!.simulate('open');
 
@@ -374,17 +385,37 @@ describe('reconnect backoff', () => {
     for (let i = 0; i < 10; i++) {
       lastWsInstance!.readyState = WebSocket.CLOSED;
       lastWsInstance!.onclose?.();
+      expect(client.reconnectExhausted).toBe(false);
       await vi.advanceTimersByTimeAsync(31_000);
     }
 
     // The 11th close exhausts the fast-retry budget and hands off to periodic
-    // retry — this is the "give up" transition.
+    // retry — this is the "give up" transition voice-room.ts relies on.
     lastWsInstance!.readyState = WebSocket.CLOSED;
     lastWsInstance!.onclose?.();
 
-    const giveUpSnapshot = snapshotsAtDisconnect.at(-1)!;
-    expect(giveUpSnapshot.reconnectTimer).toBeFalsy();
-    expect(giveUpSnapshot.periodicRetryTimer).toBeFalsy();
+    expect(client.reconnectExhausted).toBe(true);
+  });
+
+  it('reconnectExhausted resets to false on a successful reconnect', async () => {
+    const client = new SignalingClient();
+    client.connect('ws://localhost/ws');
+    lastWsInstance!.simulate('open');
+
+    for (let i = 0; i < 10; i++) {
+      lastWsInstance!.readyState = WebSocket.CLOSED;
+      lastWsInstance!.onclose?.();
+      await vi.advanceTimersByTimeAsync(31_000);
+    }
+    lastWsInstance!.readyState = WebSocket.CLOSED;
+    lastWsInstance!.onclose?.();
+    expect(client.reconnectExhausted).toBe(true);
+
+    // Periodic retry succeeds.
+    await vi.advanceTimersByTimeAsync(30_000);
+    lastWsInstance!.simulate('open');
+
+    expect(client.reconnectExhausted).toBe(false);
   });
 });
 

--- a/clients/wavis-gui/src/shared/__tests__/websocket.test.ts
+++ b/clients/wavis-gui/src/shared/__tests__/websocket.test.ts
@@ -335,6 +335,57 @@ describe('reconnect backoff', () => {
     await vi.advanceTimersByTimeAsync(1100);
     expect(wsConstructorCalls.length).toBeGreaterThan(prevCount);
   });
+
+  it('clears reconnectTimer once the scheduled reconnect attempt actually fires', async () => {
+    const client = new SignalingClient();
+    client.connect('ws://localhost/ws');
+    lastWsInstance!.simulate('open');
+
+    lastWsInstance!.readyState = WebSocket.CLOSED;
+    lastWsInstance!.onclose?.();
+    expect(client['reconnectTimer']).not.toBeNull();
+
+    // Once the scheduled callback fires, the stale handle must be cleared —
+    // otherwise it stays truthy forever and callers checking "is a reconnect
+    // still pending" can never see it go falsy.
+    await vi.advanceTimersByTimeAsync(1100);
+    expect(client['reconnectTimer']).toBeNull();
+  });
+
+  it('reconnectTimer and periodicRetryTimer are both falsy in the onStatusChange callback exactly when fast-retry exhausts', async () => {
+    // This is the exact condition voice-room.ts's reconnect-give-up branch
+    // checks (`!client['reconnectTimer'] && !client['periodicRetryTimer']`)
+    // to decide the session is truly lost and play the disconnect sound.
+    const client = new SignalingClient();
+    const snapshotsAtDisconnect: Array<{ reconnectTimer: unknown; periodicRetryTimer: unknown }> =
+      [];
+    client.onStatusChange((status) => {
+      if (status === 'disconnected') {
+        snapshotsAtDisconnect.push({
+          reconnectTimer: client['reconnectTimer'],
+          periodicRetryTimer: client['periodicRetryTimer'],
+        });
+      }
+    });
+    client.connect('ws://localhost/ws');
+    lastWsInstance!.simulate('open');
+
+    // Drive through all 10 fast-retry attempts (maxReconnectAttempt).
+    for (let i = 0; i < 10; i++) {
+      lastWsInstance!.readyState = WebSocket.CLOSED;
+      lastWsInstance!.onclose?.();
+      await vi.advanceTimersByTimeAsync(31_000);
+    }
+
+    // The 11th close exhausts the fast-retry budget and hands off to periodic
+    // retry — this is the "give up" transition.
+    lastWsInstance!.readyState = WebSocket.CLOSED;
+    lastWsInstance!.onclose?.();
+
+    const giveUpSnapshot = snapshotsAtDisconnect.at(-1)!;
+    expect(giveUpSnapshot.reconnectTimer).toBeFalsy();
+    expect(giveUpSnapshot.periodicRetryTimer).toBeFalsy();
+  });
 });
 
 // ─── connectWithAuth() ────────────────────────────────────────────
@@ -370,11 +421,29 @@ describe('connectWithAuth()', () => {
     expect(refreshTokens).toHaveBeenCalled();
   });
 
-  it('sets status to disconnected when token refresh fails', async () => {
+  it('sets status to disconnected and throws when refresh returns a 500 server_error', async () => {
+    // refreshTokens() always resolves to a truthy RefreshResult discriminated union —
+    // it never returns a bare falsy value in production (see auth.ts refreshTokens()).
+    // A 500 from POST /auth/refresh surfaces as { status: 'server_error', httpStatus: 500 }.
     const { isTokenExpired, refreshTokens } = await import('@features/auth/auth');
     vi.mocked(isTokenExpired).mockResolvedValueOnce(true);
-    // refreshTokens returns false (falsy) to signal failure
-    vi.mocked(refreshTokens).mockResolvedValueOnce(false as unknown as { status: 'success' });
+    vi.mocked(refreshTokens).mockResolvedValueOnce({ status: 'server_error', httpStatus: 500 });
+
+    const client = new SignalingClient();
+    let threw = false;
+    try {
+      await client.connectWithAuth('ws://localhost/ws');
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    expect(client.status).toBe('disconnected');
+  });
+
+  it('sets status to disconnected and throws when refresh returns a 400 bad_request', async () => {
+    const { isTokenExpired, refreshTokens } = await import('@features/auth/auth');
+    vi.mocked(isTokenExpired).mockResolvedValueOnce(true);
+    vi.mocked(refreshTokens).mockResolvedValueOnce({ status: 'bad_request' });
 
     const client = new SignalingClient();
     let threw = false;

--- a/clients/wavis-gui/src/shared/websocket.ts
+++ b/clients/wavis-gui/src/shared/websocket.ts
@@ -38,6 +38,16 @@ export class SignalingClient {
   private statusChangeHandler: ((status: WsStatus) => void) | null = null;
   private intentionalDisconnect = false;
   status: WsStatus = 'disconnected';
+  /**
+   * True once the fast exponential-backoff reconnect budget
+   * (maxReconnectAttempt) has been spent and periodic retry has taken over.
+   * Callers (voice-room.ts) use this — not "is a reconnect timer currently
+   * pending" — to decide the session is truly lost: a timer handle is
+   * transiently null between one attempt ending and the next being
+   * scheduled, so checking timer nullness alone declares defeat after a
+   * single failed attempt instead of after the real retry budget is spent.
+   */
+  reconnectExhausted = false;
 
   /** Legacy connect — no auth message sent. Preserved for backward compatibility. */
   connect(url: string): void {
@@ -50,6 +60,7 @@ export class SignalingClient {
     this.ws.onopen = () => {
       this.setStatus('connected');
       this.reconnectAttempt = 0;
+      this.reconnectExhausted = false;
       this.stopPeriodicRetry();
     };
 
@@ -101,6 +112,7 @@ export class SignalingClient {
     this.ws.onopen = () => {
       this.setStatus('connected');
       this.reconnectAttempt = 0;
+      this.reconnectExhausted = false;
       this.stopPeriodicRetry();
       // Send Auth message as first message
       this.send({ type: 'auth', accessToken: token });
@@ -151,6 +163,7 @@ export class SignalingClient {
     this.intentionalDisconnect = true;
     if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
     this.reconnectTimer = null;
+    this.reconnectExhausted = false;
     this.stopPeriodicRetry();
     this.ws?.close();
     this.ws = null;
@@ -215,6 +228,7 @@ export class SignalingClient {
   private scheduleReconnect(url: string): void {
     if (this.reconnectAttempt >= this.maxReconnectAttempt) {
       console.log(LOG_PREFIX, 'fast reconnect exhausted — starting periodic retry');
+      this.reconnectExhausted = true;
       this.startPeriodicRetry(url);
       return;
     }

--- a/clients/wavis-gui/src/shared/websocket.ts
+++ b/clients/wavis-gui/src/shared/websocket.ts
@@ -84,10 +84,10 @@ export class SignalingClient {
    */
   async connectWithAuth(wsUrl: string): Promise<void> {
     if (await isTokenExpired()) {
-      const ok = await refreshTokens();
-      if (!ok) {
+      const result = await refreshTokens();
+      if (result.status !== 'success') {
         this.setStatus('disconnected');
-        throw new Error('Token refresh failed — cannot connect');
+        throw new Error(`Token refresh failed — cannot connect (${result.status})`);
       }
     }
 
@@ -221,6 +221,7 @@ export class SignalingClient {
     const delay = Math.min(1000 * 2 ** this.reconnectAttempt, 30_000);
     this.reconnectAttempt++;
     this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
       this.connectWithAuth(url).catch((err) => {
         console.error(LOG_PREFIX, 'Reconnect auth failed:', err);
       });


### PR DESCRIPTION
## Summary

Fixes issue #200 ("Everytime there is any sort of disconnection and even server down or errors 500 or 400 should trigger the disconnect sound to the person who is actually disconnecting"). The disconnect sound already worked for voluntary leave, kicked, session-displaced, and auth failures — this closes the remaining gaps:

- **`websocket.ts` `connectWithAuth()`**: `if (!ok)` checked a `RefreshResult` object for falsiness — it's never falsy, even on `{status:'server_error'}`/`{status:'bad_request'}`. A 500/400 refreshing the token before connecting was silently swallowed instead of aborting the connect attempt.
- **`websocket.ts` `scheduleReconnect()`**: `reconnectTimer` was never cleared when its own `setTimeout` fired, so `voice-room.ts`'s WS give-up check was practically unreachable — a genuinely dead backend left the app silently retrying forever. Replaced the racy timer-nullness inference with an explicit `reconnectExhausted` flag (an earlier version of this fix that inferred exhaustion from timer nullness was itself a bug — caught live, see below).
- **`voice-room.ts`**: the WS give-up branch was missing `client.disconnect()`/`client = null` (present on every other terminal path), leaving a zombie periodic-retry loop after the session was declared lost.
- **`voice-room.ts`**: a pure LiveKit/media-layer disconnect (SFU down, WS stays up) never played the sound even after retries were exhausted — wired `playLocalDisconnectSoundOnce()` into both give-up points.
- **`voice-room.ts` `reconnectMedia()`**: `sendJoinVoiceRequest()` is fire-and-forget with no timeout. If the backend can't reach its own LiveKit dependency and never replies with a fresh `media_token`, the retry loop never got a second iteration — found via a real 10-minute live test where the app hung silently forever. Added a 15s guard timer (mirrors the existing `scheduleColdStartRetry` pattern) so a non-response counts as a failed attempt and retries/exhausts normally.
- **e2e-tooling**: added `zz-disconnect-sound.spec.mjs` (+ `stopBackendContainer()`/`startBackendContainer()` helpers) as a permanent live-backend regression test for the WS/server-down scenario.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 1407/1407 passing (vitest tests for every fix, each shown failing before / passing after)
- [x] `npx playwright test tests/zz-disconnect-sound.spec.mjs` — 1 passed (4.2m), real app + real docker backend
- [x] Live manual proof (real Tauri app, `docker stop wavis-backend`): sound fires at ~238s, "Connection lost" screen renders, backend restored healthy
- [x] Live manual proof (real Tauri app, `docker stop wavis-livekit` only, backend stays up): before the `reconnectMedia()` timeout fix, 10 minutes silent/stuck; after the fix, sound fires at ~229s and UI shows "FAILED — media disconnected — automatic retries exhausted" with `/retry`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01RUUFTRqSEnCfBF3PvSbtJZ