### PR TITLE
fix(gui): reset Watch All connection-error counter on successful reconnect

### DIFF
--- a/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
+++ b/clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx
@@ -108,6 +108,13 @@ export default function WatchAllPage() {
         console.warn('[wavis:viewer-connection] watch-all connect failed', err);
         setConnectionErrorCount((c) => c + 1);
       },
+      // Reset on every successful (re)connect, not just once at mount — the
+      // counter is documented as "consecutive" failures and drives whether a
+      // freshly-mounted tile with no stream yet renders "connection failed"
+      // immediately (see ShareTile's escalation effect). Without this, a
+      // long-lived window that saw 3 early transient failures and then
+      // recovered would keep escalating every later tile on mount forever.
+      onConnected: () => setConnectionErrorCount(0),
     });
     setConnectionErrorCount(0);
     setViewerConn(conn);

--- a/clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts
+++ b/clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts
@@ -359,3 +359,62 @@ describe('ViewerRoomConnection.refreshIdentity', () => {
     expect(events).toHaveLength(eventsBefore);
   });
 });
+
+/* ─── ViewerRoomConnection onConnected (Watch All error-counter reset) ──
+ * Regression coverage for #283: WatchAllPage's connectionErrorCount is
+ * documented as "consecutive Room-level connect failures" and escalates
+ * tiles to a visible error state at 3, but nothing ever reset it back to 0
+ * after a successful (re)connect — unlike ScreenSharePage's equivalent
+ * counter, which resets when its watch() callback delivers a stream. Once a
+ * Watch All window accumulated 3 early transient failures, every
+ * subsequently-mounted tile immediately rendered "connection failed" on
+ * mount, even with a perfectly healthy Room. onConnected gives the caller a
+ * hook to reset the counter on the event that actually means "recovered":
+ * the Room itself reconnecting, not any one tile's track arriving. */
+describe('ViewerRoomConnection onConnected', () => {
+  beforeEach(() => {
+    roomState.current = null;
+  });
+
+  it('fires once after the initial successful connect', async () => {
+    const onConnected = vi.fn();
+    const conn = new ViewerRoomConnection({ windowLabel: 'watch-all', onConnected });
+    conn.watch('alice', () => {});
+    await tick();
+    await tick();
+
+    expect(onConnected).toHaveBeenCalledTimes(1);
+    conn.dispose();
+  });
+
+  it('fires again after forceReconnect() succeeds, so a caller can reset a failure counter per reconnect', async () => {
+    const onConnected = vi.fn();
+    const conn = new ViewerRoomConnection({ windowLabel: 'watch-all', onConnected });
+    conn.watch('alice', () => {});
+    await tick();
+    await tick();
+    expect(onConnected).toHaveBeenCalledTimes(1);
+
+    conn.forceReconnect();
+    await tick();
+    await tick();
+
+    expect(onConnected).toHaveBeenCalledTimes(2);
+    conn.dispose();
+  });
+
+  it('does not fire after dispose()', async () => {
+    const onConnected = vi.fn();
+    const conn = new ViewerRoomConnection({ windowLabel: 'watch-all', onConnected });
+    conn.watch('alice', () => {});
+    await tick();
+    await tick();
+    onConnected.mockClear();
+
+    conn.dispose();
+    await tick();
+    await tick();
+
+    expect(onConnected).not.toHaveBeenCalled();
+  });
+});

--- a/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
+++ b/clients/wavis-gui/src/features/screen-share/viewer-connection.ts
@@ -79,12 +79,22 @@ export interface ViewerRoomConnectionOptions {
   windowLabel: string;
   /** Invoked after each failed connect attempt (already scheduled to retry). */
   onConnectionError?: (error: unknown) => void;
+  /**
+   * Invoked after each successful (re)connect — including the initial
+   * connect and every reconnect after a drop or forceReconnect(). Lets a
+   * caller reset a failure counter on the event that actually means
+   * "recovered": the Room itself connecting, not any one identity's track
+   * arriving (a Room can be healthy while a specific publication is still
+   * missing or dead).
+   */
+  onConnected?: () => void;
 }
 
 export class ViewerRoomConnection {
   private readonly windowLabel: string;
   private readonly windowId: string;
   private readonly onConnectionError?: (error: unknown) => void;
+  private readonly onConnected?: () => void;
 
   private room: Room | null = null;
   private connectPromise: Promise<void> | null = null;
@@ -101,6 +111,7 @@ export class ViewerRoomConnection {
   constructor(opts: ViewerRoomConnectionOptions) {
     this.windowLabel = opts.windowLabel;
     this.onConnectionError = opts.onConnectionError;
+    this.onConnected = opts.onConnected;
     this.windowId = makeViewerWindowId();
   }
 
@@ -243,6 +254,7 @@ export class ViewerRoomConnection {
 
       this.attempt = 0;
       if (DEBUG_VIEWER_CONNECTION) console.log(LOG, `[${this.windowLabel}] connected`);
+      this.onConnected?.();
       this.subscribeAll();
     } catch (err) {
       if (this.disposed || generation !== this.generation) return;


### PR DESCRIPTION
## Summary

Independent verify-and-complete audit of issue #283 ("Watch all page did not work, but single stream did"), which the project board already showed as "In review" via two merged PRs (#284, #285). This PR does **not** re-fix anything those already fixed — it confirms their claims against the current code/tests and closes one gap they left behind.

**What I verified was already fixed correctly (no changes needed):**
- `6d415a6` — the actual root-cause match for the reporter's diagnostics: `WatchAllPage` built its `ViewerRoomConnection` in `useMemo` but disposed it in an effect cleanup, so React StrictMode's simulated unmount permanently disposed the connection while the memoized instance survived the remount, leaving every tile `watch()`ing a dead connection that never requested a token. Confirmed fixed — Watch All now opens and renders correctly (see Test plan).
- `76d7302` (PR #284) — single dead-track recovery was calling `forceReconnect()`, tearing down the whole shared Room over one poisoned publication. `ViewerRoomConnection.refreshIdentity()` now resubscribes just that identity; `ShareTile` escalates to a full reconnect only after 3 consecutive failures. Confirmed via existing passing tests.
- `9a66b88` (PR #285) — Room-level connect failures now escalate tiles to a visible error/retry state after 3 consecutive failures instead of sitting on "connecting..." forever.

**Gap found and fixed here:**
`WatchAllPage`'s `connectionErrorCount` is documented as "consecutive Room-level connect failures" and gates whether a freshly-mounted tile with no stream yet renders "connection failed" immediately — but nothing ever reset it back to 0 after a successful (re)connect, unlike `ScreenSharePage`'s equivalent counter, which resets when its own `watch()` callback delivers a stream. Once a long-lived Watch All window accumulated 3 early transient failures (e.g. during initial connect backoff), *every later-mounted tile* would flash "connection failed" on mount forever, even against a perfectly healthy Room.

Fix: added `ViewerRoomConnection.onConnected`, fired after every successful `connectOnce()` (initial connect, and every reconnect including after `forceReconnect()`), and wired it in `WatchAllPage` to reset the counter.

## Changes
- `clients/wavis-gui/src/features/screen-share/viewer-connection.ts` — new `onConnected?: () => void` option, invoked on successful connect.
- `clients/wavis-gui/src/features/screen-share/WatchAllPage.tsx` — resets `connectionErrorCount` via the new callback.
- `clients/wavis-gui/src/features/screen-share/__tests__/viewer-connection.test.ts` — 3 new tests: fires once on initial connect, fires again after `forceReconnect()` succeeds, does not fire after `dispose()`.

## Test plan
- [x] New tests written failing-first: reverted the implementation via a scoped `git stash`, confirmed 2/3 new tests failed (`expected "vi.fn()" to be called 1 times, but got 0 times`), restored the implementation, confirmed all pass.
- [x] `npx vitest run src/features/screen-share/__tests__/viewer-connection.test.ts src/features/screen-share/__tests__/WatchAllPage.test.ts` — 39/39 pass
- [x] `npm test` (full suite) — 1460/1460 pass, no regressions
- [x] `npm run typecheck` — clean
- [x] `npx eslint` on changed files — 0 errors (3 pre-existing warnings on `WatchAllPage.tsx`, confirmed present on unmodified pre-dev too, unrelated to this change)
- [x] `npx prettier --check` — clean
- [x] Manual verification: built a debug exe (`VITE_DIAGNOSTICS=true`) and drove it with real Playwright via CDP (`run-wavis-gui` skill). Opened Watch All from the diagnostics panel — window opens, connects, and renders a synthetic test tile correctly, confirming the StrictMode fix holds and Watch All is not stuck on "connecting...". Screenshot attached as a comment on this PR.
- [ ] **Not independently verified**: the `connectionErrorCount` reset itself isn't exercisable through diagnostics test mode (it bypasses the real `ViewerRoomConnection` entirely), so its coverage is the new unit test above, not a GUI screenshot. A real multi-participant Watch All session against a live backend (two machines) remains the same manual gap PR #284 already documented for the rest of this issue's surface.

## Environment note
Building this worktree's debug exe hit Windows' 260-char `MAX_PATH` limit (worktree checkouts live under `.claude/worktrees/<name>/...`, and the webrtc-sys crate's vendored include paths are very deep). Worked around it with `CARGO_TARGET_DIR` pointed at a short path; not a code issue, just leaving this here in case it recurs for other worktree-based verification runs.

Closes #283 is still gated on cutting the next desktop release with the direct-LiveKit-viewer-connections rework, per PR #284's original note — this PR doesn't change that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRJU1r5UsNpcidoK6jj619