### PR TITLE
fix(ci): pin nightly-stress backend start to the wavis-backend binary

### DIFF
--- a/.github/workflows/nightly-stress.yml
+++ b/.github/workflows/nightly-stress.yml
@@ -141,7 +141,7 @@ jobs:
       # GITHUB_BUG_REPORT_REPO need to be provided.
       - name: Start backend
         run: |
-          cargo run -p wavis-backend --features test-metrics > backend.log 2>&1 &
+          cargo run -p wavis-backend --bin wavis-backend --features test-metrics > backend.log 2>&1 &
           for i in $(seq 1 60); do
             if curl -fsS http://127.0.0.1:3000/health > /dev/null 2>&1; then
               echo "backend ready after ${i}s"


### PR DESCRIPTION
## Summary
- `cargo run -p wavis-backend` in `.github/workflows/nightly-stress.yml` became ambiguous once PR #301 added a second bin target (`alpha-invite-admin`) to the `wavis-backend` crate.
- The "GUI surface tests (REST, real backend)" job has failed every nightly run since (2026-07-15, 2026-07-16, 2026-07-17): `cargo run` exits immediately with "could not determine which binary to run", the health-check loop times out after 60s, and the job fails.
- Fix: pin the invocation to `--bin wavis-backend`. The stress-harness job itself is unaffected and has been passing since the earlier crate-name fix (PR #270).

## Test plan
- [ ] Nightly Stress workflow run (scheduled or manual `workflow_dispatch`) shows "GUI surface tests (REST, real backend)" passing the "Start backend" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJU1r5UsNpcidoK6jj619