### PR TITLE
feat(backend): test-no-rate-limits cargo feature for local e2e builds

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -550,9 +550,13 @@
       "type": "node-terminal",
       "request": "launch",
       "name": "Test: GUI E2E (Playwright)",
-      // Brings the docker stack up (with the raised e2e register limit) and
-      // waits for /health before running — no manual docker compose needed.
+      // Brings the docker stack up — rebuilt with test-no-rate-limits and
+      // raised auth register/recover limits (see "Ensure E2E Backend Stack"
+      // in tasks.json) — and waits for /health before running. postDebugTask
+      // rebuilds the backend back to normal afterward either way, so the
+      // shared local dev backend never stays rate-limit-free.
       "preLaunchTask": "E2E Stack Ready",
+      "postDebugTask": "Restore Normal Backend",
       "command": "npm run test",
       "cwd": "${workspaceFolder}/clients/wavis-gui/e2e-tooling",
       "presentation": { "group": "7_gui-tauri", "order": 1 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,19 +42,23 @@
     },
     {
       // Full docker stack for the GUI e2e suite (postgres + redis + livekit
-      // + wavis-backend). AUTH_REGISTER_RATE_LIMIT must be raised from its
-      // default 5/hr: a full 7-spec run does ~14 registrations from one
-      // window (see e2e-tooling/README.md). Compose recreates wavis-backend
-      // automatically if the running container was started with a different
-      // limit. Uses the existing backend image — if you've changed backend
-      // code, rebuild it first: docker compose up -d --build
+      // + wavis-backend), rebuilt with test-no-rate-limits (see security.md)
+      // so a full suite run can't trip JoinRateLimiter/TempBanList/etc — the
+      // suite's own auth traffic still needs AUTH_REGISTER_RATE_LIMIT /
+      // AUTH_RECOVER_RATE_LIMIT raised since those aren't covered by that
+      // feature (see e2e-tooling/README.md). Always rebuilds (--build) so the
+      // running container matches these env vars and any local backend code
+      // changes; paired with "Restore Normal Backend" as this launch
+      // config's postDebugTask so the dev backend isn't left rate-limit-free.
       "label": "Ensure E2E Backend Stack",
       "type": "shell",
-      "command": "docker compose up -d",
+      "command": "docker compose up -d --build",
       "options": {
         "cwd": "${workspaceFolder}",
         "env": {
-          "AUTH_REGISTER_RATE_LIMIT": "200"
+          "AUTH_REGISTER_RATE_LIMIT": "200",
+          "AUTH_RECOVER_RATE_LIMIT": "200",
+          "CARGO_FEATURES": "test-no-rate-limits"
         }
       },
       "presentation": {
@@ -67,6 +71,23 @@
       "label": "E2E Stack Ready",
       "dependsOn": ["Ensure E2E Backend Stack", "Wait for Backend Ready"],
       "dependsOrder": "sequence",
+      "problemMatcher": []
+    },
+    {
+      // Rebuilds wavis-backend without test-no-rate-limits (CARGO_FEATURES
+      // unset → defaults to empty in docker-compose.yml) so the shared local
+      // dev backend isn't left running rate-limit-free after an e2e run.
+      // Runs as "Test: GUI E2E (Playwright)"'s postDebugTask.
+      "label": "Restore Normal Backend",
+      "type": "shell",
+      "command": "docker compose up -d --build",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "presentation": {
+        "reveal": "silent",
+        "close": true
+      },
       "problemMatcher": []
     },
 

--- a/clients/wavis-gui/e2e-tooling/README.md
+++ b/clients/wavis-gui/e2e-tooling/README.md
@@ -496,6 +496,26 @@ $env:AUTH_REGISTER_RATE_LIMIT="200"; $env:AUTH_RECOVER_RATE_LIMIT="200"; docker 
 (`docker compose restart wavis-backend` alone only clears the in-memory
 windows — enough when iterating on a single spec, not for a full-suite run.)
 
+**Beyond auth: the join limiter, temp-ban list, and WS/chat/global limiters
+have no env override at all or aren't wired into docker-compose.yml**
+(`JoinRateLimiter`'s per-room/per-code ceilings, `TempBanList`'s 10-minute
+IP ban after 5 violations, `WsRateLimiter`, `ChatRateLimiter`, both
+`GlobalRateLimiter`s — see security.md's "Test-Only Rate Limit Bypass"
+section). A full 20-test suite run can trip these — most notably
+`TempBanList`, which silently bans the test runner's own IP for 10 minutes
+and breaks every subsequent spec with generic timeouts, not an auth error.
+For a full-suite run, build the backend with the `test-no-rate-limits`
+cargo feature instead of trying to raise every individual limiter:
+
+```powershell
+$env:CARGO_FEATURES="test-no-rate-limits"; docker compose up -d --build wavis-backend
+```
+
+Rebuild **without** that env var afterward to restore normal enforcement —
+this feature is compile-time gated (never touches a production build), but
+the container it produces has no rate limiting at all, so don't leave it
+running as your regular dev backend.
+
 **Multi-tier DOM duplication.** `ActiveRoom` mounts `ChatPanel`/
 `LogsPanel`/`ParticipantsPanel` once per responsive layout tier (mobile /
 intermediate / desktop) and hides the inactive tiers with CSS rather than

--- a/clients/wavis-gui/src-tauri/src/screen_capture.rs
+++ b/clients/wavis-gui/src-tauri/src/screen_capture.rs
@@ -146,7 +146,11 @@ pub fn create_capture_backend(
     max_fps: u32,
 ) -> Result<Box<dyn ScreenCapture>, CaptureError> {
     create_capture_backend_with(
-        || Box::new(pipewire_capture::PipeWireCapture::new(max_width, max_height, max_fps)),
+        || {
+            Box::new(pipewire_capture::PipeWireCapture::new(
+                max_width, max_height, max_fps,
+            ))
+        },
         || Box::new(x11_capture::X11Capture::new()),
     )
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,11 @@ services:
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET}
 
   wavis-backend:
+    build:
+      args:
+        # Pin empty so a stray CARGO_FEATURES in the deploy host's shell or
+        # .env can never build a test-no-rate-limits backend into a deployment.
+        CARGO_FEATURES: ""
     environment:
       RUST_LOG: ${RUST_LOG}
       REQUIRE_TLS: ${REQUIRE_TLS}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,10 @@ services:
     build:
       context: .
       dockerfile: wavis-backend/Dockerfile
+      args:
+        # Empty by default (production behavior unchanged). Set to
+        # test-no-rate-limits for local e2e runs only — see security.md.
+        CARGO_FEATURES: ${CARGO_FEATURES:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/wavis-backend/Cargo.toml
+++ b/wavis-backend/Cargo.toml
@@ -11,6 +11,9 @@ workspace = true
 test-metrics = []
 concurrency-stress = []
 test-support = []
+# Effectively-unlimited rate limiters/temp-bans for local e2e testing only.
+# NEVER enable in a production build — see security.md.
+test-no-rate-limits = []
 
 [[bin]]
 name = "wavis-backend"

--- a/wavis-backend/Dockerfile
+++ b/wavis-backend/Dockerfile
@@ -22,7 +22,15 @@ COPY wavis-backend/migrations/ wavis-backend/migrations/
 # fails to parse ("workspace.lints was not defined"). Keep in sync with the root manifest.
 RUN printf '[workspace]\nresolver = "3"\nmembers = ["shared", "wavis-backend"]\n\n[workspace.lints.rust]\nunused_must_use = "deny"\n\n[workspace.lints.clippy]\ndbg_macro = "deny"\ntodo = "deny"\nunimplemented = "deny"\nmem_forget = "deny"\n' > Cargo.toml
 
-RUN cargo build --release -p wavis-backend --bin wavis-backend
+# CARGO_FEATURES is empty by default (production behavior unchanged). Local/e2e
+# builds may pass --build-arg CARGO_FEATURES=test-no-rate-limits — never set
+# this for a deployed image, see security.md.
+ARG CARGO_FEATURES=
+RUN if [ -n "$CARGO_FEATURES" ]; then \
+        cargo build --release -p wavis-backend --bin wavis-backend --features "$CARGO_FEATURES"; \
+    else \
+        cargo build --release -p wavis-backend --bin wavis-backend; \
+    fi
 
 FROM debian:bookworm-slim AS runtime
 

--- a/wavis-backend/src/abuse/join_rate_limiter.rs
+++ b/wavis-backend/src/abuse/join_rate_limiter.rs
@@ -86,6 +86,26 @@ impl Default for JoinRateLimiterConfig {
     }
 }
 
+impl JoinRateLimiterConfig {
+    /// Effectively-unlimited thresholds — local e2e testing only, never production.
+    #[cfg(feature = "test-no-rate-limits")]
+    pub fn unlimited() -> Self {
+        Self {
+            ip_total_threshold: u32::MAX,
+            ip_total_window: Duration::from_secs(60),
+            ip_failed_threshold: u32::MAX,
+            ip_failed_window: Duration::from_secs(60),
+            code_threshold: u32::MAX,
+            code_window: Duration::from_secs(60),
+            room_threshold: u32::MAX,
+            room_window: Duration::from_secs(60),
+            connection_threshold: u32::MAX,
+            connection_window: Duration::from_secs(60),
+            cooldown: Duration::from_secs(1),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // JoinRateLimiter
 // ---------------------------------------------------------------------------

--- a/wavis-backend/src/abuse/temp_ban.rs
+++ b/wavis-backend/src/abuse/temp_ban.rs
@@ -12,6 +12,10 @@ pub struct TempBanConfig {
 
 impl TempBanConfig {
     pub fn from_env() -> Self {
+        // Local e2e testing only, never production — see security.md.
+        #[cfg(feature = "test-no-rate-limits")]
+        let threshold = u32::MAX;
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let threshold = std::env::var("TEMP_BAN_THRESHOLD")
             .ok()
             .and_then(|v| v.parse().ok())

--- a/wavis-backend/src/app_state.rs
+++ b/wavis-backend/src/app_state.rs
@@ -212,10 +212,14 @@ impl AppState {
         let require_tls = std::env::var("REQUIRE_TLS")
             .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
             .unwrap_or_else(|_| !cfg!(debug_assertions));
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let max_connections_per_ip = std::env::var("MAX_CONNECTIONS_PER_IP")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(10);
+        // Local e2e testing only, never production — see security.md.
+        #[cfg(feature = "test-no-rate-limits")]
+        let max_connections_per_ip = u32::MAX;
 
         // TURN config — Ok(None) if not configured, panic on bad config
         let turn_config = match TurnConfig::try_from_env() {
@@ -238,14 +242,19 @@ impl AppState {
             Err(e) => panic!("Invalid TURN configuration: {e}"),
         };
 
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let global_ws_per_sec = std::env::var("GLOBAL_WS_UPGRADES_PER_SEC")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(100);
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let global_join_per_sec = std::env::var("GLOBAL_JOINS_PER_SEC")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(50);
+        // Local e2e testing only, never production — see security.md.
+        #[cfg(feature = "test-no-rate-limits")]
+        let (global_ws_per_sec, global_join_per_sec) = (u32::MAX, u32::MAX);
 
         #[cfg(not(windows))]
         let ec2_controller = std::env::var("LIVEKIT_EC2_INSTANCE_ID")

--- a/wavis-backend/src/main.rs
+++ b/wavis-backend/src/main.rs
@@ -337,6 +337,14 @@ async fn main() -> io::Result<()> {
     };
 
     let invite_store = Arc::new(InviteStore::new(InviteStoreConfig::default()));
+    #[cfg(feature = "test-no-rate-limits")]
+    tracing::warn!(
+        "test-no-rate-limits feature is compiled in — ALL abuse rate limits are disabled. \
+         This build must never serve production traffic."
+    );
+    #[cfg(feature = "test-no-rate-limits")]
+    let join_rate_limiter = Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::unlimited()));
+    #[cfg(not(feature = "test-no-rate-limits"))]
     let join_rate_limiter = Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::default()));
     let ip_config = IpConfig::from_env();
 

--- a/wavis-backend/src/ws/ws.rs
+++ b/wavis-backend/src/ws/ws.rs
@@ -174,6 +174,10 @@ async fn handle_socket(mut socket: WebSocket, app_state: AppState, client_ip: Ip
     let _ = &issuer_id;
     let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<String>();
     let mut rate_limiter = WsRateLimiter::new(&app_state.ws_rate_limit_config);
+    // Local e2e testing only, never production — see security.md.
+    #[cfg(feature = "test-no-rate-limits")]
+    let mut chat_rate_limiter = ChatRateLimiter::new(1_000_000.0);
+    #[cfg(not(feature = "test-no-rate-limits"))]
     let mut chat_rate_limiter = ChatRateLimiter::new(5.0);
     let sfu_config = SfuConfig::from_app_state(&app_state.jwt_secret, &app_state.jwt_issuer);
     let mut session: Option<SignalingSession> = None;

--- a/wavis-backend/src/ws/ws_rate_limit.rs
+++ b/wavis-backend/src/ws/ws_rate_limit.rs
@@ -38,14 +38,17 @@ impl WsRateLimitConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(10);
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let max_messages = env::var("WS_RATE_LIMIT_MAX_MESSAGES")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(60);
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let burst_max = env::var("WS_RATE_LIMIT_BURST")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
             .unwrap_or(15);
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let action_max = env::var("ACTION_RATE_LIMIT_MAX")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
@@ -54,6 +57,7 @@ impl WsRateLimitConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(60);
+        #[cfg(not(feature = "test-no-rate-limits"))]
         let deafen_max = env::var("DEAFEN_RATE_LIMIT_MAX")
             .ok()
             .and_then(|v| v.parse::<u32>().ok())
@@ -62,6 +66,10 @@ impl WsRateLimitConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(60);
+        // Local e2e testing only, never production — see security.md.
+        #[cfg(feature = "test-no-rate-limits")]
+        let (max_messages, burst_max, action_max, deafen_max) =
+            (u32::MAX, u32::MAX, u32::MAX, u32::MAX);
         Self {
             window: Duration::from_secs(window_secs),
             max_messages,
@@ -224,6 +232,9 @@ mod tests {
 
     static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+    // Doesn't apply under test-no-rate-limits: that feature makes from_env()
+    // intentionally ignore ACTION_RATE_LIMIT_MAX and return u32::MAX instead.
+    #[cfg(not(feature = "test-no-rate-limits"))]
     #[test]
     fn test_from_env_uses_updated_action_default() {
         let _guard = ENV_LOCK.lock().expect("env lock poisoned");


### PR DESCRIPTION
## Summary

Adds a `test-no-rate-limits` cargo feature to `wavis-backend` that compiles out all abuse rate limiters — **local e2e testing only, never production**. The full Playwright e2e suite was flaking because its burst of joins/registrations tripped `JoinRateLimiter` and `TempBanList` (10-minute IP bans mid-suite); with the feature enabled the suite went from routinely 2-3 unrelated failures to 18/20 (the remaining 2 are the known, unrelated `zz-disconnect-sound` multi-call-site issue).

**What the feature gates** (all via paired `#[cfg]`, `u32::MAX` / effectively-unlimited sentinels):
- `JoinRateLimiter` (per-IP / per-code / per-room / per-connection join windows) — `main.rs`, `abuse/join_rate_limiter.rs`
- `TempBanList` violation threshold — `abuse/temp_ban.rs`
- `GlobalRateLimiter` WS-upgrade + join ceilings and per-IP connection cap — `app_state.rs`
- Per-connection WS message/burst/action/deafen limits — `ws/ws_rate_limit.rs`
- `ChatRateLimiter` token bucket — `ws/ws.rs`

**Build wiring:** `Dockerfile` gets `ARG CARGO_FEATURES=` (empty default → production behavior unchanged); `docker-compose.yml` passes it through as a build arg (`${CARGO_FEATURES:-}`); `docker-compose.prod.yml` **pins it to `""`** so the EC2 deploy path (`infrastructure/environments/dev/deploy.sh`) can never build the bypass even if the host shell or an untracked `.env` sets the variable.

**Runtime tripwire:** `main.rs` logs a `tracing::warn!` at startup when the feature is compiled in, so a bypass build can never run silently.

**VSCode wiring:** the "Test: GUI E2E (Playwright)" launch config's pre-launch task now rebuilds the stack with `CARGO_FEATURES=test-no-rate-limits` + raised `AUTH_REGISTER/RECOVER_RATE_LIMIT` (the REST auth limiters are deliberately not covered by the feature), and a new "Restore Normal Backend" `postDebugTask` rebuilds the normal image after every run. Caveat: if VSCode is killed mid-run the restore task doesn't fire, leaving the *local* backend rate-limit-free until the next rebuild.

Also includes a standalone rustfmt fix in `clients/wavis-gui/src-tauri/src/screen_capture.rs` and an e2e-tooling README section documenting the workflow.

## Security review (done pre-push)

- Feature is strictly opt-in: no `default` feature list, no CI workflow uses `--all-features`, the ECR image build (`deploy-dev-ec2.yml`) uses plain `docker build` with no build-arg, and the only crate depending on `wavis-backend` (`tools/stress`) doesn't request it — Cargo feature unification can't pull it in.
- Every `u32::MAX` sentinel was verified against the actual limiter arithmetic (threshold comparisons only, no threshold-sized allocations, `saturating_sub` in the packed-atomic global limiter, `1_000_000.0` exact in f64) — no overflow or panic path.
- The prod-overlay pin was verified by rendering `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` with `CARGO_FEATURES=test-no-rate-limits` deliberately set in the environment: merged output still shows `CARGO_FEATURES: ""`.

## Validation

- `cargo check -p wavis-backend --features test-no-rate-limits`: clean
- `cargo test -p wavis-backend` with and without the feature: green (the one env-default test incompatible by design, `test_from_env_uses_updated_action_default`, is `cfg`-excluded under the feature rather than weakened)
- `cargo fmt --all --check`, `cargo clippy -p wavis-backend -- -D warnings`, prettier on the touched README: all green
- Full 20-test live-backend e2e suite with the feature: 18/20 (remaining 2 pre-existing and unrelated)
- VSCode pre-launch + restore tasks simulated end-to-end: backend healthy in both states, env/feature correctly applied and correctly reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiwV93JoDPZ4DRB3CxP9YF
