### PR TITLE
fix(gui): sync missing username on app resume, not just cold launch (#197)

### DIFF
--- a/clients/wavis-gui/src/features/auth/AuthGate.tsx
+++ b/clients/wavis-gui/src/features/auth/AuthGate.tsx
@@ -13,8 +13,8 @@ import {
 } from './auth';
 import {
   runAuthGateInit,
+  runAuthGateResume,
   decideScheduledRefreshAction,
-  isTransientFailure,
 } from './auth-gate-model';
 import { parseHostname } from '@shared/helpers';
 
@@ -106,21 +106,27 @@ export default function AuthGate() {
   useEffect(() => {
     async function handleVisibility() {
       if (document.visibilityState !== 'visible') return;
-      const expired = await isTokenExpired();
-      if (expired) {
-        console.log(LOG_PREFIX, 'App resumed with expired token — refreshing');
-        const result = await refreshTokens();
-        if (result.status === 'success') {
-          refreshRetriesRef.current = 0;
-          void scheduleRefresh();
-        } else if (!isTransientFailure(result)) {
-          await clearAccessTokens();
-          cancelScheduledRefresh();
-          void navigate('/login', { replace: true });
-        }
-      } else {
-        // Token still valid — re-schedule in case the timer was killed while backgrounded
-        console.log(LOG_PREFIX, 'App resumed — re-scheduling refresh timer');
+      console.log(LOG_PREFIX, 'App resumed — re-checking token and username');
+      const result = await runAuthGateResume({
+        isTokenExpired,
+        refreshTokens,
+        clearAccessTokens,
+        getUsername,
+        fetchMyUsername,
+        setUsername,
+      });
+
+      if (result.syncedUsername) setUsernameState(result.syncedUsername);
+
+      if (result.outcome === 'login') {
+        cancelScheduledRefresh();
+        void navigate('/login', { replace: true });
+        return;
+      }
+      if (result.outcome === 'refreshed') {
+        refreshRetriesRef.current = 0;
+      }
+      if (result.outcome === 'ready' || result.outcome === 'refreshed') {
         void scheduleRefresh();
       }
     }

--- a/clients/wavis-gui/src/features/auth/__tests__/auth-gate-model.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/auth-gate-model.test.ts
@@ -17,6 +17,7 @@ import fc from 'fast-check';
 import type { RefreshResult } from '../auth';
 import {
   runAuthGateInit,
+  runAuthGateResume,
   decideScheduledRefreshAction,
   jitteredDelay,
   isTransientFailure,
@@ -374,6 +375,125 @@ describe('runAuthGateInit — properties', () => {
       }),
       { numRuns: 50 },
     );
+  });
+});
+
+/* ═══ runAuthGateResume — visibilitychange (app resume) path ═══════
+ *
+ * Issue #197 follow-up: the merged fix (runAuthGateInit) only recovers a
+ * missing username once, at cold-launch mount. AuthGate.tsx's
+ * visibilitychange handler — which fires when the app resumes from OS
+ * sleep, exactly the scenario in the original bug report's diagnostics
+ * ("App resumed — re-scheduling refresh timer") — never re-ran that sync.
+ * A device paired/recovered while the app kept running across sleep/wake
+ * cycles (never fully restarted) would see the username gap persist
+ * indefinitely. These tests pin the fix: resume now recovers it too.
+ */
+describe('runAuthGateResume — username sync on app resume (issue #197 follow-up)', () => {
+  it('token still valid, no local username, server has one: synced and returned, outcome "ready"', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => false),
+      getUsername: vi.fn(async () => null),
+      fetchMyUsername: vi.fn(async () => 'diego'),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(result.outcome).toBe('ready');
+    expect(deps.setUsername).toHaveBeenCalledWith('diego');
+    expect(result.syncedUsername).toBe('diego');
+  });
+
+  it('expired token, refresh succeeds, no local username: synced and returned, outcome "refreshed"', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => true),
+      refreshTokens: vi.fn(async (): Promise<RefreshResult> => ({ status: 'success' })),
+      getUsername: vi.fn(async () => null),
+      fetchMyUsername: vi.fn(async () => 'diego'),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(result.outcome).toBe('refreshed');
+    expect(deps.setUsername).toHaveBeenCalledWith('diego');
+    expect(result.syncedUsername).toBe('diego');
+  });
+
+  it('local username already present: /me is never called, regardless of token state', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => false),
+      getUsername: vi.fn(async () => 'existing-user'),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(result.outcome).toBe('ready');
+    expect(deps.fetchMyUsername).not.toHaveBeenCalled();
+    expect(result.syncedUsername).toBeNull();
+  });
+
+  it('expired token, non-recoverable refresh failure: outcome "login", username sync never reached', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => true),
+      refreshTokens: vi.fn(async (): Promise<RefreshResult> => ({ status: 'unauthorized' })),
+      getUsername: vi.fn(async () => null),
+      fetchMyUsername: vi.fn(async () => 'diego'),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(result.outcome).toBe('login');
+    expect(deps.clearAccessTokens).toHaveBeenCalledTimes(1);
+    expect(deps.fetchMyUsername).not.toHaveBeenCalled();
+    expect(result.syncedUsername).toBeNull();
+  });
+
+  it('expired token, transient refresh failure: outcome "skipped", no clearing, username sync never reached', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => true),
+      refreshTokens: vi.fn(async (): Promise<RefreshResult> => ({
+        status: 'network_error',
+        message: 'down',
+      })),
+      getUsername: vi.fn(async () => null),
+      fetchMyUsername: vi.fn(async () => 'diego'),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(result.outcome).toBe('skipped');
+    expect(deps.clearAccessTokens).not.toHaveBeenCalled();
+    expect(deps.fetchMyUsername).not.toHaveBeenCalled();
+    expect(result.syncedUsername).toBeNull();
+  });
+
+  it('fetchMyUsername throws: best-effort, resume still completes as "ready"', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => false),
+      getUsername: vi.fn(async () => null),
+      fetchMyUsername: vi.fn(async () => {
+        throw new Error('network down');
+      }),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(result.outcome).toBe('ready');
+    expect(deps.setUsername).not.toHaveBeenCalled();
+    expect(result.syncedUsername).toBeNull();
+  });
+
+  it('fetchMyUsername resolves null: store left untouched', async () => {
+    const deps = makeDeps({
+      isTokenExpired: vi.fn(async () => false),
+      getUsername: vi.fn(async () => null),
+      fetchMyUsername: vi.fn(async () => null),
+    });
+
+    const result = await runAuthGateResume(deps);
+
+    expect(deps.setUsername).not.toHaveBeenCalled();
+    expect(result.syncedUsername).toBeNull();
   });
 });
 

--- a/clients/wavis-gui/src/features/auth/auth-gate-model.ts
+++ b/clients/wavis-gui/src/features/auth/auth-gate-model.ts
@@ -144,6 +144,75 @@ export async function runAuthGateInit(
   return { outcome: 'ready', localUsername, syncedUsername };
 }
 
+/* ─── visibilitychange resume — token re-check + username sync ──── */
+
+export type AuthGateResumeOutcome = 'login' | 'ready' | 'refreshed' | 'skipped';
+
+export interface RunAuthGateResumeResult {
+  outcome: AuthGateResumeOutcome;
+  /** Username synced from the server this run (issue #197), if any. */
+  syncedUsername: string | null;
+}
+
+type AuthGateResumeDeps = Pick<
+  AuthGateDeps,
+  | 'isTokenExpired'
+  | 'refreshTokens'
+  | 'clearAccessTokens'
+  | 'getUsername'
+  | 'fetchMyUsername'
+  | 'setUsername'
+>;
+
+/**
+ * Re-evaluate token and username state when the app regains visibility
+ * (e.g. resumes from OS sleep). Covers two token cases — expired while
+ * backgrounded (refresh now) and still valid (just re-schedule) — plus the
+ * same username sync as runAuthGateInit.
+ *
+ * That sync matters here specifically: runAuthGateInit only runs once per
+ * launch, so a long-running app that's suspended and resumed rather than
+ * restarted would otherwise never get a second chance to recover a username
+ * a best-effort pairing/recovery sync failed to persist (issue #197).
+ */
+export async function runAuthGateResume(
+  deps: AuthGateResumeDeps,
+): Promise<RunAuthGateResumeResult> {
+  const expired = await deps.isTokenExpired();
+
+  let outcome: AuthGateResumeOutcome;
+  if (expired) {
+    const result = await deps.refreshTokens();
+    if (result.status === 'success') {
+      outcome = 'refreshed';
+    } else if (!isTransientFailure(result)) {
+      await deps.clearAccessTokens();
+      return { outcome: 'login', syncedUsername: null };
+    } else {
+      // Transient — leave it for the next scheduled refresh or visibility event.
+      return { outcome: 'skipped', syncedUsername: null };
+    }
+  } else {
+    outcome = 'ready';
+  }
+
+  let syncedUsername: string | null = null;
+  const localUsername = await deps.getUsername();
+  if (!localUsername) {
+    try {
+      const serverName = await deps.fetchMyUsername();
+      if (serverName) {
+        await deps.setUsername(serverName);
+        syncedUsername = serverName;
+      }
+    } catch {
+      // Best-effort — missing username is cosmetic, proceed without blocking
+    }
+  }
+
+  return { outcome, syncedUsername };
+}
+
 /* ─── scheduleRefresh() — background sweep reducer ─────────────── */
 
 export type ScheduledRefreshAction = 'success' | 'retry' | 'login';


### PR DESCRIPTION
## Summary

Audited issue #197 ("diego connected to an empty account, relogging in fixes this") — it's still open and the project board still shows "In review" despite PR #217 claiming to close it. This PR closes the gap that survived that fix.

PR #217 correctly identified the likely mechanism: `PairDevice.tsx` and `Login.tsx`'s recovery flow both do a **best-effort** username sync after pairing/recovery (swallowed try/catch — a transient network blip leaves the username unpersisted forever). It fixed this by retrying the sync once, in `AuthGate`'s `init()`, on cold app launch.

But `AuthGate`'s `visibilitychange` (app-resume) handler never got the same treatment. A long-running desktop app that's only ever suspended/resumed — never fully restarted — would never get a second chance to recover a username that best-effort sync failed to persist. The original bug report's diagnostics captured exactly this: `App resumed — re-scheduling refresh timer`, immediately before the user reported the account looked empty.

- Extended `auth-gate-model.ts` with `runAuthGateResume()`, mirroring `runAuthGateInit()`'s token-refresh + username-sync logic as a pure, dependency-injected function.
- Wired `AuthGate.tsx`'s `handleVisibility()` to call it instead of its old inline (sync-less) logic.
- Ruled out other theories: `ChannelsList.tsx` already distinguishes loading/error/empty correctly (no swallowed-error-as-empty bug), and `fetchChannels()` is scoped server-side by the JWT's user_id so pairing/recovery always returns the right account's channels regardless of the username field.

## Test plan
- [x] `npx vitest run src/features/auth/__tests__/auth-gate-model.test.ts` — 7 new tests fail (`runAuthGateResume is not a function`) with the fix stashed, pass (35/35) with it restored
- [x] `npx vitest run src/features/auth` — 87/87 passed, no regressions
- [x] `npm run typecheck` — clean
- [x] `npx prettier --check` / `npx eslint` on touched files — 0 errors (only pre-existing warn-level rules on lines this PR didn't touch)
- [ ] Not verified: live Playwright run through the real desktop app (would need a live backend + a paired device + simulated OS suspend/resume — disproportionate for this fix; the unit evidence exercises the same real production function the component calls)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01YRJU1r5UsNpcidoK6jj619