### PR TITLE
test(e2e): leave-then-rejoin regression spec for #192

### DIFF
--- a/clients/wavis-gui/e2e-tooling/tests/leave-rejoin.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/leave-rejoin.spec.mjs
@@ -1,0 +1,84 @@
+// Live-backend: reproduces GH issue #192 ("Joined wavis room, left, now
+// cannot reconnect"). Joins a channel's voice room, leaves it via the real
+// /leave command, then rejoins the SAME channel a second time — asserting
+// the second join completes cleanly (own participant row visible, no stuck
+// "reconnecting"/"Connection lost" state) and that no console error of the
+// null-localParticipant class from the original bug report fires during
+// leave/rejoin.
+import { test, expect } from './fixtures.mjs';
+import {
+  SERVER_URL,
+  waitForBackendHealth,
+  seedChannelWithInvite,
+  registerAndLoginViaUi,
+  joinChannelViaUi,
+  enterChannelRoom,
+  leaveRoomIfActive,
+  joinDefaultSubRoomViaUi,
+  visibleText,
+} from './live-backend-helpers.mjs';
+
+test('leaving a room and rejoining the same channel succeeds', async ({ app }) => {
+  // Double the usual single-join flow (join, leave, rejoin) plus an extra
+  // sub-room join — the suite's default 30s budget (sized for one join) is
+  // too tight for this spec specifically.
+  test.setTimeout(90_000);
+  await waitForBackendHealth();
+
+  const suffix = Date.now().toString(36);
+  const channelName = `e2e-leave-rejoin-${suffix}`;
+  const { invite } = await seedChannelWithInvite(channelName);
+
+  const main = app.page();
+  await leaveRoomIfActive(main);
+  const pathname = new URL(main.url()).pathname;
+
+  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
+  }
+
+  const consoleErrors = [];
+  main.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  main.on('pageerror', (err) => consoleErrors.push(err.message));
+
+  await joinChannelViaUi(main, invite.code);
+  await enterChannelRoom(main, channelName);
+  await joinDefaultSubRoomViaUi(main);
+
+  await expect(visibleText(main, /ROOM \d+\s*\(1\)/)).toBeVisible({ timeout: 10_000 });
+
+  // Explicit leave (the exact user action issue #192's title describes).
+  await leaveRoomIfActive(main);
+  expect(new URL(main.url()).pathname.startsWith('/room')).toBe(false);
+
+  // Rejoin the SAME channel a second time. Channel membership persists
+  // across a room leave (only the voice call ended, not the channel
+  // membership), so re-using the invite code here would 409 "already a
+  // member" — just re-enter the channel row directly, like a real user
+  // clicking it again. Unlike the first entry (enterChannelRoom, above),
+  // having visited this channel's room once already means its name now
+  // also appears in a persistent recents/switcher element outside the
+  // channels-list row, so an exact-text locator resolves to multiple
+  // elements here — `.first()` picks the real channels-list row (still
+  // first in DOM order).
+  await main.getByText(channelName, { exact: true }).first().click();
+  await main.waitForURL(/\/room/, { timeout: 10_000 });
+  await joinDefaultSubRoomViaUi(main);
+
+  // The bug: after leaving, a second join never recovers — machineState gets
+  // stuck in 'reconnecting'/'idle' with an "error" event instead of 'active'.
+  // Assert the room actually came back up: own row visible, no stuck
+  // "Connection lost"/"reconnecting" system event in the log.
+  await expect(visibleText(main, /ROOM \d+\s*\(1\)/)).toBeVisible({ timeout: 10_000 });
+  await expect(visibleText(main, 'Connection lost')).toHaveCount(0);
+  await expect(visibleText(main, 'signaling reconnect failed')).toHaveCount(0);
+
+  await leaveRoomIfActive(main);
+
+  const nullLocalParticipantErrors = consoleErrors.filter((text) =>
+    text.includes("Cannot read properties of null (reading 'localParticipant')"),
+  );
+  expect(nullLocalParticipantErrors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- Verified GH issue #192 ("Joined wavis room, left, now cannot reconnect") does not reproduce on current `pre-dev` — the underlying fix landed months ago in PR #215 (unsubscribe the WS status-change handler before an intentional disconnect, `InitialRedirect` `skipAutoRedirect`, `livekit-media.ts` null guards) plus incremental reconnect hardening since. The issue never auto-closed because PR #215 merged into `pre-dev` back when `main` was still this repo's default branch.
- Adds `clients/wavis-gui/e2e-tooling/tests/leave-rejoin.spec.mjs`: a real Playwright spec against the real Tauri app + local backend that joins a channel's room, leaves it, re-enters the same channel, and asserts the room reaches `ROOM 1 (1)` again with no stuck `reconnecting`/`Connection lost` state and no null-`localParticipant` console error — locking the fix in as a regression test.
- No production code changes; nothing was actually broken.

## Test plan
- [x] `ALPHA_INVITE_CODE=E2E192LEAVE AUTH_REGISTER_RATE_LIMIT=200 npx playwright test tests/leave-rejoin.spec.mjs --reporter=list` from `clients/wavis-gui/e2e-tooling` — 3/3 clean runs against a real local backend + real debug GUI build.
- [x] Screenshot of the settled post-rejoin state (`LIVE 1/6`, `ROOM 1 (1)`, self participant visible) captured during manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDdcdE1Pz7D9kZtoPGE3iM