### PR TITLE
feat(gui): launch Wavis on startup, off by default (#67)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -189,7 +189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -637,6 +637,17 @@ checksum = "927791de46f70facea982dbfaf19719a41ce6064443403be631a85de6a58fff9"
 dependencies = [
  "log",
  "pkg-config",
+]
+
+[[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -2477,11 +2488,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -2492,8 +2523,8 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
- "windows-sys 0.59.0",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2525,7 +2556,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2770,7 +2801,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -2872,7 +2903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3510,7 +3541,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4040,7 +4071,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5070,7 +5101,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5244,7 +5275,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5814,7 +5845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6411,7 +6442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -6535,7 +6566,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6572,9 +6603,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6711,6 +6742,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d94dd2f7cd932d4dc02cc8b2b50dfd38bd079a4e5d79198b99743d7fcf9a4b4"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7056,7 +7098,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7069,7 +7111,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7127,7 +7169,7 @@ dependencies = [
  "security-framework 3.6.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8346,7 +8388,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cookie",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "getrandom 0.3.4",
@@ -8396,7 +8438,7 @@ checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -8464,6 +8506,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8639,7 +8695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
 dependencies = [
  "base64 0.22.1",
- "dirs",
+ "dirs 6.0.0",
  "flate2",
  "futures-util",
  "http 1.4.0",
@@ -8747,7 +8803,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.0.6+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -8786,7 +8842,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9293,7 +9349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2",
@@ -9305,7 +9361,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9965,6 +10021,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-http",
@@ -10485,7 +10542,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11074,6 +11131,15 @@ dependencies = [
 
 [[package]]
 name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
@@ -11204,7 +11270,7 @@ dependencies = [
  "block2",
  "cookie",
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "dom_query",
  "dpi",
  "dunce",

--- a/clients/wavis-gui/package.json
+++ b/clients/wavis-gui/package.json
@@ -59,6 +59,7 @@
     "@radix-ui/react-toggle-group": "^1.1.2",
     "@radix-ui/react-tooltip": "1.1.8",
     "@tauri-apps/api": "~2.11.0",
+    "@tauri-apps/plugin-autostart": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-global-shortcut": "^2",
     "@tauri-apps/plugin-http": "^2",

--- a/clients/wavis-gui/src-tauri/Cargo.toml
+++ b/clients/wavis-gui/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-log = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 log = "0.4"

--- a/clients/wavis-gui/src-tauri/capabilities/default.json
+++ b/clients/wavis-gui/src-tauri/capabilities/default.json
@@ -42,6 +42,7 @@
     "log:default",
     "updater:default",
     "process:default",
+    "autostart:default",
     "shell:allow-open"
   ]
 }

--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -483,6 +483,13 @@ fn main() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        // Off by default (Windows registry Run key / macOS LaunchAgent /
+        // Linux desktop autostart file) — the frontend enables it only
+        // after the user opts in (see DeviceSetup step 4, Settings toggle).
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .manage(KeyringCache::new())
         .manage(media::MediaState::new())
         .manage(external_share_helper::ExternalShareHelperState::new())

--- a/clients/wavis-gui/src/features/auth/DeviceSetup.tsx
+++ b/clients/wavis-gui/src/features/auth/DeviceSetup.tsx
@@ -9,6 +9,7 @@ import {
   deleteStoredRecoveryId,
 } from './auth';
 import { useCopyToClipboardFeedback } from '@shared/hooks/useCopyToClipboardFeedback';
+import { setLaunchOnStartupEnabled } from '@shared/autostart-bridge';
 import { AuthFieldRow } from './AuthFieldRow';
 import { AuthShell } from './AuthShell';
 import { AuthLogPanel } from './AuthLogPanel';
@@ -16,7 +17,7 @@ import { AuthLogPanel } from './AuthLogPanel';
 const MIN_PHRASE_LENGTH = 4;
 const MAX_USERNAME_LENGTH = 64;
 
-type SetupStep = 1 | 2 | 3;
+type SetupStep = 1 | 2 | 3 | 4;
 
 export function validateStep1(
   username: string,
@@ -98,6 +99,48 @@ function InsecureTlsToggle({
   );
 }
 
+function LaunchOnStartupStep({ onChoice }: { onChoice: (wantEnabled: boolean) => Promise<void> }) {
+  const [pending, setPending] = useState(false);
+
+  const choose = useCallback(
+    (wantEnabled: boolean) => {
+      if (pending) return;
+      setPending(true);
+      void onChoice(wantEnabled).finally(() => setPending(false));
+    },
+    [pending, onChoice],
+  );
+
+  return (
+    <div className="px-4 sm:px-6 py-4">
+      <div className="mb-6 border border-wavis-text-secondary bg-wavis-bg p-3">
+        <div className="mb-2 text-sm font-bold">LAUNCH WAVIS ON STARTUP</div>
+        <p className="text-sm text-wavis-text-secondary">
+          Start Wavis automatically when you log into this computer, so you never have to open it
+          manually. Off by default — you can change this anytime in Settings.
+        </p>
+      </div>
+
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => choose(false)}
+          disabled={pending}
+          className="border border-wavis-text-secondary text-wavis-text-secondary hover:border-wavis-accent hover:text-wavis-accent transition-colors px-6 py-2 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          /skip
+        </button>
+        <button
+          onClick={() => choose(true)}
+          disabled={pending}
+          className="border border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg transition-colors px-6 py-2 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {pending ? 'saving...' : '/enable'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function DeviceSetup() {
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -150,8 +193,16 @@ export default function DeviceSetup() {
     if (!trustedDevice) {
       await deleteStoredRecoveryId();
     }
-    navigate('/', { replace: true });
-  }, [username, trustedDevice, navigate]);
+    setStep(4);
+  }, [username, trustedDevice]);
+
+  const handleStartupChoice = useCallback(
+    async (wantEnabled: boolean) => {
+      await setLaunchOnStartupEnabled(wantEnabled);
+      navigate('/', { replace: true });
+    },
+    [navigate],
+  );
 
   const handleRegister = useCallback(async () => {
     if (registering) return;
@@ -214,9 +265,10 @@ export default function DeviceSetup() {
     <AuthShell
       subtitle={
         <div className="mt-2 text-wavis-text-secondary text-sm">
-          {step === 1 && 'Step 1 of 3 - create credentials'}
-          {step === 2 && 'Step 2 of 3 - choose server'}
-          {step === 3 && 'Step 3 of 3 - save recovery details'}
+          {step === 1 && 'Step 1 of 4 - create credentials'}
+          {step === 2 && 'Step 2 of 4 - choose server'}
+          {step === 3 && 'Step 3 of 4 - save recovery details'}
+          {step === 4 && 'Step 4 of 4 - launch on startup'}
         </div>
       }
     >
@@ -422,11 +474,13 @@ export default function DeviceSetup() {
         </div>
       )}
 
+      {step === 4 && <LaunchOnStartupStep onChoice={handleStartupChoice} />}
+
       <div className="px-4 sm:px-6 py-3 border-t border-wavis-text-secondary text-wavis-text-secondary text-xs">
         Tokens stored in local keychain - Auto-refresh - Device ID persisted
       </div>
 
-      {step !== 3 && (
+      {step !== 3 && step !== 4 && (
         <div className="px-4 sm:px-6 py-3 border-t border-wavis-text-secondary text-sm">
           <button
             onClick={() => navigate('/recover')}

--- a/clients/wavis-gui/src/features/settings/Settings.tsx
+++ b/clients/wavis-gui/src/features/settings/Settings.tsx
@@ -91,6 +91,7 @@ import {
 } from '@shared/hotkey-bridge';
 import { Switch } from '../../components/ui/switch';
 import { open } from '@tauri-apps/plugin-shell';
+import { isLaunchOnStartupEnabled, setLaunchOnStartupEnabled } from '@shared/autostart-bridge';
 import { ConfirmTextGate } from '@shared/ConfirmTextGate';
 import ChannelDetail from '@features/channels/ChannelDetail';
 import { useHotkeyRecorder } from './useHotkeyRecorder';
@@ -245,6 +246,7 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
     kind: 'idle',
   });
   const [minimizeToTray, setMinimizeToTrayState] = useState(false);
+  const [launchOnStartup, setLaunchOnStartupState] = useState(false);
   const [notifyToggles, setNotifyToggles] = useState<NotificationToggles>({
     participantJoined: true,
     participantLeft: true,
@@ -296,6 +298,7 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
     void getStoreValue<string>(STORE_KEYS.audioOutputDevice, '').then(setSelectedOutputDevice);
     void getAccessToken().then(setAccessTokenVal);
     void getMinimizeToTray().then(setMinimizeToTrayState);
+    void isLaunchOnStartupEnabled().then(setLaunchOnStartupState);
     void getNotificationToggles().then(setNotifyToggles);
     setPassthroughVolumeState(getVoiceRoomState().passthroughVolume);
     setPassthroughFiltersEnabledState(getVoiceRoomState().passthroughFiltersEnabled);
@@ -355,6 +358,11 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
     setMinimizeToTrayState(checked);
     void setMinimizeToTray(checked);
     emit('minimize-to-tray-changed', { enabled: checked }).catch(() => {});
+  }, []);
+
+  const handleLaunchOnStartupChange = useCallback((checked: boolean) => {
+    setLaunchOnStartupState(checked);
+    void setLaunchOnStartupEnabled(checked);
   }, []);
 
   const handleDenoiseToggle = useCallback(async (checked: boolean) => {
@@ -1174,9 +1182,9 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
 
             <div className="text-wavis-text-secondary my-4 overflow-hidden">{DIVIDER}</div>
 
-            {/* System tray */}
+            {/* System tray & startup */}
             <div className="mb-6">
-              <p className="text-sm text-wavis-text-secondary mb-2">SYSTEM TRAY</p>
+              <p className="text-sm text-wavis-text-secondary mb-2">SYSTEM TRAY & STARTUP</p>
               <div className="p-3 bg-wavis-panel border border-wavis-text-secondary space-y-3 text-sm">
                 <div className="flex items-center justify-between">
                   <span className="text-wavis-text-secondary">Minimize to tray on close</span>
@@ -1184,6 +1192,14 @@ export default function Settings({ onClose, onNavigateAway, channelId }: Setting
                     checked={minimizeToTray}
                     onCheckedChange={handleMinimizeToTrayChange}
                     aria-label="Toggle minimize to tray"
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className="text-wavis-text-secondary">Launch Wavis on startup</span>
+                  <Switch
+                    checked={launchOnStartup}
+                    onCheckedChange={handleLaunchOnStartupChange}
+                    aria-label="Toggle launch on startup"
                   />
                 </div>
               </div>

--- a/clients/wavis-gui/src/shared/__tests__/autostart-bridge.test.ts
+++ b/clients/wavis-gui/src/shared/__tests__/autostart-bridge.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Unit tests for autostart-bridge.ts — plugin call mapping and error fallback.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const enableMock = vi.fn().mockResolvedValue(undefined);
+const disableMock = vi.fn().mockResolvedValue(undefined);
+const isEnabledMock = vi.fn().mockResolvedValue(false);
+
+vi.mock('@tauri-apps/plugin-autostart', () => ({
+  enable: (...args: unknown[]): Promise<void> => enableMock(...args) as Promise<void>,
+  disable: (...args: unknown[]): Promise<void> => disableMock(...args) as Promise<void>,
+  isEnabled: (...args: unknown[]): Promise<boolean> => isEnabledMock(...args) as Promise<boolean>,
+}));
+
+import { isLaunchOnStartupEnabled, setLaunchOnStartupEnabled } from '../autostart-bridge';
+
+beforeEach(() => {
+  enableMock.mockClear();
+  disableMock.mockClear();
+  isEnabledMock.mockClear();
+});
+
+describe('isLaunchOnStartupEnabled', () => {
+  it('returns the plugin state', async () => {
+    isEnabledMock.mockResolvedValueOnce(true);
+    await expect(isLaunchOnStartupEnabled()).resolves.toBe(true);
+  });
+
+  it('falls back to false if the plugin call throws', async () => {
+    isEnabledMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(isLaunchOnStartupEnabled()).resolves.toBe(false);
+  });
+});
+
+describe('setLaunchOnStartupEnabled', () => {
+  it('calls enable() when turning on', async () => {
+    await setLaunchOnStartupEnabled(true);
+    expect(enableMock).toHaveBeenCalledTimes(1);
+    expect(disableMock).not.toHaveBeenCalled();
+  });
+
+  it('calls disable() when turning off', async () => {
+    await setLaunchOnStartupEnabled(false);
+    expect(disableMock).toHaveBeenCalledTimes(1);
+    expect(enableMock).not.toHaveBeenCalled();
+  });
+
+  it('does not throw if the plugin call rejects', async () => {
+    enableMock.mockRejectedValueOnce(new Error('boom'));
+    await expect(setLaunchOnStartupEnabled(true)).resolves.toBeUndefined();
+  });
+});

--- a/clients/wavis-gui/src/shared/autostart-bridge.ts
+++ b/clients/wavis-gui/src/shared/autostart-bridge.ts
@@ -1,0 +1,40 @@
+/**
+ * Wavis Autostart Bridge
+ *
+ * Bridges frontend ↔ the OS-level "launch Wavis at login" registration
+ * (Windows registry Run key / macOS LaunchAgent / Linux desktop autostart
+ * file) via the Tauri autostart plugin. The plugin call itself is the
+ * source of truth — there is no separate persisted setting, so the toggle
+ * always reflects what the OS actually has registered.
+ *
+ * UI components must use this module instead of importing
+ * @tauri-apps/plugin-autostart directly (see eslint no-restricted-imports
+ * fence).
+ */
+
+import { enable, disable, isEnabled } from '@tauri-apps/plugin-autostart';
+
+const LOG = '[wavis:autostart-bridge]';
+
+/** Whether Wavis is currently registered to launch at OS login. */
+export async function isLaunchOnStartupEnabled(): Promise<boolean> {
+  try {
+    return await isEnabled();
+  } catch (err) {
+    console.error(LOG, 'failed to read autostart state:', err);
+    return false;
+  }
+}
+
+/** Register (or unregister) Wavis to launch at OS login. */
+export async function setLaunchOnStartupEnabled(wantEnabled: boolean): Promise<void> {
+  try {
+    if (wantEnabled) {
+      await enable();
+    } else {
+      await disable();
+    }
+  } catch (err) {
+    console.error(LOG, 'failed to set autostart state:', err);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `tauri-plugin-autostart` (Windows registry Run key / macOS LaunchAgent / Linux desktop autostart file), **off by default**.
- After a brand-new account finishes registration (step 4 of the setup wizard), the user is asked once whether to enable launch-on-startup — `/skip` or `/enable`. This never fires for login/recovery/pairing, only for a fresh registration.
- A `Settings` → **SYSTEM TRAY & STARTUP** toggle ("Launch Wavis on startup") lets anyone change it at any time afterward.
- The OS autostart plugin call is the single source of truth (no separate persisted "enabled" flag to drift out of sync).

## How it works
- `src/shared/autostart-bridge.ts` — new bridge module wrapping `@tauri-apps/plugin-autostart` (`isLaunchOnStartupEnabled` / `setLaunchOnStartupEnabled`), following this repo's existing bridge-module convention (UI components never import `@tauri-apps/*` directly, per the `no-restricted-imports` ESLint fence).
- `DeviceSetup.tsx` gains a 4th wizard step (`LaunchOnStartupStep`, mirroring the existing `InsecureTlsToggle` extracted-component pattern) shown only after a successful new registration.
- `Settings.tsx` gets a new toggle row next to the existing "Minimize to tray on close" row, using the same `Switch` component and load/handle pattern.

## Test plan
- [x] `npx vitest --run` — new `autostart-bridge.test.ts` (plugin call mapping + error fallback) plus full existing `device-setup`/`settings-store` suites, all green.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on all changed files — 0 errors. Two pre-existing warning *types* on `DeviceSetup`/`Settings` (`max-lines-per-function`, `no-floating-promises`, `no-misused-promises`) were already present before this change; the diff adds exactly one new warning (`complexity: 18`, max 15) on `DeviceSetup`, since that component was already sitting right at the threshold. Extracted the new step into its own component (matching the existing `InsecureTlsToggle` pattern) to minimize this — going further would mean restructuring the whole pre-existing 3-step wizard, out of scope here.
- [x] `npx prettier --check` — clean.
- [x] `npx depcruise src --config .dependency-cruiser.cjs` — no circular-import violations.
- [x] `cargo check -p wavis-gui` and `cargo test -p wavis-gui` (110 passed) — both clean.
- [x] **Real end-to-end GUI verification** (Tauri debug build + Playwright via `e2e-tooling`, not just unit tests):
  - Settings toggle: screenshotted the new "SYSTEM TRAY & STARTUP" section (off by default), clicked it on, confirmed via `reg query HKCU\...\Run` that a real `Wavis` registry entry was created, clicked it off again, confirmed the registry entry was removed.
  - DeviceSetup step 4: screenshotted the "LAUNCH WAVIS ON STARTUP" screen with `/skip` and `/enable`, clicked `/enable`, confirmed via the registry again that it genuinely registered autostart. (Live-UI registration is blocked by a pre-existing, unrelated gap — the registration form has no invite-code field for this backend's alpha-invite requirement — so this specific screen was reached via a temporary, never-committed local override on a throwaway verification branch; the pre-registration steps 1–3 are unchanged code already covered by existing tests.)
  - Registry left clean on the dev machine afterward in both cases.

Closes #67