### PR TITLE
feat(gui): collect invite code in desktop registration flow

### DIFF
--- a/clients/wavis-gui/src/features/auth/DeviceSetup.tsx
+++ b/clients/wavis-gui/src/features/auth/DeviceSetup.tsx
@@ -55,6 +55,10 @@ export function validateStep1(
   return { valid: Object.keys(errors).length === 0, errors };
 }
 
+export function validateInviteCode(inviteCode: string): string | null {
+  return inviteCode.trim() ? null : 'Invite code is required';
+}
+
 function InsecureTlsToggle({
   insecureTls,
   setInsecureTls,
@@ -150,6 +154,7 @@ export default function DeviceSetup() {
   const [username, setUsernameValue] = useState('');
   const [phrase, setPhrase] = useState('');
   const [confirmPhrase, setConfirmPhrase] = useState('');
+  const [inviteCode, setInviteCode] = useState('');
   const [insecureTls, setInsecureTls] = useState(false);
   const [registering, setRegistering] = useState(false);
   const [logs, setLogs] = useState<AuthLogEntry[]>([]);
@@ -157,6 +162,7 @@ export default function DeviceSetup() {
   const [nameError, setNameError] = useState<string | null>(null);
   const [phraseError, setPhraseError] = useState<string | null>(null);
   const [confirmPhraseError, setConfirmPhraseError] = useState<string | null>(null);
+  const [inviteCodeError, setInviteCodeError] = useState<string | null>(null);
   const [registerError, setRegisterError] = useState<string | null>(null);
   const [showRetry, setShowRetry] = useState(false);
 
@@ -208,6 +214,7 @@ export default function DeviceSetup() {
     if (registering) return;
 
     setUrlError(null);
+    setInviteCodeError(null);
     setRegisterError(null);
     setShowRetry(false);
 
@@ -217,13 +224,27 @@ export default function DeviceSetup() {
       return;
     }
 
+    const trimmedInviteCode = inviteCode.trim();
+    const inviteError = validateInviteCode(inviteCode);
+    if (inviteError) {
+      setInviteCodeError(inviteError);
+      return;
+    }
+
     const trimmedName = username.trim();
     setRegistering(true);
     setLogs([]);
 
-    const result = await registerUser(serverUrl, phrase, trimmedName, insecureTls, (entry) => {
-      setLogs((prev) => [...prev, entry]);
-    });
+    const result = await registerUser(
+      serverUrl,
+      phrase,
+      trimmedName,
+      trimmedInviteCode,
+      insecureTls,
+      (entry) => {
+        setLogs((prev) => [...prev, entry]);
+      },
+    );
 
     setRegistering(false);
     setPhrase('');
@@ -235,6 +256,11 @@ export default function DeviceSetup() {
       return;
     }
 
+    if (result.inviteRejected) {
+      setInviteCodeError('Invalid or expired invite code');
+      return;
+    }
+
     const err = result.error ?? '';
     if (err.includes('too many requests')) {
       setRegisterError('too many requests - try again later');
@@ -242,7 +268,7 @@ export default function DeviceSetup() {
       setRegisterError('Registration failed - please try again');
       setShowRetry(true);
     }
-  }, [serverUrl, username, phrase, insecureTls, registering]);
+  }, [serverUrl, username, phrase, inviteCode, insecureTls, registering]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -355,6 +381,19 @@ export default function DeviceSetup() {
               </p>
               <p className="mt-2 text-wavis-accent">It looks like: https://wavis.yourteam.com</p>
             </div>
+
+            <AuthFieldRow
+              label="Invite Code:"
+              placeholder="the code your admin sent you"
+              value={inviteCode}
+              onChange={(value) => {
+                setInviteCode(value);
+                setInviteCodeError(null);
+              }}
+              onKeyDown={handleKeyDown}
+              error={inviteCodeError}
+              disabled={registering}
+            />
 
             <InsecureTlsToggle
               insecureTls={insecureTls}

--- a/clients/wavis-gui/src/features/auth/__tests__/auth-helpers.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/auth-helpers.test.ts
@@ -3,7 +3,7 @@ import { invoke } from '@tauri-apps/api/core';
 
 let mockStore: Record<string, unknown> = {};
 let mockKeychain: Record<string, string> = {};
-let mockFetchMode: 'register_ok' | 'recover_ok' = 'register_ok';
+let mockFetchMode: 'register_ok' | 'recover_ok' | 'register_invite_rejected' = 'register_ok';
 let fetchBodies: unknown[] = [];
 
 vi.mock('@tauri-apps/plugin-store', () => ({
@@ -51,6 +51,14 @@ vi.mock('@tauri-apps/plugin-http', () => ({
           access_token: `h.${btoa(JSON.stringify({ exp: futureExp }))}.s`,
           refresh_token: 'refresh-register',
         }),
+      };
+    }
+    if (url.includes('/auth/register') && mockFetchMode === 'register_invite_rejected') {
+      return {
+        ok: false,
+        status: 401,
+        headers: { get: () => null },
+        json: async () => ({ error: 'authentication failed' }),
       };
     }
     if (url.includes('/auth/recover') && mockFetchMode === 'recover_ok') {
@@ -138,12 +146,54 @@ describe('recovery ID storage helpers', () => {
       'https://wavis.example.com',
       'passphrase',
       'user',
+      'ALPHA-CODE-1',
       false,
       () => {},
     );
 
     expect(result).toEqual({ success: true, recovery_id: 'wvs-REG-0001' });
     expect(mockStore['recovery_id']).toBe('wvs-REG-0001');
+    expect(mockStore['server_url']).toBe('https://wavis.example.com');
+    expect(mockKeychain['wavis_refresh_token']).toBe('refresh-register');
+    expect(mockStore['device_id']).toBe('device-1');
+  });
+
+  it('registerUser sends invite_code alongside phrase and username', async () => {
+    mockFetchMode = 'register_ok';
+    const auth = await import('../auth');
+
+    await auth.registerUser(
+      'https://wavis.example.com',
+      'passphrase',
+      'user',
+      'ALPHA-CODE-1',
+      false,
+      () => {},
+    );
+
+    expect(fetchBodies).toMatchObject([
+      { phrase: 'passphrase', username: 'user', invite_code: 'ALPHA-CODE-1' },
+    ]);
+  });
+
+  it('registerUser surfaces a rejected invite as inviteRejected without storing any tokens', async () => {
+    mockFetchMode = 'register_invite_rejected';
+    const auth = await import('../auth');
+
+    const result = await auth.registerUser(
+      'https://wavis.example.com',
+      'passphrase',
+      'user',
+      'BAD-CODE',
+      false,
+      () => {},
+    );
+
+    expect(result.success).toBe(false);
+    expect(result).toMatchObject({ inviteRejected: true });
+    expect(mockStore['device_id']).toBeUndefined();
+    expect(mockStore['recovery_id']).toBeUndefined();
+    expect(mockKeychain['wavis_refresh_token']).toBeUndefined();
   });
 
   it('resetAuth deletes the stored recovery ID', async () => {

--- a/clients/wavis-gui/src/features/auth/__tests__/device-setup.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/device-setup.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { validateStep1 } from '../DeviceSetup';
+import { validateStep1, validateInviteCode } from '../DeviceSetup';
 
 describe('validateStep1', () => {
   it('rejects mismatched passwords', () => {
@@ -21,5 +21,19 @@ describe('validateStep1', () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors.username).toBe('username must be 64 characters or less');
+  });
+});
+
+describe('validateInviteCode', () => {
+  it('rejects an empty invite code', () => {
+    expect(validateInviteCode('')).toBe('Invite code is required');
+  });
+
+  it('rejects a whitespace-only invite code', () => {
+    expect(validateInviteCode('   ')).toBe('Invite code is required');
+  });
+
+  it('accepts a non-empty invite code', () => {
+    expect(validateInviteCode('ALPHA-CODE-1')).toBeNull();
   });
 });

--- a/clients/wavis-gui/src/features/auth/__tests__/login.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/login.test.ts
@@ -229,8 +229,8 @@ async function simulateReregister(serverUrl: string): Promise<{
 }> {
   const auth = await import('../auth');
   const insecure = await auth.getInsecureTls();
-  // TODO(task-22): pass phrase and deviceName from UI inputs
-  const result = await auth.registerUser(serverUrl, '', '', insecure, () => {});
+  // TODO(task-22): pass phrase, deviceName, and inviteCode from UI inputs
+  const result = await auth.registerUser(serverUrl, '', '', '', insecure, () => {});
 
   if (result.success) {
     navigateTarget = '/';

--- a/clients/wavis-gui/src/features/auth/auth.ts
+++ b/clients/wavis-gui/src/features/auth/auth.ts
@@ -254,9 +254,13 @@ export async function registerUser(
   serverUrl: string,
   phrase: string,
   username: string,
+  inviteCode: string,
   insecureTls: boolean,
   onLog: (entry: AuthLogEntry) => void,
-): Promise<{ success: true; recovery_id: string } | { success: false; error?: string }> {
+): Promise<
+  | { success: true; recovery_id: string }
+  | { success: false; error?: string; inviteRejected?: boolean }
+> {
   onLog(makeLogEntry('Validating server URL: ' + serverUrl, 'info'));
   const validation = validateServerUrl(serverUrl, insecureTls);
   if (!validation.valid) {
@@ -274,7 +278,7 @@ export async function registerUser(
     res = await tauriFetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ phrase, username }),
+      body: JSON.stringify({ phrase, username, invite_code: inviteCode }),
       ...(INSECURE_TLS_ALLOWED && insecureTls ? { dangerouslyIgnoreCertificateErrors: true } : {}),
     });
   } catch (err) {
@@ -282,6 +286,12 @@ export async function registerUser(
     onLog(makeLogEntry(msg, 'error'));
     console.error(LOG_PREFIX, 'register network error:', err);
     return { success: false, error: msg };
+  }
+
+  if (res.status === 401) {
+    const msg = 'Invite code rejected -- check the code and try again';
+    onLog(makeLogEntry(msg, 'error'));
+    return { success: false, error: msg, inviteRejected: true };
   }
 
   if (res.status === 429) {


### PR DESCRIPTION
## Summary
- Adds an **Invite Code** field to `DeviceSetup` step 2 (server URL step), required before `/register` fires.
- `registerUser` now sends `invite_code` alongside `phrase`/`username` and special-cases the backend's `401` (the only auth-failure code `/auth/register` returns, per `map_register_error` in `wavis-backend/src/auth/routes.rs`) as a rejected invite, surfaced as an inline field error ("Invalid or expired invite code") distinct from the generic registration-failure banner.
- Recovery (`recoverAccount`) and reconnect (`refreshTokens`) flows are untouched — they hit `/auth/recover` and `/auth/refresh`, neither of which is invite-gated.

Closes #266 (sub-task of #239, backend gate landed in #264/#281).

## Test plan
- [x] `npx vitest run src/features/auth` — 92/92 passing, including new cases: `validateInviteCode` (required/whitespace/valid), `registerUser` sends `invite_code` in the body, a rejected invite surfaces `inviteRejected: true` without storing any tokens/device id.
- [x] `npx tsc --noEmit`, `npm run format:check`, `npm run lint` (0 errors, pre-existing warning baseline unchanged), `npm run lint:deps` — all clean.
- [x] Live verification: built a debug exe against the local docker backend (`tools/dev/start-backend-e2e.ps1` + `seed-invite.ps1`), drove `DeviceSetup` end-to-end via the `run-wavis-gui` Playwright harness — a wrong invite code shows the inline "Invalid or expired invite code" error, and the seeded code completes registration through to the step-3 recovery-ID screen with a real server-issued `recovery_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8kBgRkugg4qotr9JvBMQ1