### PR TITLE
fix(gui): show READY instead of OFFLINE when media hasn't connected yet

### DIFF
--- a/clients/wavis-gui/src/features/voice/RoomHeaderBar.tsx
+++ b/clients/wavis-gui/src/features/voice/RoomHeaderBar.tsx
@@ -56,7 +56,7 @@ export function mediaIndicator(
   }
 }
 
-function combinedStatusBadge(
+export function combinedStatusBadge(
   machine: VoiceRoomMachineState,
   media: MediaState,
 ): { text: string; color: string } {
@@ -77,7 +77,10 @@ function combinedStatusBadge(
     media === 'connecting'
   )
     return { text: 'CONNECTING', color: 'var(--wavis-warn)' };
-  // Idle / disconnected
+  // Signaling is fully active — the session itself is fine, media just hasn't
+  // started yet (e.g. not in a sub-room). Not actually offline.
+  if (machine === 'active') return { text: 'READY', color: 'var(--wavis-accent)' };
+  // No active session at all
   return { text: 'OFFLINE', color: 'var(--wavis-text-secondary)' };
 }
 

--- a/clients/wavis-gui/src/features/voice/__tests__/RoomHeaderBar.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/RoomHeaderBar.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { combinedStatusBadge } from '../RoomHeaderBar';
+
+describe('combinedStatusBadge', () => {
+  it('shows READY (light green) once signaling is active but media has not started yet — not OFFLINE', () => {
+    expect(combinedStatusBadge('active', 'disconnected')).toEqual({
+      text: 'READY',
+      color: 'var(--wavis-accent)',
+    });
+  });
+
+  it('still shows OFFLINE (grey) when there is no active session at all', () => {
+    expect(combinedStatusBadge('idle', 'disconnected')).toEqual({
+      text: 'OFFLINE',
+      color: 'var(--wavis-text-secondary)',
+    });
+  });
+
+  it('shows LIVE once both signaling and media are connected', () => {
+    expect(combinedStatusBadge('active', 'connected')).toEqual({
+      text: 'LIVE',
+      color: 'var(--wavis-accent)',
+    });
+  });
+
+  it('shows CONNECTING while joining', () => {
+    expect(combinedStatusBadge('joining', 'disconnected')).toEqual({
+      text: 'CONNECTING',
+      color: 'var(--wavis-warn)',
+    });
+  });
+
+  it('shows FAILED when media fails, even if signaling is active', () => {
+    expect(combinedStatusBadge('active', 'failed')).toEqual({
+      text: 'FAILED',
+      color: 'var(--wavis-danger)',
+    });
+  });
+
+  it('shows RECONNECTING when media is reconnecting', () => {
+    expect(combinedStatusBadge('active', 'reconnecting')).toEqual({
+      text: 'RECONNECTING',
+      color: 'var(--wavis-warn)',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- The room header status badge (`combinedStatusBadge` in `RoomHeaderBar.tsx`) fell through to grey **OFFLINE** whenever signaling wasn't fully active *and* media fully connected together — including the window that occurs on **every** connect: signaling reaches `active` (the `joined` message) before LiveKit media finishes connecting (media stays buffered until the follow-up `sub_room_state`/`sub_room_joined` message triggers `connectMedia()`).
- That window is exactly what #259 reports: right after connecting, the system reads as OFFLINE even though nothing is actually wrong — the session is fine, media just hasn't started yet.
- Added a `READY` branch (light-green `--wavis-accent`, the same token already used for `LIVE`/`connected` states) for `machineState === 'active'` with media not yet connected/failed/reconnecting. Genuine offline (`idle`, no active session at all) still renders grey `OFFLINE`.
- Purely visual/label change — no functional/behavioral change, per the issue's own ask.

## Test plan
- [x] Added `RoomHeaderBar.test.ts` covering all six badge states (`READY`, `OFFLINE`, `LIVE`, `CONNECTING`, `FAILED`, `RECONNECTING`); confirmed red before the fix (function wasn't exported / READY branch didn't exist), green after.
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (739 pre-existing warnings, none in touched files)
- [x] `npm run format:check` — clean
- [x] `npm run lint:deps` — no violations
- [x] `node scripts/arch-check.mjs` — OK
- [x] **Live-app screenshot**, driven end-to-end against a real local backend (docker-compose stack, built with the `test-no-rate-limits` cargo feature for a throwaway registered account) via `run-wavis-gui`/Playwright-over-CDP: entered a real channel room and captured the header **before** joining the sub-room (`READY`, light green, `0/6`) and **after** (`LIVE`, light green, `1/6`) — both states render exactly as intended, confirming the fix against the real app, not just the unit test.

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RiwV93JoDPZ4DRB3CxP9YF