### PR TITLE
fix(audio): de-ess mic capture to tame harsh sibilance/highs

### DIFF
--- a/clients/shared/src/biquad.rs
+++ b/clients/shared/src/biquad.rs
@@ -1,0 +1,185 @@
+//! Shared RBJ biquad filter primitive used by DSP stages that need cheap,
+//! stable low-pass/high-pass/high-shelf filtering (passthrough tone shaping,
+//! de-essing). Coefficients can be retuned in place without resetting the
+//! filter's internal state, so callers that change parameters every frame
+//! (e.g. a dynamic shelf gain) don't introduce clicks.
+
+use std::f32::consts::PI;
+
+#[derive(Debug, Clone)]
+pub(crate) struct Biquad {
+    b0: f32,
+    b1: f32,
+    b2: f32,
+    a1: f32,
+    a2: f32,
+    z1: f32,
+    z2: f32,
+}
+
+impl Biquad {
+    pub(crate) fn identity() -> Self {
+        Self {
+            b0: 1.0,
+            b1: 0.0,
+            b2: 0.0,
+            a1: 0.0,
+            a2: 0.0,
+            z1: 0.0,
+            z2: 0.0,
+        }
+    }
+
+    pub(crate) fn low_pass(sample_rate: f32, cutoff_hz: f32, q: f32) -> Self {
+        let mut biquad = Self::identity();
+        biquad.retune_low_pass(sample_rate, cutoff_hz, q);
+        biquad
+    }
+
+    pub(crate) fn high_pass(sample_rate: f32, cutoff_hz: f32, q: f32) -> Self {
+        let mut biquad = Self::identity();
+        biquad.retune_high_pass(sample_rate, cutoff_hz, q);
+        biquad
+    }
+
+    pub(crate) fn high_shelf(
+        sample_rate: f32,
+        frequency_hz: f32,
+        gain_db: f32,
+        slope: f32,
+    ) -> Self {
+        let mut biquad = Self::identity();
+        biquad.retune_high_shelf(sample_rate, frequency_hz, gain_db, slope);
+        biquad
+    }
+
+    pub(crate) fn retune_low_pass(&mut self, sample_rate: f32, cutoff_hz: f32, q: f32) {
+        let cutoff = cutoff_hz.clamp(20.0, sample_rate * 0.45);
+        let omega = 2.0 * PI * cutoff / sample_rate;
+        let sin = omega.sin();
+        let cos = omega.cos();
+        let alpha = sin / (2.0 * q.max(0.001));
+        let b0 = (1.0 - cos) * 0.5;
+        let b1 = 1.0 - cos;
+        let b2 = (1.0 - cos) * 0.5;
+        let a0 = 1.0 + alpha;
+        let a1 = -2.0 * cos;
+        let a2 = 1.0 - alpha;
+        self.set_normalized(b0, b1, b2, a0, a1, a2);
+    }
+
+    pub(crate) fn retune_high_pass(&mut self, sample_rate: f32, cutoff_hz: f32, q: f32) {
+        let cutoff = cutoff_hz.clamp(20.0, sample_rate * 0.45);
+        let omega = 2.0 * PI * cutoff / sample_rate;
+        let sin = omega.sin();
+        let cos = omega.cos();
+        let alpha = sin / (2.0 * q.max(0.001));
+        let b0 = (1.0 + cos) * 0.5;
+        let b1 = -(1.0 + cos);
+        let b2 = (1.0 + cos) * 0.5;
+        let a0 = 1.0 + alpha;
+        let a1 = -2.0 * cos;
+        let a2 = 1.0 - alpha;
+        self.set_normalized(b0, b1, b2, a0, a1, a2);
+    }
+
+    pub(crate) fn retune_high_shelf(
+        &mut self,
+        sample_rate: f32,
+        frequency_hz: f32,
+        gain_db: f32,
+        slope: f32,
+    ) {
+        let frequency = frequency_hz.clamp(20.0, sample_rate * 0.45);
+        let a = 10.0_f32.powf(gain_db / 40.0);
+        let omega = 2.0 * PI * frequency / sample_rate;
+        let sin = omega.sin();
+        let cos = omega.cos();
+        let sqrt_a = a.sqrt();
+        let alpha = (sin / 2.0) * ((a + 1.0 / a) * (1.0 / slope.max(0.001) - 1.0) + 2.0).sqrt();
+
+        let b0 = a * ((a + 1.0) + (a - 1.0) * cos + 2.0 * sqrt_a * alpha);
+        let b1 = -2.0 * a * ((a - 1.0) + (a + 1.0) * cos);
+        let b2 = a * ((a + 1.0) + (a - 1.0) * cos - 2.0 * sqrt_a * alpha);
+        let a0 = (a + 1.0) - (a - 1.0) * cos + 2.0 * sqrt_a * alpha;
+        let a1 = 2.0 * ((a - 1.0) - (a + 1.0) * cos);
+        let a2 = (a + 1.0) - (a - 1.0) * cos - 2.0 * sqrt_a * alpha;
+        self.set_normalized(b0, b1, b2, a0, a1, a2);
+    }
+
+    fn set_normalized(&mut self, b0: f32, b1: f32, b2: f32, a0: f32, a1: f32, a2: f32) {
+        if !a0.is_finite() || a0.abs() < f32::EPSILON {
+            self.b0 = 1.0;
+            self.b1 = 0.0;
+            self.b2 = 0.0;
+            self.a1 = 0.0;
+            self.a2 = 0.0;
+            return;
+        }
+        self.b0 = b0 / a0;
+        self.b1 = b1 / a0;
+        self.b2 = b2 / a0;
+        self.a1 = a1 / a0;
+        self.a2 = a2 / a0;
+    }
+
+    pub(crate) fn process(&mut self, input: f32) -> f32 {
+        let input = if input.is_finite() { input } else { 0.0 };
+        let output = input * self.b0 + self.z1;
+        self.z1 = input * self.b1 + self.z2 - self.a1 * output;
+        self.z2 = input * self.b2 - self.a2 * output;
+        output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sine(freq: f32, samples: usize, sample_rate: f32) -> Vec<f32> {
+        (0..samples)
+            .map(|i| (2.0 * PI * freq * i as f32 / sample_rate).sin() * 0.5)
+            .collect()
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
+    #[test]
+    fn retune_high_shelf_preserves_state_across_gain_changes() {
+        // Retuning mid-stream must not reset z1/z2 -- otherwise a per-frame
+        // gain update (as used by the de-esser) would click every frame.
+        let mut biquad = Biquad::high_shelf(48_000.0, 5_000.0, -6.0, 0.707);
+        let warm = sine(8_000.0, 200, 48_000.0);
+        for s in &warm {
+            biquad.process(*s);
+        }
+        let before_state = (biquad.z1, biquad.z2);
+        biquad.retune_high_shelf(48_000.0, 5_000.0, -3.0, 0.707);
+        assert_eq!((biquad.z1, biquad.z2), before_state);
+    }
+
+    #[test]
+    fn high_pass_attenuates_low_frequency_more_than_high() {
+        let mut biquad_low = Biquad::high_pass(48_000.0, 5_000.0, 0.707);
+        let mut biquad_high = Biquad::high_pass(48_000.0, 5_000.0, 0.707);
+        let low: Vec<f32> = sine(300.0, 4_800, 48_000.0)
+            .into_iter()
+            .map(|s| biquad_low.process(s))
+            .collect();
+        let high: Vec<f32> = sine(8_000.0, 4_800, 48_000.0)
+            .into_iter()
+            .map(|s| biquad_high.process(s))
+            .collect();
+        assert!(rms(&low) < rms(&high) * 0.1);
+    }
+
+    #[test]
+    fn zero_gain_high_shelf_is_near_unity() {
+        let mut biquad = Biquad::high_shelf(48_000.0, 5_000.0, 0.0, 0.707);
+        let input = sine(8_000.0, 4_800, 48_000.0);
+        let output: Vec<f32> = input.iter().map(|s| biquad.process(*s)).collect();
+        assert!((rms(&output) - rms(&input)).abs() < 0.01);
+    }
+}

--- a/clients/shared/src/deesser_filter.rs
+++ b/clients/shared/src/deesser_filter.rs
@@ -1,0 +1,170 @@
+//! Dynamic de-esser for the mic capture path (#286).
+//!
+//! Consumer mics often reproduce sibilant consonants ("S"/"T") and other
+//! high-pitched transients well hotter than the rest of the voice signal,
+//! which is uncomfortable to listen to even at a normal playback volume.
+//! This applies a high-shelf cut above [`SHELF_HZ`] whose depth tracks how
+//! much energy is currently detected in that band: normal speech passes
+//! through close to untouched, sibilant bursts get pulled down. Coefficients
+//! are retuned in place each frame (not rebuilt), so the filter state
+//! carries over and gain changes don't click.
+
+use crate::biquad::Biquad;
+
+const SAMPLE_RATE_HZ: f32 = 48_000.0;
+const DETECT_HZ: f32 = 5_000.0;
+const SHELF_HZ: f32 = 5_000.0;
+const SHELF_Q: f32 = 0.707;
+/// Detector RMS (post high-pass) above which the shelf starts cutting.
+const ENGAGE_RMS: f32 = 0.05;
+/// Deepest cut the shelf will apply, regardless of how hot the sibilance is.
+const MAX_CUT_DB: f32 = -14.0;
+/// How many dB of cut are added per unit of RMS above `ENGAGE_RMS`.
+const CUT_DB_PER_RMS: f32 = 60.0;
+/// One-pole smoothing applied to the gain each 20ms frame (~50-60ms time
+/// constant) so the shelf eases in/out instead of snapping.
+const GAIN_SMOOTHING: f32 = 0.35;
+
+pub struct DeesserFilter {
+    detector: Biquad,
+    shelf: Biquad,
+    gain_db: f32,
+}
+
+impl DeesserFilter {
+    pub fn new() -> Self {
+        Self {
+            detector: Biquad::high_pass(SAMPLE_RATE_HZ, DETECT_HZ, SHELF_Q),
+            shelf: Biquad::high_shelf(SAMPLE_RATE_HZ, SHELF_HZ, 0.0, SHELF_Q),
+            gain_db: 0.0,
+        }
+    }
+
+    /// Process a frame in place. Called once per 20ms (960-sample) capture
+    /// frame in production, but any non-empty length works.
+    pub fn process(&mut self, frame: &mut [f32]) {
+        if frame.is_empty() {
+            return;
+        }
+
+        let mut sum_sq = 0.0f32;
+        for &sample in frame.iter() {
+            let sample = if sample.is_finite() { sample } else { 0.0 };
+            let detected = self.detector.process(sample);
+            sum_sq += detected * detected;
+        }
+        let detect_rms = (sum_sq / frame.len() as f32).sqrt();
+
+        let target_db = if detect_rms > ENGAGE_RMS {
+            (-(detect_rms - ENGAGE_RMS) * CUT_DB_PER_RMS).max(MAX_CUT_DB)
+        } else {
+            0.0
+        };
+        self.gain_db += (target_db - self.gain_db) * GAIN_SMOOTHING;
+        self.shelf
+            .retune_high_shelf(SAMPLE_RATE_HZ, SHELF_HZ, self.gain_db, SHELF_Q);
+
+        for sample in frame.iter_mut() {
+            let input = if sample.is_finite() { *sample } else { 0.0 };
+            let output = self.shelf.process(input);
+            *sample = if output.is_finite() { output } else { 0.0 };
+        }
+    }
+}
+
+impl Default for DeesserFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    const FRAME_SAMPLES: usize = 960; // 20ms @ 48kHz, matches production frames
+
+    fn sine(freq: f32, amplitude: f32, samples: usize) -> Vec<f32> {
+        (0..samples)
+            .map(|i| (2.0 * PI * freq * i as f32 / SAMPLE_RATE_HZ).sin() * amplitude)
+            .collect()
+    }
+
+    fn rms(samples: &[f32]) -> f32 {
+        (samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32).sqrt()
+    }
+
+    /// Feeds a signal through the filter for several 20ms frames so the
+    /// smoothed gain has time to converge, returning the last frame's output.
+    fn settle(
+        filter: &mut DeesserFilter,
+        freq: f32,
+        amplitude: f32,
+        frame_count: usize,
+    ) -> Vec<f32> {
+        let mut last = Vec::new();
+        for _ in 0..frame_count {
+            let mut frame = sine(freq, amplitude, FRAME_SAMPLES);
+            filter.process(&mut frame);
+            last = frame;
+        }
+        last
+    }
+
+    #[test]
+    fn loud_sibilant_hiss_is_attenuated() {
+        // 7.5kHz stands in for "S"/"T" sibilance energy.
+        let mut filter = DeesserFilter::new();
+        let input_rms = rms(&sine(7_500.0, 0.5, FRAME_SAMPLES));
+        let settled = settle(&mut filter, 7_500.0, 0.5, 15);
+        let output_rms = rms(&settled);
+        assert!(
+            output_rms < input_rms * 0.7,
+            "expected sibilant band to be cut, input_rms={input_rms} output_rms={output_rms}"
+        );
+    }
+
+    #[test]
+    fn normal_voiced_speech_passes_through_near_unchanged() {
+        // 300Hz stands in for a normal vowel, well below the detect band,
+        // even at a loud amplitude -- must not get pulled down.
+        let mut filter = DeesserFilter::new();
+        let input_rms = rms(&sine(300.0, 0.5, FRAME_SAMPLES));
+        let settled = settle(&mut filter, 300.0, 0.5, 15);
+        let output_rms = rms(&settled);
+        assert!(
+            (output_rms - input_rms).abs() < input_rms * 0.05,
+            "expected voiced speech untouched, input_rms={input_rms} output_rms={output_rms}"
+        );
+    }
+
+    #[test]
+    fn quiet_high_frequency_content_is_not_cut() {
+        // Quiet high-frequency air/room tone shouldn't trip the de-esser.
+        let mut filter = DeesserFilter::new();
+        let input_rms = rms(&sine(7_500.0, 0.02, FRAME_SAMPLES));
+        let settled = settle(&mut filter, 7_500.0, 0.02, 15);
+        let output_rms = rms(&settled);
+        assert!(
+            (output_rms - input_rms).abs() < input_rms * 0.1,
+            "expected quiet high content untouched, input_rms={input_rms} output_rms={output_rms}"
+        );
+    }
+
+    #[test]
+    fn output_stays_finite_with_non_finite_input() {
+        let mut filter = DeesserFilter::new();
+        let mut frame = vec![0.0f32, f32::NAN, f32::INFINITY, -0.5, 0.5];
+        filter.process(&mut frame);
+        assert!(frame.iter().all(|s| s.is_finite()));
+    }
+
+    #[test]
+    fn empty_frame_is_a_no_op() {
+        let mut filter = DeesserFilter::new();
+        let mut frame: Vec<f32> = Vec::new();
+        filter.process(&mut frame);
+        assert!(frame.is_empty());
+    }
+}

--- a/clients/shared/src/lib.rs
+++ b/clients/shared/src/lib.rs
@@ -28,9 +28,13 @@ pub mod audio_network_monitor;
 #[cfg(feature = "real-backends")]
 pub mod audio_pipeline_real;
 #[cfg(feature = "real-backends")]
+mod biquad;
+#[cfg(feature = "real-backends")]
 pub mod cpal_audio;
 #[cfg(feature = "real-backends")]
 mod cpal_device;
+#[cfg(feature = "real-backends")]
+pub mod deesser_filter;
 #[cfg(feature = "real-backends")]
 pub mod denoise_filter;
 #[cfg(feature = "real-backends")]

--- a/clients/shared/src/livekit_connection.rs
+++ b/clients/shared/src/livekit_connection.rs
@@ -20,6 +20,8 @@ use crate::cpal_audio::AudioBuffer;
 #[cfg(feature = "real-backends")]
 use crate::cpal_audio::PeerVolumes;
 #[cfg(feature = "real-backends")]
+use crate::deesser_filter::DeesserFilter;
+#[cfg(feature = "real-backends")]
 use crate::denoise_filter::DenoiseFilter;
 #[cfg(feature = "real-backends")]
 use crate::passthrough_filter::PassthroughFilters;
@@ -744,8 +746,9 @@ impl LiveKitConnection for RealLiveKitConnection {
 
         // Spawn background task to push mic PCM into the NativeAudioSource.
         // Reads 960 mono f32 samples (20ms @ 48kHz) from the capture buffer,
-        // applies denoise (if wired), converts to i16, and calls capture_frame
-        // every 20ms using absolute deadline pacing to eliminate cumulative drift.
+        // applies denoise (if wired) then de-essing, converts to i16, and
+        // calls capture_frame every 20ms using absolute deadline pacing to
+        // eliminate cumulative drift.
         #[cfg(feature = "real-backends")]
         {
             let capture_buf = self.capture_buffer.lock().unwrap().clone();
@@ -774,6 +777,7 @@ impl LiveKitConnection for RealLiveKitConnection {
                     let mut frame_i16 = vec![0i16; FRAME_SAMPLES];
                     let mut last_sample_f32: f32 = 0.0;
                     let mut primed = false;
+                    let mut deesser = DeesserFilter::new();
 
                     // Absolute-deadline pacing state.
                     let start = Instant::now();
@@ -866,6 +870,10 @@ impl LiveKitConnection for RealLiveKitConnection {
                         if let Some(ref dn) = denoise {
                             dn.process(&mut frame_f32[..FRAME_SAMPLES]);
                         }
+
+                        // De-ess: pull down harsh sibilance / high-pitched
+                        // content (#286) before it goes out over the wire.
+                        deesser.process(&mut frame_f32[..FRAME_SAMPLES]);
 
                         // Convert f32 → i16 for the LiveKit NativeAudioSource.
                         for (i, &s) in frame_f32.iter().enumerate() {

--- a/clients/shared/src/passthrough_filter.rs
+++ b/clients/shared/src/passthrough_filter.rs
@@ -1,5 +1,5 @@
+use crate::biquad::Biquad;
 use std::collections::HashSet;
-use std::f32::consts::PI;
 use std::sync::{Arc, Mutex};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -127,90 +127,10 @@ impl Default for PassthroughBiquadChain {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Biquad {
-    b0: f32,
-    b1: f32,
-    b2: f32,
-    a1: f32,
-    a2: f32,
-    z1: f32,
-    z2: f32,
-}
-
-impl Biquad {
-    fn identity() -> Self {
-        Self {
-            b0: 1.0,
-            b1: 0.0,
-            b2: 0.0,
-            a1: 0.0,
-            a2: 0.0,
-            z1: 0.0,
-            z2: 0.0,
-        }
-    }
-
-    fn low_pass(sample_rate: f32, cutoff_hz: f32, q: f32) -> Self {
-        let cutoff = cutoff_hz.clamp(20.0, sample_rate * 0.45);
-        let omega = 2.0 * PI * cutoff / sample_rate;
-        let sin = omega.sin();
-        let cos = omega.cos();
-        let alpha = sin / (2.0 * q.max(0.001));
-        let b0 = (1.0 - cos) * 0.5;
-        let b1 = 1.0 - cos;
-        let b2 = (1.0 - cos) * 0.5;
-        let a0 = 1.0 + alpha;
-        let a1 = -2.0 * cos;
-        let a2 = 1.0 - alpha;
-        Self::normalize(b0, b1, b2, a0, a1, a2)
-    }
-
-    fn high_shelf(sample_rate: f32, frequency_hz: f32, gain_db: f32, slope: f32) -> Self {
-        let frequency = frequency_hz.clamp(20.0, sample_rate * 0.45);
-        let a = 10.0_f32.powf(gain_db / 40.0);
-        let omega = 2.0 * PI * frequency / sample_rate;
-        let sin = omega.sin();
-        let cos = omega.cos();
-        let sqrt_a = a.sqrt();
-        let alpha = (sin / 2.0) * ((a + 1.0 / a) * (1.0 / slope.max(0.001) - 1.0) + 2.0).sqrt();
-
-        let b0 = a * ((a + 1.0) + (a - 1.0) * cos + 2.0 * sqrt_a * alpha);
-        let b1 = -2.0 * a * ((a - 1.0) + (a + 1.0) * cos);
-        let b2 = a * ((a + 1.0) + (a - 1.0) * cos - 2.0 * sqrt_a * alpha);
-        let a0 = (a + 1.0) - (a - 1.0) * cos + 2.0 * sqrt_a * alpha;
-        let a1 = 2.0 * ((a - 1.0) - (a + 1.0) * cos);
-        let a2 = (a + 1.0) - (a - 1.0) * cos - 2.0 * sqrt_a * alpha;
-        Self::normalize(b0, b1, b2, a0, a1, a2)
-    }
-
-    fn normalize(b0: f32, b1: f32, b2: f32, a0: f32, a1: f32, a2: f32) -> Self {
-        if !a0.is_finite() || a0.abs() < f32::EPSILON {
-            return Self::identity();
-        }
-        Self {
-            b0: b0 / a0,
-            b1: b1 / a0,
-            b2: b2 / a0,
-            a1: a1 / a0,
-            a2: a2 / a0,
-            z1: 0.0,
-            z2: 0.0,
-        }
-    }
-
-    fn process(&mut self, input: f32) -> f32 {
-        let input = if input.is_finite() { input } else { 0.0 };
-        let output = input * self.b0 + self.z1;
-        self.z1 = input * self.b1 + self.z2 - self.a1 * output;
-        self.z2 = input * self.b2 - self.a2 * output;
-        output
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f32::consts::PI;
 
     fn sine(freq: f32, samples: usize) -> Vec<f32> {
         (0..samples)


### PR DESCRIPTION
## Summary

- Fixes #286 — "the mic picks up a lot of highs and it hurts the listeners' ears even at lowish volume."
- The LiveKit mic-capture path (`livekit_connection.rs`, the path all GUI voice calls use) ran `DenoiseFilter` but had **no high-frequency/sibilance handling at all** — S/T sibilance and other harsh highs went out unprocessed.
- Adds `DeesserFilter` (`clients/shared/src/deesser_filter.rs`): a dynamic high-shelf cut above 5kHz whose depth tracks per-frame detected high-band energy (0dB when quiet, up to -14dB when hot), smoothed (~50-60ms) so it eases in/out instead of clicking. Wired in right after denoise, before Opus encode.
- Extracted the existing `Biquad` RBJ filter (previously private inside `passthrough_filter.rs`, used for the subrooms "passthrough" muffle effect) into a shared `clients/shared/src/biquad.rs` module so the de-esser reuses the same tested filter math instead of a second copy. Added `retune_*` methods that update coefficients in place without resetting filter state — needed so the de-esser's per-frame gain changes don't click.
- The raw P2P `webrtc_loops.rs`/APM send path (used only by `cli-test`/`wavis-client` dev tooling, never by the GUI) is untouched — out of scope since it's not what real users hit.

## Test plan

- [x] `cargo test -p wavis-client-shared --features real-backends --lib` — new tests in `deesser_filter.rs` reproduce the reported symptom with synthetic signals: a loud 7.5kHz sine (stand-in for S/T sibilance) is attenuated >30%, a loud 300Hz sine (normal voiced speech) passes through within 5%, quiet high-frequency content is left alone, non-finite input stays finite.
- [x] `passthrough_filter.rs`'s existing 4 tests still pass unchanged after the `Biquad` extraction (no behavior change to the subrooms passthrough filter).
- [x] `cargo clippy -p wavis-client-shared --features real-backends -- -D warnings` — clean.
- [x] `cargo fmt` — clean (touched files only).
- [x] `node scripts/arch-check.mjs` — OK.
- [ ] Full `--features livekit,real-backends` build could not be verified locally — the native `webrtc-sys` vendor C++ build fails in this worktree on a pre-existing, unrelated missing-header issue (`delegated_source_list_controller.h`, `absl/strings/has_absl_stringify.h`) that reproduces on a first native build in a fresh worktree and touches no code from this PR. CI's cached/prebuilt environment should not hit this.

Closes #286