### PR TITLE
fix: skip doomed /rtc/v1 LiveKit join attempt on every connect (#117)

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts
@@ -29,7 +29,9 @@ vi.mock('livekit-client', () => {
       this.state = 'disconnected';
       return Promise.resolve();
     });
-    constructor() {
+    options: Record<string, unknown> | undefined;
+    constructor(options?: Record<string, unknown>) {
+      this.options = options;
       roomState.current = this;
     }
     on(event: string, handler: (...args: unknown[]) => void) {
@@ -204,17 +206,41 @@ describe('pickScreenSharePublication', () => {
   });
 });
 
-/* ─── ViewerRoomConnection.refreshIdentity (Watch All dead-track recovery) ──
- * Regression coverage for #283: a single dead track used to call
- * forceReconnect(), tearing down the whole Room and blacking out every
- * Watch All tile. refreshIdentity resubscribes one identity in place. */
+/* ─── ViewerRoomConnection Room construction options — issue #117 ──
+ * Our self-hosted LiveKit server (pinned to v1.9.3) doesn't serve the SDK's
+ * default /rtc/v1 join path, so every viewer-window connect (Watch All,
+ * screen-share pop-outs) would otherwise pay a guaranteed-fail round trip
+ * before falling back to the legacy path it ends up using anyway. */
 
 interface TestRoom {
   state: string;
   remoteParticipants: Map<string, unknown>;
   disconnect: ReturnType<typeof vi.fn>;
   emit: (event: string, ...args: unknown[]) => void;
+  options?: Record<string, unknown>;
 }
+
+describe('ViewerRoomConnection Room construction', () => {
+  beforeEach(() => {
+    roomState.current = null;
+  });
+
+  it('constructs Room with singlePeerConnection:false', async () => {
+    const conn = new ViewerRoomConnection({ windowLabel: 'watch-all' });
+    conn.watch('alice', () => {});
+    await tick();
+    await tick();
+
+    const room = roomState.current as TestRoom;
+    expect(room).not.toBeNull();
+    expect(room.options?.singlePeerConnection).toBe(false);
+  });
+});
+
+/* ─── ViewerRoomConnection.refreshIdentity (Watch All dead-track recovery) ──
+ * Regression coverage for #283: a single dead track used to call
+ * forceReconnect(), tearing down the whole Room and blacking out every
+ * Watch All tile. refreshIdentity resubscribes one identity in place. */
 
 function tick(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));

--- a/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
+++ b/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
@@ -219,7 +219,11 @@ export class ViewerRoomConnection {
       // (issue #117): our self-hosted LiveKit server doesn't serve the SDK's
       // default /rtc/v1 join path, so every viewer window connect would
       // otherwise pay a guaranteed-fail round trip before falling back.
-      const room = new Room({ adaptiveStream: false, dynacast: false, singlePeerConnection: false });
+      const room = new Room({
+        adaptiveStream: false,
+        dynacast: false,
+        singlePeerConnection: false,
+      });
       this.wireRoomEvents(room);
       this.room = room;
 

--- a/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
+++ b/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
@@ -215,7 +215,11 @@ export class ViewerRoomConnection {
 
       // adaptiveStream off: tiles attach via srcObject, invisible to LiveKit's
       // element observer, and we pin quality explicitly per subscription.
-      const room = new Room({ adaptiveStream: false, dynacast: false });
+      // singlePeerConnection:false — see livekit-media.ts LIVEKIT_ROOM_OPTIONS
+      // (issue #117): our self-hosted LiveKit server doesn't serve the SDK's
+      // default /rtc/v1 join path, so every viewer window connect would
+      // otherwise pay a guaranteed-fail round trip before falling back.
+      const room = new Room({ adaptiveStream: false, dynacast: false, singlePeerConnection: false });
       this.wireRoomEvents(room);
       this.room = room;
 

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -962,8 +962,7 @@ describe('LiveKit Room connect options — issue #117 (v1 RTC path fallback)', (
     expect(LIVEKIT_ROOM_OPTIONS.singlePeerConnection).toBe(false);
     const RoomMock = vi.mocked(Room);
     expect(RoomMock).toHaveBeenCalled();
-    const roomCtorOptions = RoomMock.mock.calls.at(-1)?.[0] as
-      { singlePeerConnection?: boolean } | undefined;
+    const roomCtorOptions = RoomMock.mock.calls.at(-1)?.[0];
     expect(roomCtorOptions?.singlePeerConnection).toBe(false);
 
     mod.disconnect();

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -623,9 +623,11 @@ import {
   isForceRelayEnabled,
   mapPassthroughFilterParams,
   fitPresetToSourceAspect,
+  LIVEKIT_ROOM_OPTIONS,
   type MediaCallbacks,
 } from '../livekit-media';
 import { CAMERA_QUALITY_HIGH } from '../camera-types';
+import { Room } from 'livekit-client';
 
 describe('passthrough filter parameter mapping', () => {
   it('clamps strength and interpolates cutoff and high shelf', () => {
@@ -951,6 +953,23 @@ async function driveToConnected(mod: LiveKitModule, url = 'wss://sfu.test', toke
   await tick();
   emitRoomEvent('localTrackPublished', AUDIO_PUB, mockRoom.localParticipant);
 }
+
+describe('LiveKit Room connect options — issue #117 (v1 RTC path fallback)', () => {
+  it('constructs Room with singlePeerConnection:false so it never attempts the /rtc/v1 join path our self-hosted server (pinned to v1.9.3) 404s on every connect', async () => {
+    const mod = new LiveKitModule(createMockCallbacks());
+    await driveToConnected(mod);
+
+    expect(LIVEKIT_ROOM_OPTIONS.singlePeerConnection).toBe(false);
+    const RoomMock = vi.mocked(Room);
+    expect(RoomMock).toHaveBeenCalled();
+    const roomCtorOptions = RoomMock.mock.calls.at(-1)?.[0] as
+      | { singlePeerConnection?: boolean }
+      | undefined;
+    expect(roomCtorOptions?.singlePeerConnection).toBe(false);
+
+    mod.disconnect();
+  });
+});
 
 describe('camera publish/unpublish', () => {
   it('publishCamera publishes the selected camera with non-simulcast VP8 options', async () => {

--- a/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/livekit-media.test.ts
@@ -963,8 +963,7 @@ describe('LiveKit Room connect options — issue #117 (v1 RTC path fallback)', (
     const RoomMock = vi.mocked(Room);
     expect(RoomMock).toHaveBeenCalled();
     const roomCtorOptions = RoomMock.mock.calls.at(-1)?.[0] as
-      | { singlePeerConnection?: boolean }
-      | undefined;
+      { singlePeerConnection?: boolean } | undefined;
     expect(roomCtorOptions?.singlePeerConnection).toBe(false);
 
     mod.disconnect();

--- a/clients/wavis-gui/src/features/voice/livekit-media.ts
+++ b/clients/wavis-gui/src/features/voice/livekit-media.ts
@@ -198,6 +198,17 @@ export const LIVEKIT_ROOM_OPTIONS = {
   // recover quickly. If screen-share quality regressions reappear after
   // this change, this is the first knob to flip back to false.
   dynacast: false,
+  // The livekit-client SDK defaults to singlePeerConnection:true, which
+  // makes every connect (and every reconnect) attempt the /rtc/v1 join path
+  // first. Our self-hosted LiveKit server (pinned to v1.9.3) doesn't serve
+  // that route, so it 404s, the SDK logs "v1 RTC path not found — Retrying",
+  // and it falls back to the legacy dual-peer-connection path it ends up
+  // using anyway — paying a guaranteed extra round trip (~seconds under
+  // real-world network conditions) on top of every reconnect (issue #117).
+  // Disabling it up front skips the doomed-to-fail attempt entirely with no
+  // behavior change, since the fallback path is the only one our server
+  // has ever actually served.
+  singlePeerConnection: false,
 } as const;
 
 export function buildCameraPublishOptions(quality: CameraQuality): TrackPublishOptions {


### PR DESCRIPTION
## Summary
- `livekit-client` defaults to `singlePeerConnection: true`, so every connect/reconnect first attempts the `/rtc/v1` join path
- Our self-hosted LiveKit server (pinned to `v1.9.3` in both `docker-compose.yml` and `deploy/docker-compose.livekit.yml`) doesn't serve that route — every attempt 404s (WS 1006 close), logs `"v1 RTC path not found — Retrying"`, then falls back to the legacy path it ends up using anyway
- This is a guaranteed extra round trip on **every single connect and reconnect**, which compounds perceived lag and audio/stream interruptions during a call — matches the diagnostics attached to #117
- Fix: set `singlePeerConnection: false` in `LIVEKIT_ROOM_OPTIONS` (main room, `livekit-media.ts`) and the direct-viewer `Room` (`viewer-connection.ts`, Watch All / screen-share pop-outs). Zero behavior change since the fallback path is the only one our server has ever actually served — just skips the doomed-to-fail first attempt.
- Deliberately did **not** bump the LiveKit server version: `v1.12.0`/`v1.13.0` made breaking TURN-auth changes (deny private IPs by default, TTL-based credentials) our embedded-TURN deploy isn't configured for, and that can't be safely verified without AWS access.

## Investigation notes
- #117's own description is unusable (`aaaaaaaaaaaaaaaa`); this is derived entirely from the attached diagnostics.
- The report's captured window (first ~10s) never reaches a mid-session reconnect, so I can't factually attribute the user's "disconnect" to a specific already-existing bug. The closest matching, already-fixed mechanism (WS reconnect tearing down live media, `e054db5`/#157) merged to `pre-dev` the day before this investigation — unrelated to this PR, already in `pre-dev`.
- Hotkey "already registered" warnings in the same report are handled non-fatally by design (`hotkey-bridge.ts`) — not a bug.

## Test plan
- [x] Added a focused test per file asserting the real `Room` mock constructor call includes `singlePeerConnection: false` — confirmed red before the fix, green after
- [x] Full `wavis-gui` suite: 77 files / 1409 tests passing
- [x] `tsc --noEmit` clean
- [ ] Live app console-log capture attempted (isolated docker stack with LiveKit pinned to v1.9.3, matching prod) but blocked by a pre-existing Windows `MAX_PATH` limit in this deeply-nested worktree path (unrelated to this change) — documented, not faked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUUFTRqSEnCfBF3PvSbtJZ