### PR TITLE
feat(gui): first-time-user tutorial for create/join/enter room

### DIFF
--- a/clients/wavis-gui/src/features/channels/ChannelsList.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelsList.tsx
@@ -17,7 +17,7 @@ import { EmptyState } from '@shared/EmptyState';
 import { LoadingBlock } from '@shared/LoadingBlock';
 import { usePolling } from '@shared/hooks/usePolling';
 import { setLastChannel } from '@features/settings/settings-store';
-import { TutorialOverlay } from './TutorialOverlay';
+import { TutorialOverlay, TUTORIAL_STEPS } from './TutorialOverlay';
 import { useTutorialVisibility } from './useTutorialVisibility';
 
 /* Constants */
@@ -31,7 +31,15 @@ function apiErrorMessage(err: ApiError): string {
 /* Component */
 export default function ChannelsList() {
   const navigate = useNavigate();
-  const { showTutorial, openTutorial, dismissTutorial } = useTutorialVisibility();
+  const {
+    showTutorial,
+    step: tutorialStep,
+    openTutorial,
+    dismissTutorial,
+    nextStep,
+    backStep,
+  } = useTutorialVisibility();
+  const tutorialHighlight = showTutorial ? TUTORIAL_STEPS[tutorialStep].highlight : null;
 
   /* State */
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -376,11 +384,13 @@ export default function ChannelsList() {
           label="/create"
           onClick={() => toggleForm('create')}
           active={activeForm === 'create'}
+          highlight={tutorialHighlight === 'create'}
         />
         <CmdButton
           label="/join"
           onClick={() => toggleForm('join')}
           active={activeForm === 'join'}
+          highlight={tutorialHighlight === 'join'}
         />
         <CmdButton
           label="/refresh"
@@ -403,7 +413,14 @@ export default function ChannelsList() {
         <CmdButton label="/help" onClick={openTutorial} />
       </div>
 
-      {showTutorial && <TutorialOverlay onDismiss={dismissTutorial} />}
+      {showTutorial && (
+        <TutorialOverlay
+          step={tutorialStep}
+          onNext={nextStep}
+          onBack={backStep}
+          onDismiss={dismissTutorial}
+        />
+      )}
     </div>
   );
 }

--- a/clients/wavis-gui/src/features/channels/ChannelsList.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelsList.tsx
@@ -17,6 +17,8 @@ import { EmptyState } from '@shared/EmptyState';
 import { LoadingBlock } from '@shared/LoadingBlock';
 import { usePolling } from '@shared/hooks/usePolling';
 import { setLastChannel } from '@features/settings/settings-store';
+import { TutorialOverlay } from './TutorialOverlay';
+import { useTutorialVisibility } from './useTutorialVisibility';
 
 /* Constants */
 const POLL_MS = 15_000;
@@ -29,6 +31,7 @@ function apiErrorMessage(err: ApiError): string {
 /* Component */
 export default function ChannelsList() {
   const navigate = useNavigate();
+  const { showTutorial, openTutorial, dismissTutorial } = useTutorialVisibility();
 
   /* State */
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -397,7 +400,10 @@ export default function ChannelsList() {
             void navigate('/settings');
           }}
         />
+        <CmdButton label="/help" onClick={openTutorial} />
       </div>
+
+      {showTutorial && <TutorialOverlay onDismiss={dismissTutorial} />}
     </div>
   );
 }

--- a/clients/wavis-gui/src/features/channels/ChannelsList.tsx
+++ b/clients/wavis-gui/src/features/channels/ChannelsList.tsx
@@ -40,6 +40,17 @@ export default function ChannelsList() {
     backStep,
   } = useTutorialVisibility();
   const tutorialHighlight = showTutorial ? TUTORIAL_STEPS[tutorialStep].highlight : null;
+  const createBtnRef = useRef<HTMLButtonElement>(null);
+  const joinBtnRef = useRef<HTMLButtonElement>(null);
+  const channelListRef = useRef<HTMLDivElement>(null);
+  const tutorialTargetRef =
+    tutorialHighlight === 'create'
+      ? createBtnRef
+      : tutorialHighlight === 'join'
+        ? joinBtnRef
+        : tutorialHighlight === 'list'
+          ? channelListRef
+          : null;
 
   /* State */
   const [channels, setChannels] = useState<Channel[]>([]);
@@ -230,65 +241,67 @@ export default function ChannelsList() {
         <div className="max-w-2xl mx-auto px-3 sm:px-6 py-6">
           <h2 className="mb-6">channels</h2>
 
-          {/* Loading state */}
-          {loading && <LoadingBlock />}
+          <div ref={channelListRef}>
+            {/* Loading state */}
+            {loading && <LoadingBlock />}
 
-          {/* Error state */}
-          {!loading && error && (
-            <ErrorPanel
-              error={error}
-              onRetry={() => {
-                void loadChannels(true);
-              }}
-            />
-          )}
+            {/* Error state */}
+            {!loading && error && (
+              <ErrorPanel
+                error={error}
+                onRetry={() => {
+                  void loadChannels(true);
+                }}
+              />
+            )}
 
-          {/* Empty state */}
-          {!loading && !error && channels.length === 0 && (
-            <EmptyState
-              message="no channels yet — create one or join by invite code"
-              className="p-4 text-center"
-            />
-          )}
+            {/* Empty state */}
+            {!loading && !error && channels.length === 0 && (
+              <EmptyState
+                message="no channels yet — create one or join by invite code"
+                className="p-4 text-center"
+              />
+            )}
 
-          {/* Channel list */}
-          {!loading && !error && channels.length > 0 && (
-            <div className="flex flex-col">
-              {channels.map((ch) => (
-                <div
-                  key={ch.id}
-                  onClick={() => {
-                    void setLastChannel(ch.id, ch.name, ch.role);
-                    void navigate('/room', {
-                      state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role },
-                    });
-                  }}
-                  className="flex items-center justify-between gap-4 px-3 sm:px-4 py-3 bg-wavis-panel border border-wavis-text-secondary hover:border-wavis-accent transition-colors text-left mb-1 cursor-pointer"
-                >
-                  <span className="min-w-0 truncate">{ch.name}</span>
-                  <div className="flex items-center gap-2 shrink-0">
-                    {voiceStatus.get(ch.id)?.active && (
-                      <span className="text-wavis-accent text-xs flex items-center gap-1">
-                        <span>●</span>
-                        <span>{voiceStatus.get(ch.id)?.participantCount}</span>
-                      </span>
-                    )}
-                    <ChannelRoleBadge role={ch.role} variant="list" />
-                    {ch.role === 'owner' && <span className="text-wavis-accent text-xs">★</span>}
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        void navigate(`/channel/${ch.id}`);
-                      }}
-                      className="border border-wavis-text-secondary text-wavis-text-secondary hover:bg-wavis-text-secondary hover:text-wavis-text-contrast transition-colors px-1 py-0.5 text-[0.625rem]"
-                    >
-                      /channel settings
-                    </button>
+            {/* Channel list */}
+            {!loading && !error && channels.length > 0 && (
+              <div className="flex flex-col">
+                {channels.map((ch) => (
+                  <div
+                    key={ch.id}
+                    onClick={() => {
+                      void setLastChannel(ch.id, ch.name, ch.role);
+                      void navigate('/room', {
+                        state: { channelId: ch.id, channelName: ch.name, channelRole: ch.role },
+                      });
+                    }}
+                    className="flex items-center justify-between gap-4 px-3 sm:px-4 py-3 bg-wavis-panel border border-wavis-text-secondary hover:border-wavis-accent transition-colors text-left mb-1 cursor-pointer"
+                  >
+                    <span className="min-w-0 truncate">{ch.name}</span>
+                    <div className="flex items-center gap-2 shrink-0">
+                      {voiceStatus.get(ch.id)?.active && (
+                        <span className="text-wavis-accent text-xs flex items-center gap-1">
+                          <span>●</span>
+                          <span>{voiceStatus.get(ch.id)?.participantCount}</span>
+                        </span>
+                      )}
+                      <ChannelRoleBadge role={ch.role} variant="list" />
+                      {ch.role === 'owner' && <span className="text-wavis-accent text-xs">★</span>}
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void navigate(`/channel/${ch.id}`);
+                        }}
+                        className="border border-wavis-text-secondary text-wavis-text-secondary hover:bg-wavis-text-secondary hover:text-wavis-text-contrast transition-colors px-1 py-0.5 text-[0.625rem]"
+                      >
+                        /channel settings
+                      </button>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          )}
+                ))}
+              </div>
+            )}
+          </div>
 
           {/* Divider before forms */}
           {activeForm !== 'none' && (
@@ -381,12 +394,14 @@ export default function ChannelsList() {
       {/* Bottom command bar */}
       <div className="border-t border-wavis-text-secondary px-3 sm:px-6 py-3 flex flex-wrap items-center gap-x-6 gap-y-2">
         <CmdButton
+          ref={createBtnRef}
           label="/create"
           onClick={() => toggleForm('create')}
           active={activeForm === 'create'}
           highlight={tutorialHighlight === 'create'}
         />
         <CmdButton
+          ref={joinBtnRef}
           label="/join"
           onClick={() => toggleForm('join')}
           active={activeForm === 'join'}
@@ -416,6 +431,7 @@ export default function ChannelsList() {
       {showTutorial && (
         <TutorialOverlay
           step={tutorialStep}
+          targetRef={tutorialTargetRef}
           onNext={nextStep}
           onBack={backStep}
           onDismiss={dismissTutorial}

--- a/clients/wavis-gui/src/features/channels/TutorialOverlay.tsx
+++ b/clients/wavis-gui/src/features/channels/TutorialOverlay.tsx
@@ -1,11 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect, useState, type RefObject } from 'react';
 import { CmdButton } from '@shared/CmdButton';
 
 export interface TutorialStep {
   title: string;
   body: string;
-  /** Which bottom-command-bar button this step points at, if any. */
-  highlight: 'create' | 'join' | null;
+  /** Which element on the channels list this step points at. */
+  highlight: 'create' | 'join' | 'list' | null;
 }
 
 export const TUTORIAL_STEPS: TutorialStep[] = [
@@ -22,20 +22,87 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
   {
     title: 'enter a room',
     body: 'Click any room in the list to enter it. Once inside you can /mute or /deafen yourself, turn on your camera, share your screen, and switch rooms without leaving the call.',
-    highlight: null,
+    highlight: 'list',
   },
 ];
 
 interface TutorialOverlayProps {
   step: number;
+  targetRef: RefObject<HTMLElement | null> | null;
   onNext: () => void;
   onBack: () => void;
   onDismiss: () => void;
 }
 
-export function TutorialOverlay({ step, onNext, onBack, onDismiss }: TutorialOverlayProps) {
+const DIALOG_WIDTH = 480;
+const VIEWPORT_MARGIN = 16;
+const TARGET_GAP = 14;
+const ARROW_MARGIN = 24;
+
+interface Anchor {
+  top: number;
+  bottom: number;
+  centerX: number;
+}
+
+export interface TutorialPlacement {
+  placeBelow: boolean;
+  dialogLeft: number | null;
+  arrowLeft: number | null;
+}
+
+/**
+ * Positions the dialog directly against its anchor target, clamped to stay
+ * fully inside the viewport, with the arrow offset recomputed to still point
+ * at the target's true center even when the dialog itself got clamped away
+ * from center (e.g. a target near the window edge).
+ */
+export function computeTutorialPlacement(
+  anchor: Anchor | null,
+  viewport: { width: number; height: number },
+): TutorialPlacement {
+  if (!anchor) return { placeBelow: false, dialogLeft: null, arrowLeft: null };
+
+  const placeBelow = anchor.top < viewport.height / 2;
+  const dialogLeft = Math.min(
+    Math.max(anchor.centerX - DIALOG_WIDTH / 2, VIEWPORT_MARGIN),
+    viewport.width - DIALOG_WIDTH - VIEWPORT_MARGIN,
+  );
+  const arrowLeft = Math.min(
+    Math.max(anchor.centerX - dialogLeft, ARROW_MARGIN),
+    DIALOG_WIDTH - ARROW_MARGIN,
+  );
+
+  return { placeBelow, dialogLeft, arrowLeft };
+}
+
+export function TutorialOverlay({
+  step,
+  targetRef,
+  onNext,
+  onBack,
+  onDismiss,
+}: TutorialOverlayProps) {
   const isLast = step === TUTORIAL_STEPS.length - 1;
   const current = TUTORIAL_STEPS[step];
+  const [anchor, setAnchor] = useState<Anchor | null>(null);
+
+  // Re-measures the target on every step change (a different element) and on
+  // resize (app window is user-resizable, min 480x400 — positions shift).
+  useLayoutEffect(() => {
+    function measure() {
+      const el = targetRef?.current;
+      if (!el) {
+        setAnchor(null);
+        return;
+      }
+      const rect = el.getBoundingClientRect();
+      setAnchor({ top: rect.top, bottom: rect.bottom, centerX: rect.left + rect.width / 2 });
+    }
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, [targetRef, step]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -45,55 +112,84 @@ export function TutorialOverlay({ step, onNext, onBack, onDismiss }: TutorialOve
     return () => document.removeEventListener('keydown', handler);
   }, [onDismiss]);
 
+  // Targets in the top half of the window get the dialog placed below them
+  // (arrow pointing up); targets in the bottom half get it placed above
+  // (arrow pointing down) — same idea as the old bottom-command-bar-only
+  // anchor, generalized to any target position.
+  const { placeBelow, dialogLeft, arrowLeft } = computeTutorialPlacement(anchor, {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  const dialogStyle =
+    anchor && dialogLeft !== null
+      ? placeBelow
+        ? { position: 'fixed' as const, top: anchor.bottom + TARGET_GAP, left: dialogLeft }
+        : {
+            position: 'fixed' as const,
+            top: anchor.top - TARGET_GAP,
+            left: dialogLeft,
+            transform: 'translateY(-100%)',
+          }
+      : { position: 'fixed' as const, left: '50%', bottom: '5rem', transform: 'translateX(-50%)' };
+
   return (
-    <div className="fixed inset-x-0 bottom-20 z-50 flex justify-center px-4 pointer-events-none">
-      <div
-        role="dialog"
-        aria-label="Wavis tutorial"
-        className="pointer-events-auto relative w-[480px] max-w-full bg-wavis-bg border border-wavis-accent font-mono text-wavis-text p-6 flex flex-col gap-4 shadow-lg"
-      >
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-wavis-accent">▲ welcome to wavis</span>
-          <button
-            onClick={onDismiss}
-            aria-label="Skip tutorial"
-            className="text-wavis-text-secondary hover:text-wavis-text text-xs"
-          >
-            /skip
-          </button>
-        </div>
-
-        <div>
-          <p className="text-sm text-wavis-accent mb-2">
-            {step + 1}/{TUTORIAL_STEPS.length} — {current.title}
-          </p>
-          <p className="text-sm text-wavis-text leading-relaxed">{current.body}</p>
-        </div>
-
-        <div className="flex items-center justify-between mt-2">
-          <div className="flex gap-1" aria-hidden="true">
-            {TUTORIAL_STEPS.map((s, i) => (
-              <span
-                key={s.title}
-                className={`h-1.5 w-1.5 rounded-full ${
-                  i === step ? 'bg-wavis-accent' : 'bg-wavis-text-secondary'
-                }`}
-              />
-            ))}
-          </div>
-          <div className="flex gap-2">
-            {step > 0 && <CmdButton label="/back" onClick={onBack} />}
-            {!isLast && <CmdButton label="/next" active onClick={onNext} />}
-            {isLast && <CmdButton label="/done" active onClick={onDismiss} />}
-          </div>
-        </div>
-
-        {/* Points down toward the command bar the step above refers to. */}
-        <div
-          aria-hidden="true"
-          className="absolute left-1/2 top-full -mt-[7px] -translate-x-1/2 h-3 w-3 rotate-45 border-b border-r border-wavis-accent bg-wavis-bg"
-        />
+    <div
+      role="dialog"
+      aria-label="Wavis tutorial"
+      style={dialogStyle}
+      className="z-50 w-[480px] max-w-full bg-wavis-bg border border-wavis-accent font-mono text-wavis-text p-6 flex flex-col gap-4 shadow-lg"
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-wavis-accent">▲ welcome to wavis</span>
+        <button
+          onClick={onDismiss}
+          aria-label="Skip tutorial"
+          className="text-wavis-text-secondary hover:text-wavis-text text-xs"
+        >
+          /skip
+        </button>
       </div>
+
+      <div>
+        <p className="text-sm text-wavis-accent mb-2">
+          {step + 1}/{TUTORIAL_STEPS.length} — {current.title}
+        </p>
+        <p className="text-sm text-wavis-text leading-relaxed">{current.body}</p>
+      </div>
+
+      <div className="flex items-center justify-between mt-2">
+        <div className="flex gap-1" aria-hidden="true">
+          {TUTORIAL_STEPS.map((s, i) => (
+            <span
+              key={s.title}
+              className={`h-1.5 w-1.5 rounded-full ${
+                i === step ? 'bg-wavis-accent' : 'bg-wavis-text-secondary'
+              }`}
+            />
+          ))}
+        </div>
+        <div className="flex gap-2">
+          {step > 0 && <CmdButton label="/back" onClick={onBack} />}
+          {!isLast && <CmdButton label="/next" active onClick={onNext} />}
+          {isLast && <CmdButton label="/done" active onClick={onDismiss} />}
+        </div>
+      </div>
+
+      {arrowLeft !== null &&
+        (placeBelow ? (
+          <div
+            aria-hidden="true"
+            style={{ left: arrowLeft }}
+            className="absolute bottom-full -mb-[7px] -translate-x-1/2 h-3 w-3 rotate-45 border-t border-l border-wavis-accent bg-wavis-bg"
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            style={{ left: arrowLeft }}
+            className="absolute top-full -mt-[7px] -translate-x-1/2 h-3 w-3 rotate-45 border-b border-r border-wavis-accent bg-wavis-bg"
+          />
+        ))}
     </div>
   );
 }

--- a/clients/wavis-gui/src/features/channels/TutorialOverlay.tsx
+++ b/clients/wavis-gui/src/features/channels/TutorialOverlay.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { CmdButton } from '@shared/CmdButton';
+
+interface TutorialStep {
+  title: string;
+  body: string;
+}
+
+export const TUTORIAL_STEPS: TutorialStep[] = [
+  {
+    title: 'create a room',
+    body: 'Click /create in the bar below, type a name for your room, and hit Enter — your room is ready instantly.',
+  },
+  {
+    title: 'join a room',
+    body: 'Got an invite code from a teammate? Click /join, paste the code, and hit Enter to join their room.',
+  },
+  {
+    title: 'enter a room',
+    body: 'Click any room in the list to enter it. Once inside you can /mute or /deafen yourself, turn on your camera, share your screen, and switch rooms without leaving the call.',
+  },
+];
+
+interface TutorialOverlayProps {
+  onDismiss: () => void;
+}
+
+export function TutorialOverlay({ onDismiss }: TutorialOverlayProps) {
+  const [step, setStep] = useState(0);
+  const isLast = step === TUTORIAL_STEPS.length - 1;
+  const current = TUTORIAL_STEPS[step];
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onDismiss();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onDismiss]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-wavis-overlay-base/60">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Wavis tutorial"
+        className="w-[480px] max-w-[95vw] bg-wavis-bg border border-wavis-text-secondary font-mono text-wavis-text p-6 flex flex-col gap-4 shadow-lg"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-wavis-accent">▲ welcome to wavis</span>
+          <button
+            onClick={onDismiss}
+            aria-label="Skip tutorial"
+            className="text-wavis-text-secondary hover:text-wavis-text text-xs"
+          >
+            /skip
+          </button>
+        </div>
+
+        <div>
+          <p className="text-sm text-wavis-accent mb-2">
+            {step + 1}/{TUTORIAL_STEPS.length} — {current.title}
+          </p>
+          <p className="text-sm text-wavis-text leading-relaxed">{current.body}</p>
+        </div>
+
+        <div className="flex items-center justify-between mt-2">
+          <div className="flex gap-1" aria-hidden="true">
+            {TUTORIAL_STEPS.map((s, i) => (
+              <span
+                key={s.title}
+                className={`h-1.5 w-1.5 rounded-full ${
+                  i === step ? 'bg-wavis-accent' : 'bg-wavis-text-secondary'
+                }`}
+              />
+            ))}
+          </div>
+          <div className="flex gap-2">
+            {step > 0 && <CmdButton label="/back" onClick={() => setStep((s) => s - 1)} />}
+            {!isLast && <CmdButton label="/next" active onClick={() => setStep((s) => s + 1)} />}
+            {isLast && <CmdButton label="/done" active onClick={onDismiss} />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/wavis-gui/src/features/channels/TutorialOverlay.tsx
+++ b/clients/wavis-gui/src/features/channels/TutorialOverlay.tsx
@@ -1,32 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { CmdButton } from '@shared/CmdButton';
 
-interface TutorialStep {
+export interface TutorialStep {
   title: string;
   body: string;
+  /** Which bottom-command-bar button this step points at, if any. */
+  highlight: 'create' | 'join' | null;
 }
 
 export const TUTORIAL_STEPS: TutorialStep[] = [
   {
     title: 'create a room',
     body: 'Click /create in the bar below, type a name for your room, and hit Enter — your room is ready instantly.',
+    highlight: 'create',
   },
   {
     title: 'join a room',
     body: 'Got an invite code from a teammate? Click /join, paste the code, and hit Enter to join their room.',
+    highlight: 'join',
   },
   {
     title: 'enter a room',
     body: 'Click any room in the list to enter it. Once inside you can /mute or /deafen yourself, turn on your camera, share your screen, and switch rooms without leaving the call.',
+    highlight: null,
   },
 ];
 
 interface TutorialOverlayProps {
+  step: number;
+  onNext: () => void;
+  onBack: () => void;
   onDismiss: () => void;
 }
 
-export function TutorialOverlay({ onDismiss }: TutorialOverlayProps) {
-  const [step, setStep] = useState(0);
+export function TutorialOverlay({ step, onNext, onBack, onDismiss }: TutorialOverlayProps) {
   const isLast = step === TUTORIAL_STEPS.length - 1;
   const current = TUTORIAL_STEPS[step];
 
@@ -39,12 +46,11 @@ export function TutorialOverlay({ onDismiss }: TutorialOverlayProps) {
   }, [onDismiss]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-wavis-overlay-base/60">
+    <div className="fixed inset-x-0 bottom-20 z-50 flex justify-center px-4 pointer-events-none">
       <div
         role="dialog"
-        aria-modal="true"
         aria-label="Wavis tutorial"
-        className="w-[480px] max-w-[95vw] bg-wavis-bg border border-wavis-text-secondary font-mono text-wavis-text p-6 flex flex-col gap-4 shadow-lg"
+        className="pointer-events-auto relative w-[480px] max-w-full bg-wavis-bg border border-wavis-accent font-mono text-wavis-text p-6 flex flex-col gap-4 shadow-lg"
       >
         <div className="flex items-center justify-between">
           <span className="text-sm text-wavis-accent">▲ welcome to wavis</span>
@@ -76,11 +82,17 @@ export function TutorialOverlay({ onDismiss }: TutorialOverlayProps) {
             ))}
           </div>
           <div className="flex gap-2">
-            {step > 0 && <CmdButton label="/back" onClick={() => setStep((s) => s - 1)} />}
-            {!isLast && <CmdButton label="/next" active onClick={() => setStep((s) => s + 1)} />}
+            {step > 0 && <CmdButton label="/back" onClick={onBack} />}
+            {!isLast && <CmdButton label="/next" active onClick={onNext} />}
             {isLast && <CmdButton label="/done" active onClick={onDismiss} />}
           </div>
         </div>
+
+        {/* Points down toward the command bar the step above refers to. */}
+        <div
+          aria-hidden="true"
+          className="absolute left-1/2 top-full -mt-[7px] -translate-x-1/2 h-3 w-3 rotate-45 border-b border-r border-wavis-accent bg-wavis-bg"
+        />
       </div>
     </div>
   );

--- a/clients/wavis-gui/src/features/channels/__tests__/TutorialOverlay.test.ts
+++ b/clients/wavis-gui/src/features/channels/__tests__/TutorialOverlay.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { computeTutorialPlacement } from '../TutorialOverlay';
+
+const VIEWPORT = { width: 960, height: 680 };
+
+describe('computeTutorialPlacement', () => {
+  it('returns nulls when there is no anchor', () => {
+    expect(computeTutorialPlacement(null, VIEWPORT)).toEqual({
+      placeBelow: false,
+      dialogLeft: null,
+      arrowLeft: null,
+    });
+  });
+
+  it('places the dialog above a target in the bottom half, arrow pointing down', () => {
+    const anchor = { top: 640, bottom: 664, centerX: 60 }; // bottom command bar
+    const { placeBelow, dialogLeft, arrowLeft } = computeTutorialPlacement(anchor, VIEWPORT);
+    expect(placeBelow).toBe(false);
+    expect(dialogLeft).not.toBeNull();
+    expect(arrowLeft).not.toBeNull();
+  });
+
+  it('places the dialog below a target in the top half, arrow pointing up', () => {
+    const anchor = { top: 120, bottom: 200, centerX: 480 }; // channel list near the top
+    const { placeBelow } = computeTutorialPlacement(anchor, VIEWPORT);
+    expect(placeBelow).toBe(true);
+  });
+
+  it('clamps the dialog to the left viewport margin for a target near the left edge', () => {
+    const anchor = { top: 640, bottom: 664, centerX: 20 }; // e.g. /create, near x=20
+    const { dialogLeft } = computeTutorialPlacement(anchor, VIEWPORT);
+    expect(dialogLeft).toBe(16); // VIEWPORT_MARGIN
+  });
+
+  it('clamps the dialog to the right viewport margin for a target near the right edge', () => {
+    const anchor = { top: 640, bottom: 664, centerX: 940 };
+    const { dialogLeft } = computeTutorialPlacement(anchor, VIEWPORT);
+    expect(dialogLeft).toBe(VIEWPORT.width - 480 - 16); // width - DIALOG_WIDTH - VIEWPORT_MARGIN
+  });
+
+  it('keeps the arrow pointing at the true target center even when the dialog is clamped', () => {
+    // centerX=100 clamps the dialog left (would otherwise center at -140)
+    // but leaves the arrow's own offset (84px) within its own margin, so
+    // this isolates the dialog-clamp behavior from the arrow-clamp behavior
+    // covered by the next test.
+    const anchor = { top: 640, bottom: 664, centerX: 100 };
+    const { dialogLeft, arrowLeft } = computeTutorialPlacement(anchor, VIEWPORT);
+    // The arrow's offset from the dialog's clamped left edge should still
+    // land on the target's real center-x, not the dialog's own center.
+    expect((dialogLeft ?? 0) + (arrowLeft ?? 0)).toBe(anchor.centerX);
+  });
+
+  it('clamps the arrow to stay within the dialog bounds when the target center-arrow math would push it out', () => {
+    const anchor = { top: 640, bottom: 664, centerX: 20 };
+    const { arrowLeft } = computeTutorialPlacement(anchor, VIEWPORT);
+    expect(arrowLeft).toBeGreaterThanOrEqual(24); // ARROW_MARGIN
+    expect(arrowLeft).toBeLessThanOrEqual(480 - 24); // DIALOG_WIDTH - ARROW_MARGIN
+  });
+});

--- a/clients/wavis-gui/src/features/channels/useTutorialVisibility.ts
+++ b/clients/wavis-gui/src/features/channels/useTutorialVisibility.ts
@@ -1,9 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 import { getHasSeenTutorial, setHasSeenTutorial } from '@features/settings/settings-store';
+import { TUTORIAL_STEPS } from './TutorialOverlay';
+
+const LAST_STEP = TUTORIAL_STEPS.length - 1;
 
 /** Shows the first-time tutorial once per account, and lets it be reopened on demand. */
 export function useTutorialVisibility() {
   const [showTutorial, setShowTutorial] = useState(false);
+  const [step, setStep] = useState(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -15,12 +19,18 @@ export function useTutorialVisibility() {
     };
   }, []);
 
-  const openTutorial = useCallback(() => setShowTutorial(true), []);
+  const openTutorial = useCallback(() => {
+    setStep(0);
+    setShowTutorial(true);
+  }, []);
 
   const dismissTutorial = useCallback(() => {
     setShowTutorial(false);
     void setHasSeenTutorial(true);
   }, []);
 
-  return { showTutorial, openTutorial, dismissTutorial };
+  const nextStep = useCallback(() => setStep((s) => Math.min(s + 1, LAST_STEP)), []);
+  const backStep = useCallback(() => setStep((s) => Math.max(s - 1, 0)), []);
+
+  return { showTutorial, step, openTutorial, dismissTutorial, nextStep, backStep };
 }

--- a/clients/wavis-gui/src/features/channels/useTutorialVisibility.ts
+++ b/clients/wavis-gui/src/features/channels/useTutorialVisibility.ts
@@ -1,0 +1,26 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getHasSeenTutorial, setHasSeenTutorial } from '@features/settings/settings-store';
+
+/** Shows the first-time tutorial once per account, and lets it be reopened on demand. */
+export function useTutorialVisibility() {
+  const [showTutorial, setShowTutorial] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getHasSeenTutorial().then((seen) => {
+      if (!cancelled && !seen) setShowTutorial(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const openTutorial = useCallback(() => setShowTutorial(true), []);
+
+  const dismissTutorial = useCallback(() => {
+    setShowTutorial(false);
+    void setHasSeenTutorial(true);
+  }, []);
+
+  return { showTutorial, openTutorial, dismissTutorial };
+}

--- a/clients/wavis-gui/src/features/settings/__tests__/settings-store.test.ts
+++ b/clients/wavis-gui/src/features/settings/__tests__/settings-store.test.ts
@@ -48,6 +48,8 @@ import {
   setDenoiseEnabled,
   getVideoInputDevice,
   setVideoInputDevice,
+  getHasSeenTutorial,
+  setHasSeenTutorial,
   STORE_KEYS,
   DEFAULT_VOLUME,
   DEFAULT_MUTE_HOTKEY,
@@ -353,6 +355,25 @@ describe('inputVolumeToGain', () => {
       }),
       { numRuns: 101 },
     );
+  });
+});
+
+describe('Has seen tutorial round-trip', () => {
+  it('persists and retrieves boolean', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.boolean(), async (seen) => {
+        mockStorage.clear();
+        await setHasSeenTutorial(seen);
+        const result = await getHasSeenTutorial();
+        expect(result).toBe(seen);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  it('defaults to false when unset', async () => {
+    const result = await getHasSeenTutorial();
+    expect(result).toBe(false);
   });
 });
 

--- a/clients/wavis-gui/src/features/settings/settings-store.ts
+++ b/clients/wavis-gui/src/features/settings/settings-store.ts
@@ -74,6 +74,7 @@ export const STORE_KEYS = {
   lastChannelId: 'wavis_last_channel_id',
   lastChannelName: 'wavis_last_channel_name',
   lastChannelRole: 'wavis_last_channel_role',
+  hasSeenTutorial: 'wavis_has_seen_tutorial',
 } as const;
 
 export const DEFAULT_RECONNECT_CONFIG: ReconnectConfig = {
@@ -379,6 +380,16 @@ export async function clearLastChannel(): Promise<void> {
     setStoreValue(STORE_KEYS.lastChannelName, null),
     setStoreValue(STORE_KEYS.lastChannelRole, null),
   ]);
+}
+
+// ─── First-Time Tutorial ───────────────────────────────────────────
+
+export async function getHasSeenTutorial(): Promise<boolean> {
+  return getStoreValue(STORE_KEYS.hasSeenTutorial, false);
+}
+
+export async function setHasSeenTutorial(seen: boolean): Promise<void> {
+  return setStoreValue(STORE_KEYS.hasSeenTutorial, seen);
 }
 
 // ─── Screen Share Codec Override (W4 post-shootout) ────────────────

--- a/clients/wavis-gui/src/shared/CmdButton.tsx
+++ b/clients/wavis-gui/src/shared/CmdButton.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from 'react';
+
 interface CmdButtonProps {
   label: string;
   onClick: () => void;
@@ -8,28 +10,24 @@ interface CmdButtonProps {
   className?: string;
 }
 
-export function CmdButton({
-  label,
-  onClick,
-  active,
-  danger,
-  disabled,
-  highlight,
-  className,
-}: CmdButtonProps) {
+export const CmdButton = forwardRef<HTMLButtonElement, CmdButtonProps>(function CmdButton(
+  { label, onClick, active, danger, disabled, highlight, className },
+  ref,
+) {
   return (
     <button
+      ref={ref}
       onClick={onClick}
       disabled={disabled}
       className={`disabled:opacity-40 disabled:cursor-not-allowed border text-center transition-colors ${className ?? 'text-xs px-1 py-0.5'} ${
         danger
           ? 'border-wavis-danger text-wavis-danger hover:bg-wavis-danger hover:text-wavis-bg'
           : active
-            ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
+            ? 'border-wavis-accent text-wavis-accent bg-wavis-accent/8 hover:bg-wavis-accent hover:text-wavis-bg'
             : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'
       } ${highlight ? 'ring-2 ring-wavis-accent ring-offset-2 ring-offset-wavis-bg animate-pulse' : ''}`}
     >
       {label}
     </button>
   );
-}
+});

--- a/clients/wavis-gui/src/shared/CmdButton.tsx
+++ b/clients/wavis-gui/src/shared/CmdButton.tsx
@@ -4,10 +4,19 @@ interface CmdButtonProps {
   active?: boolean;
   danger?: boolean;
   disabled?: boolean;
+  highlight?: boolean;
   className?: string;
 }
 
-export function CmdButton({ label, onClick, active, danger, disabled, className }: CmdButtonProps) {
+export function CmdButton({
+  label,
+  onClick,
+  active,
+  danger,
+  disabled,
+  highlight,
+  className,
+}: CmdButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -18,7 +27,7 @@ export function CmdButton({ label, onClick, active, danger, disabled, className 
           : active
             ? 'border-wavis-accent text-wavis-accent hover:bg-wavis-accent hover:text-wavis-bg'
             : 'border-wavis-text-secondary text-wavis-text hover:bg-wavis-text-secondary hover:text-wavis-text-contrast'
-      }`}
+      } ${highlight ? 'ring-2 ring-wavis-accent ring-offset-2 ring-offset-wavis-bg animate-pulse' : ''}`}
     >
       {label}
     </button>


### PR DESCRIPTION
## Summary
- Adds a dismissible, terminal-styled tutorial overlay shown once to first-time users on the channels list, walking through creating a room, joining by invite code, and what to expect once inside a room (mute/deafen/camera/share/switch rooms).
- Dismissal persists via a new `hasSeenTutorial` settings-store flag (`wavis_has_seen_tutorial`), following the existing boolean-flag pattern (see `getMinimizeToTray`/`setMinimizeToTray`).
- Adds a `/help` command to the channels-list command bar so the tutorial can be reopened anytime, independent of the persisted flag.
- Gating logic extracted into `useTutorialVisibility` to keep the already-oversized `ChannelsList` component's lint footprint (max-lines-per-function / complexity, both pre-existing baseline warnings) essentially unchanged.

The issue (#176) had no body/spec — this was a greenfield feature with no prior onboarding/tutorial code anywhere in the repo (confirmed via full-codebase search). Scope and design (auto-show once + manual reopen, matching the app's existing terminal/`/command` aesthetic) were derived from the issue title and the codebase's existing UI conventions.

## Test plan
- [x] Unit: `getHasSeenTutorial`/`setHasSeenTutorial` round-trip + default-false test added to `settings-store.test.ts` (existing property-test pattern) — 29/29 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` on changed files — 0 new warnings (`TutorialOverlay.tsx`/`useTutorialVisibility.ts` are warning-free; `ChannelsList.tsx`'s 3 warnings are pre-existing baseline, confirmed unchanged before/after).
- [x] `npm run lint:deps` — no dependency violations.
- [x] `npx prettier --check .` — clean.
- [x] Full suite: `npx vitest --run` — 1467/1467 pass.
- [x] Real-app verification (Tauri debug build + Playwright over CDP via `run-wavis-gui` skill, real backend): confirmed tutorial auto-shows on first visit to the channels list, steps 1→2→3 navigate correctly, dismiss (`/done`) persists (does not reappear after relaunch), and `/help` reopens it manually.

## Screenshots (real app)
Auto-shown, step 1/3:
`▲ welcome to wavis` · `1/3 — create a room` · `/create in the bar below...`

Reopened via `/help` after dismissal on a fresh relaunch (proves persistence + manual reopen both work).

Closes #176