### PR TITLE
feat(backend): require WS pre-auth tickets before upgrade

### DIFF
--- a/wavis-backend/src/abuse/abuse_metrics.rs
+++ b/wavis-backend/src/abuse/abuse_metrics.rs
@@ -24,6 +24,7 @@ pub struct AbuseMetrics {
     pub revoke_authorization_rejections: AtomicU64,
     pub tls_proto_rejections: AtomicU64,
     pub invite_usage_anomalies: AtomicU64,
+    pub ws_ticket_rejections: AtomicU64,
 }
 
 impl AbuseMetrics {
@@ -46,6 +47,7 @@ impl AbuseMetrics {
             revoke_authorization_rejections: AtomicU64::new(0),
             tls_proto_rejections: AtomicU64::new(0),
             invite_usage_anomalies: AtomicU64::new(0),
+            ws_ticket_rejections: AtomicU64::new(0),
         }
     }
 
@@ -82,6 +84,7 @@ impl AbuseMetrics {
                 .load(Ordering::Relaxed),
             tls_proto_rejections: self.tls_proto_rejections.load(Ordering::Relaxed),
             invite_usage_anomalies: self.invite_usage_anomalies.load(Ordering::Relaxed),
+            ws_ticket_rejections: self.ws_ticket_rejections.load(Ordering::Relaxed),
         }
     }
 }
@@ -112,6 +115,7 @@ pub struct AbuseMetricsSnapshot {
     pub revoke_authorization_rejections: u64,
     pub tls_proto_rejections: u64,
     pub invite_usage_anomalies: u64,
+    pub ws_ticket_rejections: u64,
 }
 
 /// Tracks per-IP failed join attempts within a sliding window.

--- a/wavis-backend/src/app_state.rs
+++ b/wavis-backend/src/app_state.rs
@@ -32,6 +32,7 @@ use crate::abuse::temp_ban::{TempBanConfig, TempBanList};
 use crate::auth::auth_rate_limiter::AuthRateLimiter;
 use crate::auth::phrase;
 use crate::auth::recovery_rate_limiter::RecoveryRateLimiter;
+use crate::auth::ws_ticket::WsTicketStore;
 use crate::channel::channel_rate_limiter::{ChannelRateLimiter, ChannelRateLimiterConfig};
 use crate::channel::invite::InviteStore;
 use crate::connections::LiveConnections;
@@ -139,6 +140,9 @@ pub struct AppState {
     pub refresh_token_pepper_previous: Option<Arc<Vec<u8>>>,
     /// HMAC pepper for closed-alpha invite code hashing.
     pub alpha_invite_code_pepper: Arc<Vec<u8>>,
+    /// In-memory store for short-lived, one-use `/ws` pre-auth tickets.
+    /// Not Postgres-backed: a 60-second TTL has no value across restarts.
+    pub ws_ticket_store: Arc<WsTicketStore>,
     /// Channel_ID → active Room_ID mapping. A Channel has at most one active Room.
     /// Lock ordering position 0: active_room_map (0) → rooms (1) → per-room (2) → peer_to_room (3).
     pub active_room_map: ActiveRoomMap,
@@ -279,6 +283,21 @@ impl AppState {
         }
         let alpha_invite_code_pepper = Arc::new(alpha_invite_code_pepper.into_bytes());
 
+        let ws_ticket_pepper = match std::env::var("WS_TICKET_PEPPER") {
+            Ok(s) => s,
+            Err(_) => {
+                if cfg!(debug_assertions) {
+                    "dev-ws-ticket-pepper-32-bytes!!X".to_string()
+                } else {
+                    panic!("WS_TICKET_PEPPER must be set in release builds");
+                }
+            }
+        };
+        if ws_ticket_pepper.len() < 32 {
+            panic!("WS_TICKET_PEPPER must be at least 32 bytes");
+        }
+        let ws_ticket_store = Arc::new(WsTicketStore::new(ws_ticket_pepper.into_bytes()));
+
         Self {
             room_state: Arc::new(InMemoryRoomState::new()),
             connections: Arc::new(LiveConnections::new()),
@@ -345,6 +364,7 @@ impl AppState {
             refresh_token_pepper,
             refresh_token_pepper_previous,
             alpha_invite_code_pepper,
+            ws_ticket_store,
             active_room_map: Arc::new(RwLock::new(HashMap::new())),
             dummy_verifier,
             pairing_code_pepper,

--- a/wavis-backend/src/auth/mod.rs
+++ b/wavis-backend/src/auth/mod.rs
@@ -9,3 +9,4 @@ pub mod pairing;
 pub mod phrase;
 pub mod recovery_rate_limiter;
 pub mod routes;
+pub mod ws_ticket;

--- a/wavis-backend/src/auth/routes.rs
+++ b/wavis-backend/src/auth/routes.rs
@@ -26,6 +26,7 @@ use crate::auth::device::{self, DeviceError};
 use crate::auth::extractor::AuthenticatedUser;
 use crate::auth::jwt::ACCESS_TOKEN_TTL_SECS;
 use crate::auth::pairing::{self, PairingError};
+use crate::auth::ws_ticket;
 use crate::ip::extract_client_ip;
 use crate::redaction::redact_token;
 use axum::Json;
@@ -140,6 +141,12 @@ pub struct UpdateUsernameRequest {
 #[derive(Serialize)]
 pub struct MeResponse {
     pub username: String,
+}
+
+#[derive(Serialize)]
+pub struct WsTicketResponse {
+    pub ticket: String,
+    pub expires_in: u64,
 }
 
 #[derive(Serialize)]
@@ -708,6 +715,24 @@ pub async fn rotate_phrase(
             ))
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// POST /auth/ws-ticket (Bearer auth required)
+// ---------------------------------------------------------------------------
+
+pub async fn issue_ws_ticket(
+    State(app_state): State<AppState>,
+    user: AuthenticatedUser,
+) -> Json<WsTicketResponse> {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(user.user_id, user.device_id);
+
+    Json(WsTicketResponse {
+        ticket,
+        expires_in: ws_ticket::TICKET_TTL_SECS,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/wavis-backend/src/auth/ws_ticket.rs
+++ b/wavis-backend/src/auth/ws_ticket.rs
@@ -1,0 +1,250 @@
+//! Short-lived, one-use WebSocket pre-auth tickets.
+//!
+//! A ticket lets an already Bearer-authenticated client prove its identity
+//! to the `/ws` upgrade handler without ever sending a long-lived access
+//! token over a connection that hasn't upgraded yet. Minted by
+//! `POST /auth/ws-ticket`, consumed exactly once by the `/ws` pre-upgrade
+//! check.
+//!
+//! Stored in-memory (not Postgres): a 60-second TTL has no value once the
+//! process restarts, and every other pre-upgrade abuse control (temp ban,
+//! IP cap, global ceiling) is already an in-memory `RwLock<HashMap<..>>` —
+//! this follows the same pattern rather than introducing a DB round-trip
+//! into the hot `/ws` upgrade path.
+
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use sha2::Sha256;
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Ticket time-to-live (Req: short-lived).
+pub const TICKET_TTL_SECS: u64 = 60;
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum WsTicketError {
+    #[error("ticket not found")]
+    NotFound,
+    #[error("ticket expired")]
+    Expired,
+    #[error("ticket already consumed")]
+    AlreadyConsumed,
+}
+
+struct TicketRecord {
+    user_id: Uuid,
+    device_id: Uuid,
+    expires_at: Instant,
+    consumed: bool,
+}
+
+/// Compute HMAC-SHA256 of a raw ticket using the server-side pepper.
+/// Only this hash is ever stored — the raw ticket exists solely in the
+/// REST response and the client's `?ticket=` query parameter.
+fn hash_ticket(raw_ticket: &str, pepper: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(pepper).expect("HMAC-SHA256 accepts any key length");
+    mac.update(raw_ticket.as_bytes());
+    mac.finalize().into_bytes().to_vec()
+}
+
+/// Generate a cryptographically random ticket (256-bit, base64url-encoded, no padding).
+fn generate_ticket() -> String {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+pub struct WsTicketStore {
+    tickets: RwLock<HashMap<Vec<u8>, TicketRecord>>,
+    pepper: Vec<u8>,
+    ttl: Duration,
+    now: fn() -> Instant,
+}
+
+impl WsTicketStore {
+    pub fn new(pepper: Vec<u8>) -> Self {
+        Self::with_clock(pepper, Instant::now)
+    }
+
+    pub fn with_clock(pepper: Vec<u8>, now: fn() -> Instant) -> Self {
+        Self {
+            tickets: RwLock::new(HashMap::new()),
+            pepper,
+            ttl: Duration::from_secs(TICKET_TTL_SECS),
+            now,
+        }
+    }
+
+    /// Mint a new ticket for an authenticated user/device. Returns the raw
+    /// (plaintext) ticket — only its hash is retained.
+    pub fn issue(&self, user_id: Uuid, device_id: Uuid) -> String {
+        let raw = generate_ticket();
+        let hash = hash_ticket(&raw, &self.pepper);
+        let expires_at = (self.now)() + self.ttl;
+
+        self.tickets
+            .write()
+            .expect("ws tickets write lock poisoned")
+            .insert(
+                hash,
+                TicketRecord {
+                    user_id,
+                    device_id,
+                    expires_at,
+                    consumed: false,
+                },
+            );
+
+        raw
+    }
+
+    /// Validate and atomically consume a raw ticket. One-use: the check and
+    /// the `consumed` mutation happen under a single write-lock acquisition,
+    /// so two concurrent consumers of the same ticket cannot both succeed.
+    pub fn validate_and_consume(&self, raw_ticket: &str) -> Result<(Uuid, Uuid), WsTicketError> {
+        let hash = hash_ticket(raw_ticket, &self.pepper);
+        let now = (self.now)();
+        let mut tickets = self
+            .tickets
+            .write()
+            .expect("ws tickets write lock poisoned");
+
+        match tickets.get_mut(&hash) {
+            None => Err(WsTicketError::NotFound),
+            Some(record) if record.consumed => Err(WsTicketError::AlreadyConsumed),
+            Some(record) if record.expires_at <= now => Err(WsTicketError::Expired),
+            Some(record) => {
+                record.consumed = true;
+                Ok((record.user_id, record.device_id))
+            }
+        }
+    }
+
+    /// Prune expired/consumed entries so the map stays bounded. Returns the
+    /// count removed. Wired into the background auth-token sweep.
+    pub fn prune_expired(&self) -> usize {
+        let now = (self.now)();
+        let mut tickets = self
+            .tickets
+            .write()
+            .expect("ws tickets write lock poisoned");
+        let before = tickets.len();
+        tickets.retain(|_, r| !r.consumed && r.expires_at > now);
+        before - tickets.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    fn test_store() -> WsTicketStore {
+        WsTicketStore::new(b"test-ws-ticket-pepper-32-bytes!!".to_vec())
+    }
+
+    #[test]
+    fn issue_then_consume_succeeds_once() {
+        let store = test_store();
+        let user_id = Uuid::new_v4();
+        let device_id = Uuid::new_v4();
+
+        let ticket = store.issue(user_id, device_id);
+        let result = store.validate_and_consume(&ticket);
+        assert_eq!(result, Ok((user_id, device_id)));
+    }
+
+    #[test]
+    fn replayed_ticket_fails() {
+        let store = test_store();
+        let ticket = store.issue(Uuid::new_v4(), Uuid::new_v4());
+
+        assert!(store.validate_and_consume(&ticket).is_ok());
+        assert_eq!(
+            store.validate_and_consume(&ticket),
+            Err(WsTicketError::AlreadyConsumed)
+        );
+    }
+
+    #[test]
+    fn unknown_ticket_fails() {
+        let store = test_store();
+        assert_eq!(
+            store.validate_and_consume("not-a-real-ticket"),
+            Err(WsTicketError::NotFound)
+        );
+    }
+
+    #[test]
+    fn expired_ticket_fails_via_clock_injection() {
+        static TICK: AtomicU64 = AtomicU64::new(0);
+        TICK.store(0, Ordering::SeqCst);
+        fn fake_clock() -> Instant {
+            Instant::now() + Duration::from_secs(TICK.load(Ordering::SeqCst))
+        }
+
+        let store =
+            WsTicketStore::with_clock(b"test-ws-ticket-pepper-32-bytes!!".to_vec(), fake_clock);
+        let ticket = store.issue(Uuid::new_v4(), Uuid::new_v4());
+
+        TICK.store(TICKET_TTL_SECS + 1, Ordering::SeqCst);
+        assert_eq!(
+            store.validate_and_consume(&ticket),
+            Err(WsTicketError::Expired)
+        );
+    }
+
+    #[test]
+    fn prune_expired_removes_stale_and_consumed_entries() {
+        static TICK: AtomicU64 = AtomicU64::new(0);
+        TICK.store(0, Ordering::SeqCst);
+        fn fake_clock() -> Instant {
+            Instant::now() + Duration::from_secs(TICK.load(Ordering::SeqCst))
+        }
+
+        let store =
+            WsTicketStore::with_clock(b"test-ws-ticket-pepper-32-bytes!!".to_vec(), fake_clock);
+        let consumed_ticket = store.issue(Uuid::new_v4(), Uuid::new_v4());
+        let _unconsumed_ticket = store.issue(Uuid::new_v4(), Uuid::new_v4());
+        store.validate_and_consume(&consumed_ticket).unwrap();
+
+        TICK.store(TICKET_TTL_SECS + 1, Ordering::SeqCst);
+        let pruned = store.prune_expired();
+        assert_eq!(
+            pruned, 2,
+            "both consumed and expired-unconsumed tickets are pruned"
+        );
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        #[test]
+        fn prop_hash_ticket_deterministic(
+            ticket in "[A-Za-z0-9_-]{8,64}",
+            pepper in prop::collection::vec(any::<u8>(), 16..64),
+        ) {
+            let hash1 = hash_ticket(&ticket, &pepper);
+            let hash2 = hash_ticket(&ticket, &pepper);
+            prop_assert_eq!(hash1, hash2);
+        }
+
+        #[test]
+        fn prop_different_tickets_different_hashes(
+            ticket_a in "[A-Za-z0-9_-]{8,64}",
+            ticket_b in "[A-Za-z0-9_-]{8,64}",
+            pepper in prop::collection::vec(any::<u8>(), 16..64),
+        ) {
+            prop_assume!(ticket_a != ticket_b);
+            let hash_a = hash_ticket(&ticket_a, &pepper);
+            let hash_b = hash_ticket(&ticket_b, &pepper);
+            prop_assert_ne!(hash_a, hash_b);
+        }
+    }
+}

--- a/wavis-backend/src/main.rs
+++ b/wavis-backend/src/main.rs
@@ -617,6 +617,7 @@ async fn main() -> io::Result<()> {
             post(auth::routes::revoke_device),
         )
         .route("/auth/phrase/rotate", post(auth::routes::rotate_phrase))
+        .route("/auth/ws-ticket", post(auth::routes::issue_ws_ticket))
         // Channel routes — static /channels/* routes MUST come before /channels/{channel_id}
         .route(
             "/channels",
@@ -1099,6 +1100,11 @@ pub fn spawn_auth_token_sweep(app_state: AppState) {
                 .prune_stale(std::time::Instant::now());
             if pruned > 0 {
                 tracing::debug!(pruned, "pruned stale auth rate limiter entries");
+            }
+            // Prune expired/consumed ws-tickets (in-memory, unbounded otherwise).
+            let ws_tickets_pruned = app_state.ws_ticket_store.prune_expired();
+            if ws_tickets_pruned > 0 {
+                tracing::debug!(ws_tickets_pruned, "pruned expired/consumed ws-tickets");
             }
         }
     });

--- a/wavis-backend/src/ws/ws.rs
+++ b/wavis-backend/src/ws/ws.rs
@@ -35,10 +35,11 @@ use crate::ws::ws_dispatch::{DispatchContext, DispatchOutcome, SfuConfig, dispat
 use crate::ws::ws_rate_limit::{WsRateLimiter, check_json_depth};
 use crate::ws::ws_session::{SignalingSession, cleanup_unjoined_connection};
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
-use axum::extract::{ConnectInfo, State};
+use axum::extract::{ConnectInfo, Query, State};
 use axum::http::HeaderMap;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
 use shared::signaling::{self, ErrorPayload, SignalingMessage};
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
@@ -46,6 +47,12 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
+
+/// Query params accepted on the `/ws` upgrade request.
+#[derive(Deserialize)]
+pub struct WsUpgradeQuery {
+    ticket: Option<String>,
+}
 
 const MAX_TEXT_MESSAGE_BYTES: usize = 64 * 1024;
 const MSG_TOO_LARGE: &str = "message too large";
@@ -111,6 +118,7 @@ pub async fn ws_handler(
     ws: WebSocketUpgrade,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
+    Query(query): Query<WsUpgradeQuery>,
     State(app_state): State<AppState>,
 ) -> Response {
     let client_ip = extract_client_ip(&ConnectInfo(addr), &headers, &app_state.ip_config);
@@ -148,7 +156,33 @@ pub async fn ws_handler(
         return (StatusCode::TOO_MANY_REQUESTS, "too many requests").into_response();
     }
 
-    // Pre-upgrade check 2: per-IP connection cap (Req 2.2)
+    // Pre-upgrade check 2a: ws-ticket required (closed-alpha lockdown — every
+    // /ws connection must present a ticket minted by an authenticated
+    // POST /auth/ws-ticket call). Runs before the IP cap increment below so
+    // a rejected ticket never consumes a connection-count slot.
+    let authenticated = match query.ticket.as_deref() {
+        Some(ticket) if !ticket.is_empty() => {
+            match app_state.ws_ticket_store.validate_and_consume(ticket) {
+                Ok(pair) => pair,
+                Err(err) => {
+                    app_state
+                        .abuse_metrics
+                        .increment(&app_state.abuse_metrics.ws_ticket_rejections);
+                    warn!(ip = %client_ip, error = %err, "ws upgrade rejected: invalid ticket");
+                    return StatusCode::UNAUTHORIZED.into_response();
+                }
+            }
+        }
+        _ => {
+            app_state
+                .abuse_metrics
+                .increment(&app_state.abuse_metrics.ws_ticket_rejections);
+            warn!(ip = %client_ip, "ws upgrade rejected: missing ticket");
+            return StatusCode::UNAUTHORIZED.into_response();
+        }
+    };
+
+    // Pre-upgrade check 2b: per-IP connection cap (Req 2.2)
     if !app_state.ip_connection_tracker.try_add(client_ip) {
         app_state
             .abuse_metrics
@@ -157,10 +191,15 @@ pub async fn ws_handler(
         return (StatusCode::TOO_MANY_REQUESTS, "too many requests").into_response();
     }
 
-    ws.on_upgrade(move |socket| handle_socket(socket, app_state, client_ip))
+    ws.on_upgrade(move |socket| handle_socket(socket, app_state, client_ip, authenticated))
 }
 
-async fn handle_socket(mut socket: WebSocket, app_state: AppState, client_ip: IpAddr) {
+async fn handle_socket(
+    mut socket: WebSocket,
+    app_state: AppState,
+    client_ip: IpAddr,
+    authenticated: (Uuid, Uuid),
+) {
     // RAII guard: decrements per-IP connection count when this function exits for any reason (Req 2.3)
     let _conn_guard = ConnectionGuard {
         tracker: app_state.ip_connection_tracker.clone(),
@@ -181,9 +220,13 @@ async fn handle_socket(mut socket: WebSocket, app_state: AppState, client_ip: Ip
     let mut chat_rate_limiter = ChatRateLimiter::new(5.0);
     let sfu_config = SfuConfig::from_app_state(&app_state.jwt_secret, &app_state.jwt_issuer);
     let mut session: Option<SignalingSession> = None;
-    let mut authenticated_user_id: Option<String> = None;
+    // A validated ws-ticket authenticates the connection before the message
+    // loop even starts (Req: successful ticket validation initializes the
+    // WebSocket as authenticated for that user/device).
+    let (ticket_user_id, ticket_device_id) = authenticated;
+    let mut authenticated_user_id: Option<String> = Some(ticket_user_id.to_string());
     #[allow(unused_variables, unused_assignments)]
-    let mut authenticated_device_id: Option<Uuid> = None;
+    let mut authenticated_device_id: Option<Uuid> = Some(ticket_device_id);
     // authenticated_device_id is stored for the connection lifetime (audit logging, future use)
 
     app_state.connections.register(peer_id.clone(), outbound_tx);

--- a/wavis-backend/tests/abuse_controls_integration.rs
+++ b/wavis-backend/tests/abuse_controls_integration.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::ip_tracker::IpConnectionTracker;
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
@@ -164,15 +165,24 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
 
 /// Try to connect â€” returns Err if server rejects upgrade (e.g. HTTP 429).
-async fn try_ws_connect(addr: SocketAddr) -> Result<(WsSink, WsStream), String> {
-    let url = format!("ws://{addr}/ws");
+async fn try_ws_connect(
+    addr: SocketAddr,
+    app_state: &AppState,
+) -> Result<(WsSink, WsStream), String> {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     match connect_async(&url).await {
         Ok((ws, _)) => Ok(ws.split()),
         Err(e) => Err(format!("{e}")),
@@ -252,10 +262,10 @@ async fn expect_close_or_error(stream: &mut WsStream, expected_error: &str) {
 // 10b: Host mutes Guest â†’ both receive participant_muted (BroadcastAll)
 #[tokio::test]
 async fn test10_mute_participant_host_flow() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Host joins first
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"mute-test","roomType":"sfu"}),
@@ -266,7 +276,7 @@ async fn test10_mute_participant_host_flow() {
     drain(&mut r_host).await;
 
     // Guest joins second
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"mute-test","roomType":"sfu"}),
@@ -305,7 +315,7 @@ async fn test10_mute_participant_host_flow() {
 
     // Verify guest is still in the room (mute is advisory, not removal)
     assert_eq!(
-        _state.room_state.peer_count("mute-test"),
+        state.room_state.peer_count("mute-test"),
         2,
         "both peers should still be in room after mute"
     );
@@ -318,10 +328,10 @@ async fn test10_mute_participant_host_flow() {
 // 10c: Mute nonexistent participant â†’ error
 #[tokio::test]
 async fn test10c_mute_nonexistent_participant() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Host joins
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"mute-ghost","roomType":"sfu"}),
@@ -347,10 +357,10 @@ async fn test10c_mute_nonexistent_participant() {
 // 10d: Mute in P2P room â†’ "action not supported in P2P mode"
 #[tokio::test]
 async fn test10d_mute_in_p2p_room_rejected() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Join a P2P room (explicit roomType:"p2p")
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     ws_send(
         &mut s1,
         json!({"type":"join","roomId":"p2p-mute","roomType":"p2p"}),
@@ -360,7 +370,7 @@ async fn test10d_mute_in_p2p_room_rejected() {
     drain(&mut r1).await;
 
     // Second peer joins P2P room
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"p2p-mute","roomType":"p2p"}),
@@ -398,9 +408,9 @@ async fn test11_1_ws_message_rate_limiting() {
         deafen_window: Duration::from_secs(60),
         max_json_depth: 32,
     };
-    let (addr, _state) = start_server_custom(false, Some(ws_config), None, None).await;
+    let (addr, state) = start_server_custom(false, Some(ws_config), None, None).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Message 1: join (counts toward rate limit)
     ws_send(
@@ -439,9 +449,9 @@ async fn test11_2_burst_detection() {
         deafen_window: Duration::from_secs(60),
         max_json_depth: 32,
     };
-    let (addr, _state) = start_server_custom(false, Some(ws_config), None, None).await;
+    let (addr, state) = start_server_custom(false, Some(ws_config), None, None).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Send 4 messages rapidly within 1 second â€” first 3 accepted, 4th triggers burst limit
     // Message 1: join
@@ -502,10 +512,10 @@ async fn test11_3_action_rate_limiting() {
         deafen_window: Duration::from_secs(60),
         max_json_depth: 32,
     };
-    let (addr, _state) = start_server_custom(false, Some(ws_config), None, None).await;
+    let (addr, state) = start_server_custom(false, Some(ws_config), None, None).await;
 
     // Host joins
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"action-rl","roomType":"sfu"}),
@@ -515,7 +525,7 @@ async fn test11_3_action_rate_limiting() {
     drain(&mut r_host).await;
 
     // Guest joins
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"action-rl","roomType":"sfu"}),
@@ -571,10 +581,10 @@ async fn test11_3_kick_and_mute_share_action_counter() {
         deafen_max: 1000,
         deafen_window: Duration::from_secs(60),
     };
-    let (addr, _state) = start_server_custom(false, Some(ws_config), None, None).await;
+    let (addr, state) = start_server_custom(false, Some(ws_config), None, None).await;
 
     // Host joins
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"shared-rl","roomType":"sfu"}),
@@ -584,7 +594,7 @@ async fn test11_3_kick_and_mute_share_action_counter() {
     drain(&mut r_host).await;
 
     // Guest joins
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"shared-rl","roomType":"sfu"}),
@@ -614,7 +624,7 @@ async fn test11_3_kick_and_mute_share_action_counter() {
     let _ = recv_type(&mut r_host, "participant_kicked").await;
 
     // Need a new guest for the 3rd action attempt
-    let (mut s_guest2, mut r_guest2) = ws_connect(addr).await;
+    let (mut s_guest2, mut r_guest2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest2,
         json!({"type":"join","roomId":"shared-rl","roomType":"sfu"}),
@@ -642,9 +652,9 @@ async fn test11_3_kick_and_mute_share_action_counter() {
 // ==========================================================================
 #[tokio::test]
 async fn test11_4_json_depth_limit() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Send a deeply nested JSON message (depth > 32)
     let nested = "{\"a\":".repeat(33) + "\"x\"" + &"}".repeat(33);
@@ -656,9 +666,9 @@ async fn test11_4_json_depth_limit() {
 // Verify that braces inside JSON strings do NOT count toward depth
 #[tokio::test]
 async fn test11_4_json_depth_ignores_string_braces() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Join first
     ws_send(
@@ -686,10 +696,10 @@ async fn test11_4_json_depth_ignores_string_braces() {
 #[tokio::test]
 async fn test11_5_per_ip_connection_cap() {
     let tracker = Arc::new(IpConnectionTracker::new(2));
-    let (addr, _state) = start_server_custom(false, None, Some(tracker), None).await;
+    let (addr, state) = start_server_custom(false, None, Some(tracker), None).await;
 
     // Connection 1: should succeed
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     ws_send(
         &mut s1,
         json!({"type":"join","roomId":"cap-test","roomType":"sfu"}),
@@ -698,7 +708,7 @@ async fn test11_5_per_ip_connection_cap() {
     let _ = recv_type(&mut r1, "joined").await;
 
     // Connection 2: should succeed
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"cap-test-2","roomType":"sfu"}),
@@ -707,7 +717,7 @@ async fn test11_5_per_ip_connection_cap() {
     let _ = recv_type(&mut r2, "joined").await;
 
     // Connection 3: should be rejected with HTTP 429 (before WS upgrade)
-    let result = try_ws_connect(addr).await;
+    let result = try_ws_connect(addr, &state).await;
     assert!(
         result.is_err(),
         "3rd connection should be rejected, but got: {:?}",
@@ -720,7 +730,7 @@ async fn test11_5_per_ip_connection_cap() {
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Connection 3 retry: should now succeed
-    let result = try_ws_connect(addr).await;
+    let result = try_ws_connect(addr, &state).await;
     assert!(
         result.is_ok(),
         "connection after drop should succeed, but got: {:?}",
@@ -758,11 +768,11 @@ async fn test11_6_temp_ban_after_rate_limit_violations() {
         ban_duration: Duration::from_secs(600),
         max_entries: 100,
     }));
-    let (addr, _state) = start_server_custom(false, Some(ws_config), None, Some(temp_ban)).await;
+    let (addr, state) = start_server_custom(false, Some(ws_config), None, Some(temp_ban)).await;
 
     // Violation 1: connect, send 4+ messages to trigger rate limit close
     {
-        let (mut sink, mut stream) = ws_connect(addr).await;
+        let (mut sink, mut stream) = ws_connect(addr, &state).await;
         ws_send(
             &mut sink,
             json!({"type":"join","roomId":"ban-1","roomType":"sfu"}),
@@ -781,7 +791,7 @@ async fn test11_6_temp_ban_after_rate_limit_violations() {
 
     // Should still be able to connect (1 violation, threshold is 2)
     {
-        let result = try_ws_connect(addr).await;
+        let result = try_ws_connect(addr, &state).await;
         assert!(result.is_ok(), "should still connect after 1 violation");
         let (mut sink, mut stream) = result.unwrap();
 
@@ -801,7 +811,7 @@ async fn test11_6_temp_ban_after_rate_limit_violations() {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Now IP should be temp-banned â†’ HTTP 429 at pre-upgrade
-    let result = try_ws_connect(addr).await;
+    let result = try_ws_connect(addr, &state).await;
     assert!(
         result.is_err(),
         "connection should be rejected after temp ban, but got: {:?}",
@@ -809,7 +819,7 @@ async fn test11_6_temp_ban_after_rate_limit_violations() {
     );
 
     // Verify abuse metrics
-    let snapshot = _state.abuse_metrics.snapshot();
+    let snapshot = state.abuse_metrics.snapshot();
     assert!(
         snapshot.connections_rejected_temp_ban >= 1,
         "expected at least 1 temp ban rejection, got: {}",

--- a/wavis-backend/tests/authorization_matrix_integration.rs
+++ b/wavis-backend/tests/authorization_matrix_integration.rs
@@ -19,6 +19,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -124,8 +125,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -177,14 +181,14 @@ async fn join_sfu(sink: &mut WsSink, stream: &mut WsStream, room_id: &str) -> St
 // ============================================================
 #[tokio::test]
 async fn guest_cannot_kick_participant() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
     // Host joins first
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     let host_id = join_sfu(&mut s_host, &mut r_host, "auth-kick").await;
 
     // Guest joins second
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     let _guest_id = join_sfu(&mut s_guest, &mut r_guest, "auth-kick").await;
     // Drain host's participant_joined notification
     let _ = recv_type(&mut r_host, "participant_joined").await;
@@ -205,12 +209,12 @@ async fn guest_cannot_kick_participant() {
 // ============================================================
 #[tokio::test]
 async fn guest_cannot_mute_participant() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     let host_id = join_sfu(&mut s_host, &mut r_host, "auth-mute").await;
 
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     let _guest_id = join_sfu(&mut s_guest, &mut r_guest, "auth-mute").await;
     let _ = recv_type(&mut r_host, "participant_joined").await;
     drain(&mut r_host).await;
@@ -230,10 +234,10 @@ async fn guest_cannot_mute_participant() {
 // ============================================================
 #[tokio::test]
 async fn guest_cannot_revoke_invite() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
     // Host joins and creates an invite
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     let _host_id = join_sfu(&mut s_host, &mut r_host, "auth-revoke").await;
 
     ws_send(&mut s_host, json!({"type":"invite_create","maxUses":1})).await;
@@ -241,7 +245,7 @@ async fn guest_cannot_revoke_invite() {
     let invite_code = created["inviteCode"].as_str().unwrap().to_string();
 
     // Guest joins
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     let _guest_id = join_sfu(&mut s_guest, &mut r_guest, "auth-revoke").await;
     let _ = recv_type(&mut r_host, "participant_joined").await;
     drain(&mut r_host).await;
@@ -262,14 +266,14 @@ async fn guest_cannot_revoke_invite() {
 // ============================================================
 #[tokio::test]
 async fn host_cannot_kick_cross_room() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
     // Host in room A
-    let (mut s_host_a, mut r_host_a) = ws_connect(addr).await;
+    let (mut s_host_a, mut r_host_a) = ws_connect(addr, &state).await;
     let _host_a_id = join_sfu(&mut s_host_a, &mut r_host_a, "room-a-kick").await;
 
     // Someone in room B (so we have a valid peer ID from a different room)
-    let (mut s_peer_b, mut r_peer_b) = ws_connect(addr).await;
+    let (mut s_peer_b, mut r_peer_b) = ws_connect(addr, &state).await;
     let peer_b_id = join_sfu(&mut s_peer_b, &mut r_peer_b, "room-b-kick").await;
 
     // Host A tries to kick peer B (who is in room B) → "target not in room"
@@ -287,10 +291,10 @@ async fn host_cannot_kick_cross_room() {
 // ============================================================
 #[tokio::test]
 async fn host_cannot_revoke_invite_cross_room() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
     // Host in room A creates an invite (invite is bound to room A)
-    let (mut s_host_a, mut r_host_a) = ws_connect(addr).await;
+    let (mut s_host_a, mut r_host_a) = ws_connect(addr, &state).await;
     let _host_a_id = join_sfu(&mut s_host_a, &mut r_host_a, "room-a-rev").await;
 
     ws_send(&mut s_host_a, json!({"type":"invite_create","maxUses":1})).await;
@@ -298,7 +302,7 @@ async fn host_cannot_revoke_invite_cross_room() {
     let invite_code = created["inviteCode"].as_str().unwrap().to_string();
 
     // Host in room B tries to revoke room A's invite → "unauthorized"
-    let (mut s_host_b, mut r_host_b) = ws_connect(addr).await;
+    let (mut s_host_b, mut r_host_b) = ws_connect(addr, &state).await;
     let _host_b_id = join_sfu(&mut s_host_b, &mut r_host_b, "room-b-rev").await;
 
     ws_send(
@@ -315,10 +319,10 @@ async fn host_cannot_revoke_invite_cross_room() {
 // ============================================================
 #[tokio::test]
 async fn non_member_cannot_execute_privileged_actions() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
     // Connect but do NOT join any room
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Try KickParticipant → "not authenticated"
     ws_send(
@@ -353,10 +357,10 @@ async fn non_member_cannot_execute_privileged_actions() {
 // ============================================================
 #[tokio::test]
 async fn host_can_kick_mute_revoke_in_own_room() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
     // Host joins
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     let _host_id = join_sfu(&mut s_host, &mut r_host, "auth-success").await;
 
     // Host creates an invite for later revocation
@@ -366,7 +370,7 @@ async fn host_can_kick_mute_revoke_in_own_room() {
     drain(&mut r_host).await;
 
     // Guest joins
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     let guest_id = join_sfu(&mut s_guest, &mut r_guest, "auth-success").await;
     let _ = recv_type(&mut r_host, "participant_joined").await;
     drain(&mut r_host).await;

--- a/wavis-backend/tests/backend_restart.rs
+++ b/wavis-backend/tests/backend_restart.rs
@@ -22,6 +22,7 @@ use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -205,8 +206,11 @@ async fn bind_with_retry(addr: SocketAddr, attempts: u32, delay_ms: u64) -> TcpL
 // WebSocket helpers
 // ============================================================
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -311,11 +315,11 @@ async fn backend_restart_contract() {
     let server_a = start_server(false).await;
     let addr_a = server_a.addr;
 
-    let (mut sink_a1, mut stream_a1) = ws_connect(addr_a).await;
+    let (mut sink_a1, mut stream_a1) = ws_connect(addr_a, &server_a.app_state).await;
     let joined_a1 = join_room_p2p(&mut sink_a1, &mut stream_a1, "restart-room").await;
     assert_eq!(joined_a1["peerCount"], 1);
 
-    let (mut sink_a2, mut stream_a2) = ws_connect(addr_a).await;
+    let (mut sink_a2, mut stream_a2) = ws_connect(addr_a, &server_a.app_state).await;
     let joined_a2 = join_room_p2p(&mut sink_a2, &mut stream_a2, "restart-room").await;
     assert_eq!(joined_a2["peerCount"], 2);
 
@@ -382,7 +386,7 @@ async fn backend_restart_contract() {
     // ========================================================
     // Phase 4: Connect new client to B, join new room, verify success
     // ========================================================
-    let (mut sink_b1, mut stream_b1) = ws_connect(server_b.addr).await;
+    let (mut sink_b1, mut stream_b1) = ws_connect(server_b.addr, &server_b.app_state).await;
 
     // B has require_invite_code=true, but the first join to a new P2P room
     // needs an invite. Generate one on B first.
@@ -398,7 +402,7 @@ async fn backend_restart_contract() {
     // ========================================================
     // Phase 5: Attempt join on B with old invite code from A â€” must be rejected
     // ========================================================
-    let (mut sink_b2, mut stream_b2) = ws_connect(server_b.addr).await;
+    let (mut sink_b2, mut stream_b2) = ws_connect(server_b.addr, &server_b.app_state).await;
     ws_send(
         &mut sink_b2,
         json!({

--- a/wavis-backend/tests/create_room_integration.rs
+++ b/wavis-backend/tests/create_room_integration.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -233,8 +234,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -296,9 +300,9 @@ async fn drain(stream: &mut WsStream) {
 /// Â§22c: CreateRoom after already joined â†’ "already joined"
 #[tokio::test]
 async fn test22c_create_room_after_join_rejected() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Join a room first
     ws_send(
@@ -323,9 +327,9 @@ async fn test22c_create_room_after_join_rejected() {
 /// Â§22d: Join after CreateRoom â†’ "already joined"
 #[tokio::test]
 async fn test22d_join_after_create_room_rejected() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Create a room first
     ws_send(
@@ -350,9 +354,9 @@ async fn test22d_join_after_create_room_rejected() {
 /// Â§22e: CreateRoom before authentication â†’ allowed (room_created response)
 #[tokio::test]
 async fn test22e_create_room_before_auth_allowed() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // CreateRoom without any prior join â€” should succeed
     ws_send(
@@ -373,9 +377,9 @@ async fn test22e_create_room_before_auth_allowed() {
 /// Â§36a: Create SFU room â€” room_created + media_token
 #[tokio::test]
 async fn test36a_create_sfu_room_success() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     ws_send(
         &mut sink,
@@ -403,9 +407,9 @@ async fn test36a_create_sfu_room_success() {
 /// Â§36b: Create P2P room â€” room_created, no media_token
 #[tokio::test]
 async fn test36b_create_p2p_room() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     ws_send(
         &mut sink,
@@ -428,10 +432,10 @@ async fn test36b_create_p2p_room() {
 /// Â§36c: Create room that already exists â†’ error
 #[tokio::test]
 async fn test36c_create_room_already_exists() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // First client creates the room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({"type":"create_room","roomId":"create-test","roomType":"sfu"}),
@@ -441,7 +445,7 @@ async fn test36c_create_room_already_exists() {
     drain(&mut stream1).await;
 
     // Second client tries to create the same room
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({"type":"create_room","roomId":"create-test","roomType":"sfu"}),
@@ -454,9 +458,9 @@ async fn test36c_create_room_already_exists() {
 /// Â§36d: Create room with empty room ID â†’ error "invalid room ID"
 #[tokio::test]
 async fn test36d_create_room_empty_id() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Empty string
     ws_send(
@@ -480,9 +484,9 @@ async fn test36d_create_room_empty_id() {
 /// Â§36e: CreateRoom while already in a room â†’ "already joined"
 #[tokio::test]
 async fn test36e_create_room_while_in_room() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Create first room
     ws_send(
@@ -506,10 +510,10 @@ async fn test36e_create_room_while_in_room() {
 /// Â§36f: Second client joins via invite code from CreateRoom
 #[tokio::test]
 async fn test36f_join_via_create_room_invite() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
     // Client 1: create room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({"type":"create_room","roomId":"invite-room","roomType":"sfu"}),
@@ -521,7 +525,7 @@ async fn test36f_join_via_create_room_invite() {
     drain(&mut stream1).await;
 
     // Client 2: join with the invite code
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({"type":"join","roomId":"invite-room","roomType":"sfu","inviteCode": invite_code}),
@@ -550,9 +554,9 @@ async fn test36f_join_via_create_room_invite() {
 /// Â§36g: CreateRoom with TURN credentials â†’ iceConfig populated
 #[tokio::test]
 async fn test36g_create_room_with_turn() {
-    let (addr, _state) = start_server_with_turn(false).await;
+    let (addr, state) = start_server_with_turn(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     ws_send(
         &mut sink,
@@ -599,9 +603,9 @@ async fn test36g_create_room_with_turn() {
 /// Â§36g supplement: CreateRoom without TURN â†’ iceConfig is null
 #[tokio::test]
 async fn test36g_create_room_without_turn_no_ice_config() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     ws_send(
         &mut sink,

--- a/wavis-backend/tests/display_name_integration.rs
+++ b/wavis-backend/tests/display_name_integration.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -135,8 +136,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -181,10 +185,10 @@ async fn drain(stream: &mut WsStream) {
 /// broadcast to existing peers carries that display name.
 #[tokio::test]
 async fn test41g_join_with_display_name_propagates_to_participant_joined() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create a room (no display name)
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -198,7 +202,7 @@ async fn test41g_join_with_display_name_propagates_to_participant_joined() {
     drain(&mut stream1).await;
 
     // Client 2: join with a displayName
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -224,10 +228,10 @@ async fn test41g_join_with_display_name_propagates_to_participant_joined() {
 /// stored and visible to late joiners in the participants list.
 #[tokio::test]
 async fn test41g_create_room_with_display_name_visible_to_joiner() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create room with displayName
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -244,7 +248,7 @@ async fn test41g_create_room_with_display_name_visible_to_joiner() {
     drain(&mut stream1).await;
 
     // Client 2: join the room â€” should see "Charlie" in participants list
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -279,10 +283,10 @@ async fn test41g_create_room_with_display_name_visible_to_joiner() {
 /// using the peer_id as the display name in participant_joined events.
 #[tokio::test]
 async fn test41h_join_without_display_name_falls_back_to_peer_id() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create a room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -296,7 +300,7 @@ async fn test41h_join_without_display_name_falls_back_to_peer_id() {
     drain(&mut stream1).await;
 
     // Client 2: join WITHOUT displayName
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -326,10 +330,10 @@ async fn test41h_join_without_display_name_falls_back_to_peer_id() {
 /// falls back to peer_id in the participants list.
 #[tokio::test]
 async fn test41h_create_room_without_display_name_falls_back_to_peer_id() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create room WITHOUT displayName
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -345,7 +349,7 @@ async fn test41h_create_room_without_display_name_falls_back_to_peer_id() {
     drain(&mut stream1).await;
 
     // Client 2: join the room
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -382,10 +386,10 @@ async fn test41h_create_room_without_display_name_falls_back_to_peer_id() {
 /// joiner in the participants list, and a second client sees the display name.
 #[tokio::test]
 async fn test41i_join_with_display_name_raw_json() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -400,7 +404,7 @@ async fn test41i_join_with_display_name_raw_json() {
     drain(&mut stream1).await;
 
     // Client 2: join with displayName "Charlie"
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -436,10 +440,10 @@ async fn test41i_join_with_display_name_raw_json() {
 /// in the participants list.
 #[tokio::test]
 async fn test41i_create_room_with_display_name_raw_json() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create room with displayName "Dana"
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -456,7 +460,7 @@ async fn test41i_create_room_with_display_name_raw_json() {
     drain(&mut stream1).await;
 
     // Client 2: join the room
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -491,10 +495,10 @@ async fn test41i_create_room_with_display_name_raw_json() {
 /// - Joiner's name appears in creator's participant_joined event
 #[tokio::test]
 async fn test41_both_clients_with_display_names() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create room as "Alice"
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -510,7 +514,7 @@ async fn test41_both_clients_with_display_names() {
     drain(&mut stream1).await;
 
     // Client 2: join as "Bob"
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({
@@ -543,10 +547,10 @@ async fn test41_both_clients_with_display_names() {
 /// Â§41h edge case: Join with empty displayName string â†’ falls back to peer_id
 #[tokio::test]
 async fn test41h_empty_display_name_falls_back_to_peer_id() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Client 1: create room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({
@@ -560,7 +564,7 @@ async fn test41h_empty_display_name_falls_back_to_peer_id() {
     drain(&mut stream1).await;
 
     // Client 2: join with empty displayName
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({

--- a/wavis-backend/tests/invite_lifecycle_integration.rs
+++ b/wavis-backend/tests/invite_lifecycle_integration.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -128,8 +129,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -174,10 +178,10 @@ use std::time::Instant;
 // ==========================================================================
 #[tokio::test]
 async fn invite_generate_and_use() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Step 1: First peer joins without invite (bypass mode allows it)
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     ws_send(
         &mut s1,
         json!({"type":"join","roomId":"inv-test","roomType":"sfu"}),
@@ -195,7 +199,7 @@ async fn invite_generate_and_use() {
     assert!(!code.is_empty());
 
     // Step 3: Second peer joins with invite code
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"inv-test","roomType":"sfu","inviteCode":&code}),
@@ -259,7 +263,7 @@ async fn invite_rejection_pipeline() {
     state.invite_store.consume_use(&exhausted_code); // use the 1 allowed use
 
     // --- invite_required: join without any invite code ---
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     ws_send(
         &mut s1,
         json!({"type":"join","roomId":"rej-test","roomType":"sfu"}),
@@ -273,7 +277,7 @@ async fn invite_rejection_pipeline() {
     drop(s1);
 
     // --- invite_invalid: join with a random code ---
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"rej-test","roomType":"sfu","inviteCode":"bogus-code"}),
@@ -287,7 +291,7 @@ async fn invite_rejection_pipeline() {
     drop(s2);
 
     // --- invite_revoked: join with a revoked code ---
-    let (mut s3, mut r3) = ws_connect(addr).await;
+    let (mut s3, mut r3) = ws_connect(addr, &state).await;
     ws_send(
         &mut s3,
         json!({"type":"join","roomId":"rej-test","roomType":"sfu","inviteCode":&revoke_code}),
@@ -301,7 +305,7 @@ async fn invite_rejection_pipeline() {
     drop(s3);
 
     // --- invite_exhausted: join with an exhausted code ---
-    let (mut s4, mut r4) = ws_connect(addr).await;
+    let (mut s4, mut r4) = ws_connect(addr, &state).await;
     ws_send(
         &mut s4,
         json!({"type":"join","roomId":"rej-test","roomType":"sfu","inviteCode":&exhausted_code}),
@@ -315,7 +319,7 @@ async fn invite_rejection_pipeline() {
     drop(s4);
 
     // --- Valid code succeeds, then second use is exhausted ---
-    let (mut s5, mut r5) = ws_connect(addr).await;
+    let (mut s5, mut r5) = ws_connect(addr, &state).await;
     ws_send(
         &mut s5,
         json!({"type":"join","roomId":"rej-test","roomType":"sfu","inviteCode":&valid_code}),
@@ -326,7 +330,7 @@ async fn invite_rejection_pipeline() {
     drain(&mut r5).await;
 
     // Same code again â€” now exhausted
-    let (mut s6, mut r6) = ws_connect(addr).await;
+    let (mut s6, mut r6) = ws_connect(addr, &state).await;
     ws_send(
         &mut s6,
         json!({"type":"join","roomId":"rej-test","roomType":"sfu","inviteCode":&valid_code}),

--- a/wavis-backend/tests/livekit_e2e_integration.rs
+++ b/wavis-backend/tests/livekit_e2e_integration.rs
@@ -197,8 +197,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url)
         .await
         .expect("WebSocket connection to in-process server should succeed");
@@ -396,9 +399,9 @@ async fn livekit_backend_issues_valid_media_token_accepted_by_livekit() {
     };
 
     let room_id = unique_room_id("e2e-media-token");
-    let (addr, _state) = start_server_with_livekit(&api_key, &api_secret, &host, false).await;
+    let (addr, state) = start_server_with_livekit(&api_key, &api_secret, &host, false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Create an SFU room via WebSocket
     ws_send(
@@ -479,10 +482,10 @@ async fn livekit_room_cleanup_on_last_leave() {
     };
 
     let room_id = unique_room_id("e2e-cleanup");
-    let (addr, _state) = start_server_with_livekit(&api_key, &api_secret, &host, true).await;
+    let (addr, state) = start_server_with_livekit(&api_key, &api_secret, &host, true).await;
 
     // Client 1: host creates the room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({"type": "create_room", "roomId": room_id, "roomType": "sfu"}),
@@ -498,7 +501,7 @@ async fn livekit_room_cleanup_on_last_leave() {
     drain(&mut stream1).await;
 
     // Client 2: guest joins with the invite code
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink2,
         json!({

--- a/wavis-backend/tests/phase3_manual_tests_integration.rs
+++ b/wavis-backend/tests/phase3_manual_tests_integration.rs
@@ -25,6 +25,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::global_rate_limiter::GlobalRateLimiter;
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
@@ -322,15 +323,21 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
 
 /// Try to connect; returns None if the server rejects (e.g. HTTP 429).
-async fn try_ws_connect(addr: SocketAddr) -> Option<(WsSink, WsStream)> {
-    let url = format!("ws://{addr}/ws");
+async fn try_ws_connect(addr: SocketAddr, app_state: &AppState) -> Option<(WsSink, WsStream)> {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     match connect_async(&url).await {
         Ok((ws, _)) => Some(ws.split()),
         Err(_) => None,
@@ -396,10 +403,10 @@ async fn drain(stream: &mut WsStream) {
 /// Â§18a: Start screen share â€” success. Both peers receive share_started.
 #[tokio::test]
 async fn test18a_start_share_success() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Host joins
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"share-test","roomType":"sfu"}),
@@ -410,7 +417,7 @@ async fn test18a_start_share_success() {
     drain(&mut r_host).await;
 
     // Guest joins
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"share-test","roomType":"sfu"}),
@@ -436,9 +443,9 @@ async fn test18a_start_share_success() {
 /// Â§18b: Start share while another is active â€” multi-share allows concurrent shares.
 #[tokio::test]
 async fn test18b_start_share_already_active() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"share-dup","roomType":"sfu"}),
@@ -447,7 +454,7 @@ async fn test18b_start_share_already_active() {
     let _ = recv_type(&mut r_host, "joined").await;
     drain(&mut r_host).await;
 
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"share-dup","roomType":"sfu"}),
@@ -473,9 +480,9 @@ async fn test18b_start_share_already_active() {
 /// Â§18c: Stop share by owner.
 #[tokio::test]
 async fn test18c_stop_share_by_owner() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"share-stop","roomType":"sfu"}),
@@ -485,7 +492,7 @@ async fn test18c_stop_share_by_owner() {
     let host_id = joined["peerId"].as_str().unwrap().to_string();
     drain(&mut r_host).await;
 
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"share-stop","roomType":"sfu"}),
@@ -513,10 +520,10 @@ async fn test18c_stop_share_by_owner() {
 /// Â§18d: Stop share by Host (override another participant's share).
 #[tokio::test]
 async fn test18d_stop_share_host_override() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Host joins first
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"share-override","roomType":"sfu"}),
@@ -526,7 +533,7 @@ async fn test18d_stop_share_host_override() {
     drain(&mut r_host).await;
 
     // Guest joins second
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"share-override","roomType":"sfu"}),
@@ -559,9 +566,9 @@ async fn test18d_stop_share_host_override() {
 /// Â§18e: Stop share as non-owner Guest â€” silent no-op.
 #[tokio::test]
 async fn test18e_stop_share_non_owner_noop() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"share-noop","roomType":"sfu"}),
@@ -571,7 +578,7 @@ async fn test18e_stop_share_non_owner_noop() {
     let host_id = joined["peerId"].as_str().unwrap().to_string();
     drain(&mut r_host).await;
 
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"share-noop","roomType":"sfu"}),
@@ -596,7 +603,7 @@ async fn test18e_stop_share_non_owner_noop() {
 
     // Verify share is still active (host can still see it)
     assert!(
-        _state
+        state
             .room_state
             .get_room_info("share-noop")
             .map(|i| i.active_shares.contains(&host_id))
@@ -608,9 +615,9 @@ async fn test18e_stop_share_non_owner_noop() {
 /// Â§18f: Start share in P2P room â€” rejected.
 #[tokio::test]
 async fn test18f_start_share_p2p_rejected() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     // Join P2P room â€” must explicitly pass roomType:"p2p" since MAX_ROOM_PARTICIPANTS=6
     // defaults to SFU via determine_room_type(None, 6) = Sfu
     ws_send(
@@ -629,9 +636,9 @@ async fn test18f_start_share_p2p_rejected() {
 /// Â§18g: Disconnect cleanup â€” share cleared when owner disconnects.
 #[tokio::test]
 async fn test18g_disconnect_cleanup() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"share-dc","roomType":"sfu"}),
@@ -641,7 +648,7 @@ async fn test18g_disconnect_cleanup() {
     let host_id = joined["peerId"].as_str().unwrap().to_string();
     drain(&mut r_host).await;
 
-    let (mut _s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut _s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut _s_guest,
         json!({"type":"join","roomId":"share-dc","roomType":"sfu"}),
@@ -674,9 +681,9 @@ async fn test18g_disconnect_cleanup() {
 /// Â§19a: With TURN configured, Joined response includes iceConfig.
 #[tokio::test]
 async fn test19a_join_with_turn_includes_ice_config() {
-    let (addr, _state) = start_server_with_turn(false).await;
+    let (addr, state) = start_server_with_turn(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"turn-test","roomType":"sfu"}),
@@ -710,10 +717,10 @@ async fn test19a_join_with_turn_includes_ice_config() {
 /// Â§19a (continued): Each peer gets unique credentials.
 #[tokio::test]
 async fn test19a_unique_credentials_per_peer() {
-    let (addr, _state) = start_server_with_turn(false).await;
+    let (addr, state) = start_server_with_turn(false).await;
 
     // Peer 1
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     ws_send(
         &mut s1,
         json!({"type":"join","roomId":"turn-unique","roomType":"sfu"}),
@@ -730,7 +737,7 @@ async fn test19a_unique_credentials_per_peer() {
         .to_string();
 
     // Peer 2
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"turn-unique","roomType":"sfu"}),
@@ -759,9 +766,9 @@ async fn test19a_unique_credentials_per_peer() {
 /// Â§19b: Without TURN configured, Joined response has no iceConfig.
 #[tokio::test]
 async fn test19b_join_without_turn_no_ice_config() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"no-turn","roomType":"sfu"}),
@@ -784,17 +791,17 @@ async fn test19b_join_without_turn_no_ice_config() {
 #[tokio::test]
 async fn test20a_global_ws_upgrade_ceiling() {
     // Set ceiling to 2 WS upgrades per second
-    let (addr, _state) = start_server_with_global_limits(2, 100).await;
+    let (addr, state) = start_server_with_global_limits(2, 100).await;
 
     // First 2 connections should succeed
-    let conn1 = try_ws_connect(addr).await;
+    let conn1 = try_ws_connect(addr, &state).await;
     assert!(conn1.is_some(), "1st connection should succeed");
 
-    let conn2 = try_ws_connect(addr).await;
+    let conn2 = try_ws_connect(addr, &state).await;
     assert!(conn2.is_some(), "2nd connection should succeed");
 
     // 3rd connection in the same second should be rejected (HTTP 429)
-    let conn3 = try_ws_connect(addr).await;
+    let conn3 = try_ws_connect(addr, &state).await;
     assert!(
         conn3.is_none(),
         "3rd connection should be rejected by global WS ceiling"
@@ -802,7 +809,7 @@ async fn test20a_global_ws_upgrade_ceiling() {
 
     // After waiting for the epoch to reset, new connections should work
     tokio::time::sleep(Duration::from_secs(1)).await;
-    let conn4 = try_ws_connect(addr).await;
+    let conn4 = try_ws_connect(addr, &state).await;
     assert!(
         conn4.is_some(),
         "connection after epoch reset should succeed"
@@ -813,7 +820,7 @@ async fn test20a_global_ws_upgrade_ceiling() {
 #[tokio::test]
 async fn test20b_global_join_ceiling() {
     // Set join ceiling to 2 per second, WS ceiling high
-    let (addr, _state) = start_server_with_global_limits(100, 2).await;
+    let (addr, state) = start_server_with_global_limits(100, 2).await;
 
     // Note: global join ceiling is only checked when require_invite_code=true.
     // With require_invite=false, the join ceiling check is skipped.
@@ -827,7 +834,7 @@ async fn test20b_global_join_ceiling() {
     // The WS ceiling test (20a) validates the integration pattern.
 
     // Verify joins work normally with the high WS ceiling
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     ws_send(
         &mut s1,
         json!({"type":"join","roomId":"join-ceil-1","roomType":"sfu"}),
@@ -836,7 +843,7 @@ async fn test20b_global_join_ceiling() {
     let j1 = recv_type(&mut r1, "joined").await;
     assert_eq!(j1["roomId"], "join-ceil-1");
 
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"join-ceil-2","roomType":"sfu"}),
@@ -857,9 +864,9 @@ async fn test20b_global_join_ceiling() {
 /// Â§21a: Oversized room_id (> 128 chars) â€” rejected with field name in error.
 #[tokio::test]
 async fn test21a_oversized_room_id() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     let long_room = "x".repeat(200);
     ws_send(&mut sink, json!({"type":"join","roomId": long_room})).await;
     let err = recv_type(&mut stream, "error").await;
@@ -889,9 +896,9 @@ async fn test21a_oversized_room_id() {
 /// Â§21b: Oversized invite_code (> 64 chars) â€” rejected.
 #[tokio::test]
 async fn test21b_oversized_invite_code() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     let long_code = "x".repeat(70);
     ws_send(
         &mut sink,
@@ -909,9 +916,9 @@ async fn test21b_oversized_invite_code() {
 /// Â§21c: Oversized target_participant_id in stop_share (> 128 chars) â€” rejected.
 #[tokio::test]
 async fn test21c_oversized_participant_id_in_stop_share() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     // Must join first (pre-join gate)
     ws_send(
         &mut sink,
@@ -938,9 +945,9 @@ async fn test21c_oversized_participant_id_in_stop_share() {
 /// Â§21d: Valid-length fields pass through normally.
 #[tokio::test]
 async fn test21d_valid_fields_pass() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"normal-room","roomType":"sfu"}),
@@ -960,9 +967,9 @@ async fn test21d_valid_fields_pass() {
 /// (Extends test10 with start_share specifically, as documented in Â§22a)
 #[tokio::test]
 async fn test22a_start_share_before_auth() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(&mut sink, json!({"type":"start_share"})).await;
     let err = recv_type(&mut stream, "error").await;
     assert_eq!(err["message"], "not authenticated");
@@ -976,9 +983,9 @@ async fn test22a_start_share_before_auth() {
 /// Â§22b: Re-Join after already joined â€” "already joined".
 #[tokio::test]
 async fn test22b_rejoin_after_joined() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"room-1","roomType":"sfu"}),

--- a/wavis-backend/tests/readme_manual_tests_integration.rs
+++ b/wavis-backend/tests/readme_manual_tests_integration.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -217,8 +218,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -277,11 +281,11 @@ async fn test9_join_rate_limiting() {
         connection_window: Duration::from_secs(60),
         cooldown: Duration::from_secs(60),
     };
-    let (addr, _state) = start_server_with_rate_limiter(true, rl_config).await;
+    let (addr, state) = start_server_with_rate_limiter(true, rl_config).await;
 
     // Send bad invite codes â€” first 3 should be invite_invalid, then rate_limited
     for i in 0..5 {
-        let (mut sink, mut stream) = ws_connect(addr).await;
+        let (mut sink, mut stream) = ws_connect(addr, &state).await;
         ws_send(
             &mut sink,
             json!({"type":"join","roomId":"rate-test","roomType":"sfu","inviteCode":format!("bad-{i}")}),
@@ -307,8 +311,8 @@ async fn test9_join_rate_limiting() {
 // ==========================================================================
 #[tokio::test]
 async fn test10_pre_join_auth_gate() {
-    let (addr, _state) = start_server(false).await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server(false).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // 10a: Offer before join â†’ "not authenticated"
     ws_send(
@@ -355,10 +359,10 @@ async fn test10_pre_join_auth_gate() {
 // ==========================================================================
 #[tokio::test]
 async fn test11_kick_participant() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Host joins first
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_host,
         json!({"type":"join","roomId":"kick-test","roomType":"sfu"}),
@@ -369,7 +373,7 @@ async fn test11_kick_participant() {
     drain(&mut r_host).await;
 
     // Guest joins second
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     ws_send(
         &mut s_guest,
         json!({"type":"join","roomId":"kick-test","roomType":"sfu"}),
@@ -405,7 +409,7 @@ async fn test11_kick_participant() {
 
     // Verify room now has only the host
     assert_eq!(
-        _state.room_state.peer_count("kick-test"),
+        state.room_state.peer_count("kick-test"),
         1,
         "only host should remain after kick"
     );
@@ -422,9 +426,9 @@ async fn test11_kick_participant() {
 // ==========================================================================
 #[tokio::test]
 async fn test12_sdp_and_ice_size_limits() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     // Join first (pre-join gate would block us)
     ws_send(
         &mut sink,
@@ -467,7 +471,7 @@ async fn test12_sdp_and_ice_size_limits() {
     }
 
     // Reconnect after the oversized frame closed the connection
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"size-test-2","roomType":"sfu"}),
@@ -551,7 +555,7 @@ async fn test13_room_cleanup_removes_invites() {
     let (addr, state) = start_server(false).await;
 
     // Join and create an invite
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"cleanup-test","roomType":"sfu"}),

--- a/wavis-backend/tests/reconnect_drop_matrix.rs
+++ b/wavis-backend/tests/reconnect_drop_matrix.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -137,8 +138,11 @@ async fn start_server() -> (SocketAddr, AppState) {
 // ============================================================
 
 /// Connect a new WebSocket client to the server. Returns split (sink, stream).
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -266,7 +270,7 @@ async fn scaffolding_smoke_test() {
     assert_total_participants(&app_state, 0);
 
     // Connect and join a room.
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &app_state).await;
     let joined = join_room(&mut sink, &mut stream, "smoke-room").await;
     assert_eq!(joined["peerCount"], 1);
 
@@ -302,7 +306,7 @@ async fn drop_before_join() {
     assert_total_participants(&app_state, 0);
 
     // Connect and immediately close without sending Join.
-    let (mut sink, _stream) = ws_connect(addr).await;
+    let (mut sink, _stream) = ws_connect(addr, &app_state).await;
     ws_close(&mut sink).await;
 
     // Give the server a moment to process the disconnect.
@@ -335,12 +339,12 @@ async fn drop_after_join_before_offer() {
     let (addr, app_state) = start_server().await;
 
     // Client A joins "drop-room" as P2P — creates the room.
-    let (mut sink_a, mut stream_a) = ws_connect(addr).await;
+    let (mut sink_a, mut stream_a) = ws_connect(addr, &app_state).await;
     let joined_a = join_room_p2p(&mut sink_a, &mut stream_a, "drop-room").await;
     assert_eq!(joined_a["peerCount"], 1);
 
     // Client B joins "drop-room" as P2P.
-    let (mut sink_b, mut stream_b) = ws_connect(addr).await;
+    let (mut sink_b, mut stream_b) = ws_connect(addr, &app_state).await;
     let joined_b = join_room_p2p(&mut sink_b, &mut stream_b, "drop-room").await;
     assert_eq!(joined_b["peerCount"], 2);
 
@@ -368,7 +372,7 @@ async fn drop_after_join_before_offer() {
     assert_eq!(peer_left["type"], "peer_left");
 
     // Capacity restored: a new client can join (room max is 6).
-    let (mut sink_c, mut stream_c) = ws_connect(addr).await;
+    let (mut sink_c, mut stream_c) = ws_connect(addr, &app_state).await;
     let joined_c = join_room_p2p(&mut sink_c, &mut stream_c, "drop-room").await;
     assert_eq!(joined_c["peerCount"], 2);
     assert_peer_count(&app_state, "drop-room", 2);
@@ -389,12 +393,12 @@ async fn drop_during_ice_exchange() {
     let (addr, app_state) = start_server().await;
 
     // Client A joins "ice-room" as P2P — creates the room.
-    let (mut sink_a, mut stream_a) = ws_connect(addr).await;
+    let (mut sink_a, mut stream_a) = ws_connect(addr, &app_state).await;
     let joined_a = join_room_p2p(&mut sink_a, &mut stream_a, "ice-room").await;
     assert_eq!(joined_a["peerCount"], 1);
 
     // Client B joins "ice-room" as P2P.
-    let (mut sink_b, mut stream_b) = ws_connect(addr).await;
+    let (mut sink_b, mut stream_b) = ws_connect(addr, &app_state).await;
     let joined_b = join_room_p2p(&mut sink_b, &mut stream_b, "ice-room").await;
     assert_eq!(joined_b["peerCount"], 2);
 
@@ -474,7 +478,7 @@ async fn drop_during_ice_exchange() {
     assert_eq!(peer_left["type"], "peer_left");
 
     // Capacity restored: a new client can join (room max is 6).
-    let (mut sink_c, mut stream_c) = ws_connect(addr).await;
+    let (mut sink_c, mut stream_c) = ws_connect(addr, &app_state).await;
     let joined_c = join_room_p2p(&mut sink_c, &mut stream_c, "ice-room").await;
     assert_eq!(joined_c["peerCount"], 2);
     assert_peer_count(&app_state, "ice-room", 2);
@@ -498,7 +502,7 @@ async fn rejoin_after_drop() {
     let (addr, app_state) = start_server().await;
 
     // --- Phase 1: Client connects and joins "rejoin-room" as P2P ---
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &app_state).await;
     let joined1 = join_room_p2p(&mut sink1, &mut stream1, "rejoin-room").await;
     assert_eq!(joined1["peerCount"], 1);
     assert_peer_count(&app_state, "rejoin-room", 1);
@@ -517,7 +521,7 @@ async fn rejoin_after_drop() {
     assert_no_ghosts(&app_state);
 
     // --- Phase 3: Client reconnects with a NEW WebSocket connection ---
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &app_state).await;
 
     // --- Phase 4: Client joins the same "rejoin-room" again ---
     let joined2 = join_room_p2p(&mut sink2, &mut stream2, "rejoin-room").await;
@@ -559,7 +563,7 @@ async fn rapid_connect_disconnect_cycle() {
 
     for i in 0..3 {
         // --- Connect ---
-        let (mut sink, mut stream) = ws_connect(addr).await;
+        let (mut sink, mut stream) = ws_connect(addr, &app_state).await;
 
         // --- Join "cycle-room" as P2P ---
         let joined = join_room_p2p(&mut sink, &mut stream, "cycle-room").await;
@@ -599,7 +603,7 @@ async fn test_clean_session_lifecycle() {
     assert_active_rooms(&app_state, 0);
     assert_total_participants(&app_state, 0);
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &app_state).await;
     let joined = join_room_p2p(&mut sink, &mut stream, "lifecycle-room").await;
     assert_eq!(joined["peerCount"], 1);
 
@@ -627,7 +631,7 @@ async fn test_unclean_disconnect_cleans_up() {
     assert_active_rooms(&app_state, 0);
     assert_total_participants(&app_state, 0);
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &app_state).await;
     let joined = join_room_p2p(&mut sink, &mut stream, "unclean-room").await;
     assert_eq!(joined["peerCount"], 1);
 
@@ -648,7 +652,7 @@ async fn test_unclean_disconnect_cleans_up() {
     assert_total_participants(&app_state, 0);
     assert_no_ghosts(&app_state);
 
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
+    let (mut sink2, mut stream2) = ws_connect(addr, &app_state).await;
     let joined2 = join_room_p2p(&mut sink2, &mut stream2, "unclean-room").await;
     assert_eq!(joined2["peerCount"], 1);
 

--- a/wavis-backend/tests/screen_share_ws_integration.rs
+++ b/wavis-backend/tests/screen_share_ws_integration.rs
@@ -32,6 +32,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -142,8 +143,11 @@ async fn start_server(require_invite: bool) -> (SocketAddr, AppState) {
     (addr, app_state)
 }
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -200,8 +204,12 @@ async fn drain(stream: &mut WsStream) {
 // ============================================================
 
 /// Creates an SFU room. Returns (sink, stream, peer_id, invite_code).
-async fn create_sfu_room(addr: SocketAddr, room_id: &str) -> (WsSink, WsStream, String, String) {
-    let (mut sink, mut stream) = ws_connect(addr).await;
+async fn create_sfu_room(
+    addr: SocketAddr,
+    room_id: &str,
+    app_state: &AppState,
+) -> (WsSink, WsStream, String, String) {
+    let (mut sink, mut stream) = ws_connect(addr, app_state).await;
     ws_send(
         &mut sink,
         json!({"type":"create_room","roomId":room_id,"roomType":"sfu"}),
@@ -220,8 +228,9 @@ async fn join_sfu_room(
     addr: SocketAddr,
     room_id: &str,
     invite_code: &str,
+    app_state: &AppState,
 ) -> (WsSink, WsStream, String) {
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, app_state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":room_id,"roomType":"sfu","inviteCode":invite_code}),
@@ -241,10 +250,12 @@ async fn join_sfu_room(
 /// Â§13: Start share â†’ share_started broadcast to all peers.
 #[tokio::test]
 async fn test_13_start_share_broadcast() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, _host_id, invite) = create_sfu_room(addr, "share-broadcast").await;
-    let (_sink2, mut stream2, _guest_id) = join_sfu_room(addr, "share-broadcast", &invite).await;
+    let (mut sink1, mut stream1, _host_id, invite) =
+        create_sfu_room(addr, "share-broadcast", &state).await;
+    let (_sink2, mut stream2, _guest_id) =
+        join_sfu_room(addr, "share-broadcast", &invite, &state).await;
 
     // Host on stream1 needs to drain the participant_joined from guest joining
     drain(&mut stream1).await;
@@ -262,12 +273,12 @@ async fn test_13_start_share_broadcast() {
 /// Â§13: Concurrent shares from different participants both succeed.
 #[tokio::test]
 async fn test_13_concurrent_shares() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
     let (mut sink1, mut stream1, host_id, invite) =
-        create_sfu_room(addr, "concurrent-shares").await;
+        create_sfu_room(addr, "concurrent-shares", &state).await;
     let (mut sink2, mut stream2, guest_id) =
-        join_sfu_room(addr, "concurrent-shares", &invite).await;
+        join_sfu_room(addr, "concurrent-shares", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Host starts sharing
@@ -289,11 +300,12 @@ async fn test_13_concurrent_shares() {
 /// Â§13: Same sender's second start_share â†’ no-op (no error, no broadcast).
 #[tokio::test]
 async fn test_13_idempotent_start_share() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
     let (mut sink1, mut stream1, _host_id, invite) =
-        create_sfu_room(addr, "idempotent-share").await;
-    let (_sink2, mut stream2, _guest_id) = join_sfu_room(addr, "idempotent-share", &invite).await;
+        create_sfu_room(addr, "idempotent-share", &state).await;
+    let (_sink2, mut stream2, _guest_id) =
+        join_sfu_room(addr, "idempotent-share", &invite, &state).await;
     drain(&mut stream1).await;
 
     // First start_share â†’ broadcast
@@ -314,10 +326,11 @@ async fn test_13_idempotent_start_share() {
 /// Â§13: Stop share â†’ share_stopped broadcast to all peers.
 #[tokio::test]
 async fn test_13_stop_share_broadcast() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, host_id, invite) = create_sfu_room(addr, "stop-share").await;
-    let (_sink2, mut stream2, _guest_id) = join_sfu_room(addr, "stop-share", &invite).await;
+    let (mut sink1, mut stream1, host_id, invite) =
+        create_sfu_room(addr, "stop-share", &state).await;
+    let (_sink2, mut stream2, _guest_id) = join_sfu_room(addr, "stop-share", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Start sharing
@@ -337,10 +350,12 @@ async fn test_13_stop_share_broadcast() {
 /// Â§13: Host-directed stop (targetParticipantId) â†’ share_stopped for target only.
 #[tokio::test]
 async fn test_13_host_directed_stop() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, _host_id, invite) = create_sfu_room(addr, "host-stop").await;
-    let (mut sink2, mut stream2, guest_id) = join_sfu_room(addr, "host-stop", &invite).await;
+    let (mut sink1, mut stream1, _host_id, invite) =
+        create_sfu_room(addr, "host-stop", &state).await;
+    let (mut sink2, mut stream2, guest_id) =
+        join_sfu_room(addr, "host-stop", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Guest starts sharing
@@ -364,10 +379,12 @@ async fn test_13_host_directed_stop() {
 /// Â§13: Non-host targeted stop â†’ permission error.
 #[tokio::test]
 async fn test_13_non_host_targeted_stop_rejected() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, host_id, invite) = create_sfu_room(addr, "nonhost-stop").await;
-    let (mut sink2, mut stream2, _guest_id) = join_sfu_room(addr, "nonhost-stop", &invite).await;
+    let (mut sink1, mut stream1, host_id, invite) =
+        create_sfu_room(addr, "nonhost-stop", &state).await;
+    let (mut sink2, mut stream2, _guest_id) =
+        join_sfu_room(addr, "nonhost-stop", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Host starts sharing
@@ -397,10 +414,12 @@ async fn test_13_non_host_targeted_stop_rejected() {
 /// Â§13: Stop all shares (host) â†’ one share_stopped per active sharer.
 #[tokio::test]
 async fn test_13_stop_all_shares_host() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, host_id, invite) = create_sfu_room(addr, "stop-all-host").await;
-    let (mut sink2, mut stream2, guest_id) = join_sfu_room(addr, "stop-all-host", &invite).await;
+    let (mut sink1, mut stream1, host_id, invite) =
+        create_sfu_room(addr, "stop-all-host", &state).await;
+    let (mut sink2, mut stream2, guest_id) =
+        join_sfu_room(addr, "stop-all-host", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Both start sharing
@@ -433,10 +452,12 @@ async fn test_13_stop_all_shares_host() {
 /// Â§13: Stop all shares (non-host) â†’ permission error.
 #[tokio::test]
 async fn test_13_stop_all_shares_non_host_rejected() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, _host_id, invite) = create_sfu_room(addr, "stop-all-guest").await;
-    let (mut sink2, mut stream2, _guest_id) = join_sfu_room(addr, "stop-all-guest", &invite).await;
+    let (mut sink1, mut stream1, _host_id, invite) =
+        create_sfu_room(addr, "stop-all-guest", &state).await;
+    let (mut sink2, mut stream2, _guest_id) =
+        join_sfu_room(addr, "stop-all-guest", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Host starts sharing
@@ -462,16 +483,17 @@ async fn test_13_stop_all_shares_non_host_rejected() {
 /// Â§13: Late joiner receives share_state snapshot with active sharers.
 #[tokio::test]
 async fn test_13_late_joiner_share_state() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (mut sink1, mut stream1, host_id, invite) = create_sfu_room(addr, "late-join-state").await;
+    let (mut sink1, mut stream1, host_id, invite) =
+        create_sfu_room(addr, "late-join-state", &state).await;
 
     // Host starts sharing before anyone else joins
     ws_send(&mut sink1, json!({"type":"start_share"})).await;
     recv_type(&mut stream1, "share_started").await;
 
     // Late joiner connects â€” should receive share_state after joined/media_token
-    let (mut _sink2, mut stream2) = ws_connect(addr).await;
+    let (mut _sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut _sink2,
         json!({"type":"join","roomId":"late-join-state","roomType":"sfu","inviteCode":invite}),
@@ -497,13 +519,14 @@ async fn test_13_late_joiner_share_state() {
 /// a room where no shares are active).
 #[tokio::test]
 async fn test_13_first_joiner_empty_share_state() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
     // Creator makes the room (no share_state sent on create_room path)
-    let (_sink1, mut _stream1, _host_id, invite) = create_sfu_room(addr, "empty-share-state").await;
+    let (_sink1, mut _stream1, _host_id, invite) =
+        create_sfu_room(addr, "empty-share-state", &state).await;
 
     // Second peer joins â€” no shares active, should get empty share_state
-    let (mut _sink2, mut stream2) = ws_connect(addr).await;
+    let (mut _sink2, mut stream2) = ws_connect(addr, &state).await;
     ws_send(
         &mut _sink2,
         json!({"type":"join","roomId":"empty-share-state","roomType":"sfu","inviteCode":invite}),
@@ -523,11 +546,12 @@ async fn test_13_first_joiner_empty_share_state() {
 /// Â§13: Disconnect cleanup â€” sharing peer disconnects â†’ share_stopped broadcast.
 #[tokio::test]
 async fn test_13_disconnect_cleanup() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
-    let (_sink1, mut stream1, _host_id, invite) = create_sfu_room(addr, "disconnect-cleanup").await;
+    let (_sink1, mut stream1, _host_id, invite) =
+        create_sfu_room(addr, "disconnect-cleanup", &state).await;
     let (mut sink2, mut stream2, guest_id) =
-        join_sfu_room(addr, "disconnect-cleanup", &invite).await;
+        join_sfu_room(addr, "disconnect-cleanup", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Guest starts sharing
@@ -548,12 +572,12 @@ async fn test_13_disconnect_cleanup() {
 /// Â§13: Disconnect non-sharer â†’ no share_stopped signal.
 #[tokio::test]
 async fn test_13_disconnect_non_sharer_no_signal() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
     let (mut sink1, mut stream1, _host_id, invite) =
-        create_sfu_room(addr, "disconnect-noshare").await;
+        create_sfu_room(addr, "disconnect-noshare", &state).await;
     let (mut sink2, mut stream2, _guest_id) =
-        join_sfu_room(addr, "disconnect-noshare", &invite).await;
+        join_sfu_room(addr, "disconnect-noshare", &invite, &state).await;
     drain(&mut stream1).await;
 
     // Host starts sharing (guest does NOT share)
@@ -578,10 +602,10 @@ async fn test_13_disconnect_non_sharer_no_signal() {
 /// Â§13: P2P room â†’ start_share returns "screen sharing unavailable in P2P mode".
 #[tokio::test]
 async fn test_13_p2p_room_rejected() {
-    let (addr, _state) = start_server(true).await;
+    let (addr, state) = start_server(true).await;
 
     // Create a P2P room
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
+    let (mut sink1, mut stream1) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink1,
         json!({"type":"create_room","roomId":"p2p-share-test","roomType":"p2p"}),

--- a/wavis-backend/tests/security_hardening_integration.rs
+++ b/wavis-backend/tests/security_hardening_integration.rs
@@ -34,6 +34,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
 use wavis_backend::app_state::AppState;
@@ -322,8 +323,11 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -405,10 +409,10 @@ async fn http_get_status(addr: SocketAddr, path: &str, extra_headers: &str) -> u
 
 #[tokio::test]
 async fn test27d_revoke_nonexistent_code() {
-    let (addr, _state) = start_server(false).await;
+    let (addr, state) = start_server(false).await;
 
     // Host joins
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     let _host_id = join_sfu(&mut s_host, &mut r_host, "revoke-nonexist").await;
 
     // Try to revoke a code that was never created
@@ -434,7 +438,7 @@ async fn test27_revoke_authorization_rejections_metric() {
     let (addr, state) = start_server(false).await;
 
     // Host joins and creates invite
-    let (mut s_host, mut r_host) = ws_connect(addr).await;
+    let (mut s_host, mut r_host) = ws_connect(addr, &state).await;
     let _host_id = join_sfu(&mut s_host, &mut r_host, "revoke-metric").await;
 
     ws_send(&mut s_host, json!({"type":"invite_create","maxUses":5})).await;
@@ -443,7 +447,7 @@ async fn test27_revoke_authorization_rejections_metric() {
     drain(&mut r_host).await;
 
     // Guest joins
-    let (mut s_guest, mut r_guest) = ws_connect(addr).await;
+    let (mut s_guest, mut r_guest) = ws_connect(addr, &state).await;
     let _guest_id = join_sfu(&mut s_guest, &mut r_guest, "revoke-metric").await;
     drain(&mut r_host).await;
     drain(&mut r_guest).await;
@@ -661,7 +665,7 @@ fn test29f_all_positive_values_accepted() {
 async fn test30a_media_token_includes_jti_nbf_iat() {
     let (addr, state) = start_server(false).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"jwt-claims-test","roomType":"sfu"}),
@@ -764,7 +768,7 @@ async fn test30b_server_with_dual_secrets_issues_valid_tokens() {
 
     let (addr, state) = start_server_with_jwt_secrets(current, Some(previous)).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     ws_send(
         &mut sink,
         json!({"type":"join","roomId":"dual-secret-test","roomType":"sfu"}),
@@ -866,7 +870,7 @@ async fn test31_per_ip_failed_join_threshold_detection() {
     // Attempt 11: rate limiter's ip_failed dimension rejects (threshold=10),
     //   record_failure is called â†’ count=11 > threshold=10 â†’ Some(11) â†’ metric incremented.
     for i in 0..11 {
-        let (mut sink, mut stream) = ws_connect(addr).await;
+        let (mut sink, mut stream) = ws_connect(addr, &app_state).await;
         ws_send(
             &mut sink,
             json!({

--- a/wavis-backend/tests/test_metrics_integration.rs
+++ b/wavis-backend/tests/test_metrics_integration.rs
@@ -32,6 +32,7 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::time::timeout;
     use tokio_tungstenite::{connect_async, tungstenite::Message};
+    use uuid::Uuid;
 
     use axum::Router;
     use axum::routing::get;
@@ -284,8 +285,11 @@ mod tests {
         >,
     >;
 
-    async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-        let url = format!("ws://{addr}/ws");
+    async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+        let ticket = app_state
+            .ws_ticket_store
+            .issue(Uuid::new_v4(), Uuid::new_v4());
+        let url = format!("ws://{addr}/ws?ticket={ticket}");
         let (ws, _) = connect_async(&url).await.expect("WS connect failed");
         ws.split()
     }
@@ -401,7 +405,7 @@ mod tests {
         let server = start_server_with_metrics(false, "test-token-24e").await;
 
         // Join an SFU room via WebSocket on the main port
-        let (mut sink, mut stream) = ws_connect(server.ws_addr).await;
+        let (mut sink, mut stream) = ws_connect(server.ws_addr, &server.app_state).await;
         ws_send(
             &mut sink,
             json!({"type": "join", "roomId": "metrics-room", "roomType": "sfu"}),
@@ -442,7 +446,7 @@ mod tests {
         );
 
         // Join a second peer
-        let (mut sink2, mut stream2) = ws_connect(server.ws_addr).await;
+        let (mut sink2, mut stream2) = ws_connect(server.ws_addr, &server.app_state).await;
         ws_send(
             &mut sink2,
             json!({"type": "join", "roomId": "metrics-room", "roomType": "sfu"}),
@@ -511,7 +515,7 @@ mod tests {
         let server = start_server_with_metrics(false, "test-token-24e-abuse").await;
 
         // Send a non-join message without joining first â†’ state_machine_rejections
-        let (mut sink, mut stream) = ws_connect(server.ws_addr).await;
+        let (mut sink, mut stream) = ws_connect(server.ws_addr, &server.app_state).await;
         ws_send(&mut sink, json!({"type": "leave"})).await;
 
         // Should get "not authenticated" error

--- a/wavis-backend/tests/voice_ws_integration.rs
+++ b/wavis-backend/tests/voice_ws_integration.rs
@@ -9,8 +9,10 @@
 //! Tables are truncated between tests for isolation.
 //!
 //! Covered:
-//!   28.1  JoinVoice â€” happy path (auth â†’ join_voice â†’ joined + media_token)
-//!   28.2  JoinVoice â€” requires authentication
+//!   28.1  JoinVoice â€” happy path (ws-ticket auth â†’ join_voice â†’ joined + media_token)
+//!   28.2  RETIRED (issue #267): every /ws connection is now pre-authenticated by
+//!         its ticket, so "connected but not authenticated" is no longer reachable.
+//!         See ws_ticket_gate_integration.rs instead.
 //!   28.3  JoinVoice â€” non-member rejection (opaque not_authorized)
 //!   28.4  JoinVoice â€” banned user rejection (opaque not_authorized)
 //!   28.5  JoinVoice â€” non-existent channel (opaque not_authorized)
@@ -266,8 +268,25 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let url = format!("ws://{addr}/ws");
+/// Connect to `/ws` pre-authenticated as a specific registered user via a
+/// freshly-issued ws-ticket. Replaces the old connect-then-send-Auth-message
+/// flow (`ws_auth`): a ticket-authenticated connection now rejects a
+/// subsequent signaling `Auth` message as "already authenticated"
+/// (ws/validation.rs), since the ticket already proved identity at upgrade
+/// time.
+async fn ws_connect_as(
+    addr: SocketAddr,
+    app_state: &AppState,
+    pool: &PgPool,
+    user_id: Uuid,
+) -> (WsSink, WsStream) {
+    let device_id: Uuid = sqlx::query_scalar("SELECT device_id FROM devices WHERE user_id = $1")
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("device lookup failed");
+    let ticket = app_state.ws_ticket_store.issue(user_id, device_id);
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
     let (ws, _) = connect_async(&url).await.expect("WS connect failed");
     ws.split()
 }
@@ -318,16 +337,6 @@ async fn drain(stream: &mut WsStream) {
     while let Ok(Some(Ok(_))) = timeout(Duration::from_millis(200), stream.next()).await {
         // Continue draining
     }
-}
-
-/// Authenticate a WS connection. Sends Auth and waits for auth_success.
-async fn ws_auth(sink: &mut WsSink, stream: &mut WsStream, token: &str) {
-    ws_send(sink, json!({"type": "auth", "accessToken": token})).await;
-    let resp = recv_type(stream, "auth_success").await;
-    assert!(
-        resp["userId"].as_str().is_some(),
-        "auth_success must have userId"
-    );
 }
 
 /// Send join_voice and wait for joined + media_token. Returns the joined payload.
@@ -473,14 +482,8 @@ async fn test_28_1_join_voice_happy_path() {
 
     let (addr, state) = start_server(pool).await;
 
-    // Owner connects, authenticates, joins voice
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink1,
-        &mut stream1,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    // Owner connects, pre-authenticated via ws-ticket, joins voice
+    let (mut sink1, mut stream1) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
 
     let joined1 = ws_join_voice(&mut sink1, &mut stream1, &channel_id.to_string(), "Owner").await;
 
@@ -493,14 +496,8 @@ async fn test_28_1_join_voice_happy_path() {
     assert!(joined1["peerId"].as_str().is_some());
     assert_eq!(joined1["peerCount"].as_u64().unwrap(), 1);
 
-    // Member connects, authenticates, joins same channel voice
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink2,
-        &mut stream2,
-        &sign_test_token(&state.db_pool, &member).await,
-    )
-    .await;
+    // Member connects, pre-authenticated via ws-ticket, joins same channel voice
+    let (mut sink2, mut stream2) = ws_connect_as(addr, &state, &state.db_pool, member).await;
 
     let joined2 = ws_join_voice(&mut sink2, &mut stream2, &channel_id.to_string(), "Member").await;
 
@@ -516,33 +513,17 @@ async fn test_28_1_join_voice_happy_path() {
 
 // ===========================================================================
 // 28.2 JoinVoice â€” requires authentication
+//
+// Retired (issue #267): every `/ws` connection now requires a valid
+// pre-auth ticket, and a successfully-ticketed connection is authenticated
+// at upgrade time (see ws.rs's handle_socket). There is no longer a
+// reachable state where a client is WS-connected but not authenticated, so
+// "connect, skip auth, send join_voice" can no longer be constructed. The
+// invariant this test protected — an unauthenticated client cannot
+// join_voice — is now enforced earlier and unconditionally by the ticket
+// gate itself; see ws_ticket_gate_integration.rs's
+// `ws_without_ticket_fails_before_upgrade`.
 // ===========================================================================
-
-#[tokio::test]
-#[ignore]
-async fn test_28_2_join_voice_requires_auth() {
-    let pool = test_pool().await;
-    truncate_tables(&pool).await;
-
-    let owner = register_test_user(&pool).await;
-    let channel_id = create_test_channel(&pool, owner, "voice-noauth").await;
-
-    let (addr, _state) = start_server(pool).await;
-
-    // Connect WITHOUT authenticating, send join_voice
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_send(
-        &mut sink,
-        json!({
-            "type": "join_voice",
-            "channelId": channel_id.to_string()
-        }),
-    )
-    .await;
-
-    let err = recv_type(&mut stream, "error").await;
-    assert_eq!(err["message"].as_str().unwrap(), "not authenticated");
-}
 
 // ===========================================================================
 // 28.3 JoinVoice â€” non-member rejection
@@ -560,13 +541,7 @@ async fn test_28_3_join_voice_non_member() {
 
     let (addr, state) = start_server(pool).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &outsider).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, outsider).await;
 
     ws_send(
         &mut sink,
@@ -599,13 +574,7 @@ async fn test_28_4_join_voice_banned_user() {
 
     let (addr, state) = start_server(pool).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &target).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, target).await;
 
     ws_send(
         &mut sink,
@@ -638,13 +607,7 @@ async fn test_28_5_join_voice_nonexistent_channel() {
 
     let (addr, state) = start_server(pool).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &user).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, user).await;
 
     let fake_channel = Uuid::new_v4();
     ws_send(
@@ -674,13 +637,7 @@ async fn test_28_6_join_voice_invalid_channel_id() {
 
     let (addr, state) = start_server(pool).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &user).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, user).await;
 
     ws_send(
         &mut sink,
@@ -710,13 +667,7 @@ async fn test_28_7_join_voice_field_length_validation() {
 
     let (addr, state) = start_server(pool).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &user).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, user).await;
 
     // channelId > 64 chars â†’ field-length error
     let long_channel_id = "x".repeat(65);
@@ -771,13 +722,7 @@ async fn test_28_8_join_voice_already_joined() {
 
     let (addr, state) = start_server(pool).await;
 
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
 
     // First join_voice succeeds
     ws_join_voice(&mut sink, &mut stream, &channel_id.to_string(), "Owner").await;
@@ -813,13 +758,7 @@ async fn test_28_9_voice_query_happy_path() {
     let (addr, state) = start_server(pool).await;
 
     // Owner joins voice via WS
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
     ws_join_voice(&mut sink, &mut stream, &channel_id.to_string(), "OwnerName").await;
 
     // REST query voice status
@@ -903,23 +842,11 @@ async fn test_28_12_ban_eject_from_voice() {
     let (addr, state) = start_server(pool).await;
 
     // Owner joins voice
-    let (mut sink1, mut stream1) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink1,
-        &mut stream1,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    let (mut sink1, mut stream1) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
     ws_join_voice(&mut sink1, &mut stream1, &channel_id.to_string(), "Owner").await;
 
     // Member joins voice
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink2,
-        &mut stream2,
-        &sign_test_token(&state.db_pool, &member).await,
-    )
-    .await;
+    let (mut sink2, mut stream2) = ws_connect_as(addr, &state, &state.db_pool, member).await;
     ws_join_voice(&mut sink2, &mut stream2, &channel_id.to_string(), "Member").await;
 
     // Owner should have received participant_joined for member
@@ -967,13 +894,7 @@ async fn test_28_13_room_cleanup_on_last_leave() {
     let (addr, state) = start_server(pool).await;
 
     // Join voice
-    let (mut sink, mut stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink,
-        &mut stream,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    let (mut sink, mut stream) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
     let joined = ws_join_voice(&mut sink, &mut stream, &channel_id.to_string(), "Owner").await;
     let room_id_1 = joined["roomId"].as_str().unwrap().to_string();
 
@@ -994,13 +915,7 @@ async fn test_28_13_room_cleanup_on_last_leave() {
 
     // Re-join voice â€” should get a different roomId
     // Need a new WS connection since the old session is in a post-leave state
-    let (mut sink2, mut stream2) = ws_connect(addr).await;
-    ws_auth(
-        &mut sink2,
-        &mut stream2,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    let (mut sink2, mut stream2) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
     let joined2 = ws_join_voice(&mut sink2, &mut stream2, &channel_id.to_string(), "Owner").await;
     let room_id_2 = joined2["roomId"].as_str().unwrap().to_string();
 
@@ -1024,11 +939,12 @@ async fn second_join_voice_same_user_displaces_first_and_frees_slot() {
     let channel_id = create_test_channel(&pool, owner, "voice-displacement").await;
 
     let (addr, state) = start_server(pool).await;
+    // Kept for the REST voice-status call near the end of this test — REST
+    // auth is still Bearer-token based, unaffected by the ws-ticket change.
     let token = sign_test_token(&state.db_pool, &owner).await;
 
     // Connection A: first session for the user.
-    let (mut sink_a, mut stream_a) = ws_connect(addr).await;
-    ws_auth(&mut sink_a, &mut stream_a, &token).await;
+    let (mut sink_a, mut stream_a) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
     let joined_a = ws_join_voice(
         &mut sink_a,
         &mut stream_a,
@@ -1059,8 +975,7 @@ async fn second_join_voice_same_user_displaces_first_and_frees_slot() {
     );
 
     // Connection B: same user, same channel, second WebSocket session.
-    let (mut sink_b, mut stream_b) = ws_connect(addr).await;
-    ws_auth(&mut sink_b, &mut stream_b, &token).await;
+    let (mut sink_b, mut stream_b) = ws_connect_as(addr, &state, &state.db_pool, owner).await;
     ws_send(
         &mut sink_b,
         json!({
@@ -1141,13 +1056,8 @@ async fn passthrough_permission_allows_member_link_but_not_member_toggle() {
     add_member(&pool, channel_id, owner, member).await;
     let (addr, state) = start_server(pool).await;
 
-    let (mut owner_sink, mut owner_stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut owner_sink,
-        &mut owner_stream,
-        &sign_test_token(&state.db_pool, &owner).await,
-    )
-    .await;
+    let (mut owner_sink, mut owner_stream) =
+        ws_connect_as(addr, &state, &state.db_pool, owner).await;
     ws_join_voice(
         &mut owner_sink,
         &mut owner_stream,
@@ -1156,13 +1066,8 @@ async fn passthrough_permission_allows_member_link_but_not_member_toggle() {
     )
     .await;
 
-    let (mut member_sink, mut member_stream) = ws_connect(addr).await;
-    ws_auth(
-        &mut member_sink,
-        &mut member_stream,
-        &sign_test_token(&state.db_pool, &member).await,
-    )
-    .await;
+    let (mut member_sink, mut member_stream) =
+        ws_connect_as(addr, &state, &state.db_pool, member).await;
     ws_join_voice(
         &mut member_sink,
         &mut member_stream,

--- a/wavis-backend/tests/ws_dispatch_newer_variants.rs
+++ b/wavis-backend/tests/ws_dispatch_newer_variants.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::time::timeout;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
 
 use axum::Router;
 use axum::routing::get;
@@ -123,8 +124,13 @@ type WsStream = futures_util::stream::SplitStream<
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>,
 >;
 
-async fn ws_connect(addr: SocketAddr) -> (WsSink, WsStream) {
-    let (ws, _) = connect_async(format!("ws://{addr}/ws")).await.unwrap();
+async fn ws_connect(addr: SocketAddr, app_state: &AppState) -> (WsSink, WsStream) {
+    let ticket = app_state
+        .ws_ticket_store
+        .issue(Uuid::new_v4(), Uuid::new_v4());
+    let (ws, _) = connect_async(format!("ws://{addr}/ws?ticket={ticket}"))
+        .await
+        .unwrap();
     ws.split()
 }
 
@@ -168,10 +174,10 @@ async fn join_sfu(sink: &mut WsSink, stream: &mut WsStream, room_id: &str) -> St
 
 #[tokio::test]
 async fn self_deafen_broadcasts_participant_deafened() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
-    let (mut s1, mut r1) = ws_connect(addr).await;
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
 
     let peer1 = join_sfu(&mut s1, &mut r1, "deafen-room").await;
     let _peer2 = join_sfu(&mut s2, &mut r2, "deafen-room").await;
@@ -190,8 +196,8 @@ async fn self_deafen_broadcasts_participant_deafened() {
 
 #[tokio::test]
 async fn self_deafen_not_in_room_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Send SelfDeafen without joining a room first
     ws_send(&mut sink, json!({"type":"self_deafen"})).await;
@@ -207,10 +213,10 @@ async fn self_deafen_not_in_room_returns_error() {
 
 #[tokio::test]
 async fn self_undeafen_broadcasts_participant_undeafened() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
-    let (mut s1, mut r1) = ws_connect(addr).await;
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
 
     let peer1 = join_sfu(&mut s1, &mut r1, "undeafen-room").await;
     let _peer2 = join_sfu(&mut s2, &mut r2, "undeafen-room").await;
@@ -232,8 +238,8 @@ async fn self_undeafen_broadcasts_participant_undeafened() {
 
 #[tokio::test]
 async fn self_undeafen_not_in_room_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     ws_send(&mut sink, json!({"type":"self_undeafen"})).await;
     let err = recv_type(&mut stream, "error").await;
@@ -246,8 +252,8 @@ async fn self_undeafen_not_in_room_returns_error() {
 
 #[tokio::test]
 async fn set_passthrough_without_channel_session_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "pt-room").await;
     drain(&mut stream).await;
 
@@ -269,8 +275,8 @@ async fn set_passthrough_without_channel_session_returns_error() {
 
 #[tokio::test]
 async fn clear_passthrough_without_channel_session_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "cpt-room").await;
     drain(&mut stream).await;
 
@@ -286,8 +292,8 @@ async fn clear_passthrough_without_channel_session_returns_error() {
 
 #[tokio::test]
 async fn set_passthrough_volume_without_channel_session_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "ptv-room").await;
     drain(&mut stream).await;
 
@@ -309,8 +315,8 @@ async fn set_passthrough_volume_without_channel_session_returns_error() {
 
 #[tokio::test]
 async fn sub_room_state_from_client_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "sr-room").await;
     drain(&mut stream).await;
 
@@ -328,8 +334,8 @@ async fn sub_room_state_from_client_returns_error() {
 
 #[tokio::test]
 async fn sub_room_created_from_client_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "src-room").await;
     drain(&mut stream).await;
 
@@ -345,8 +351,8 @@ async fn sub_room_created_from_client_returns_error() {
 
 #[tokio::test]
 async fn sub_room_joined_from_client_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "srj-room").await;
     drain(&mut stream).await;
 
@@ -366,8 +372,8 @@ async fn sub_room_joined_from_client_returns_error() {
 
 #[tokio::test]
 async fn sub_room_left_from_client_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "srl-room").await;
     drain(&mut stream).await;
 
@@ -387,8 +393,8 @@ async fn sub_room_left_from_client_returns_error() {
 
 #[tokio::test]
 async fn sub_room_deleted_from_client_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "srd-room").await;
     drain(&mut stream).await;
 
@@ -410,8 +416,8 @@ async fn sub_room_deleted_from_client_returns_error() {
 
 #[tokio::test]
 async fn chat_history_request_without_session_returns_error() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
 
     // Not joined — state machine should reject with "not in a room"
     ws_send(&mut sink, json!({"type":"chat_history_request"})).await;
@@ -425,8 +431,8 @@ async fn chat_history_request_without_session_returns_error() {
 
 #[tokio::test]
 async fn chat_history_request_in_room_reaches_dispatch() {
-    let (addr, _state) = start_server().await;
-    let (mut sink, mut stream) = ws_connect(addr).await;
+    let (addr, state) = start_server().await;
+    let (mut sink, mut stream) = ws_connect(addr, &state).await;
     join_sfu(&mut sink, &mut stream, "chat-hist-room").await;
     drain(&mut stream).await;
 
@@ -465,9 +471,9 @@ async fn chat_history_request_in_room_reaches_dispatch() {
 
 #[tokio::test]
 async fn deafened_state_visible_in_room_state_for_late_joiner() {
-    let (addr, _state) = start_server().await;
+    let (addr, state) = start_server().await;
 
-    let (mut s1, mut r1) = ws_connect(addr).await;
+    let (mut s1, mut r1) = ws_connect(addr, &state).await;
     let peer1 = join_sfu(&mut s1, &mut r1, "deafen-late-room").await;
     drain(&mut r1).await;
 
@@ -476,7 +482,7 @@ async fn deafened_state_visible_in_room_state_for_late_joiner() {
     drain(&mut r1).await;
 
     // Late joiner
-    let (mut s2, mut r2) = ws_connect(addr).await;
+    let (mut s2, mut r2) = ws_connect(addr, &state).await;
     ws_send(
         &mut s2,
         json!({"type":"join","roomId":"deafen-late-room","roomType":"sfu"}),

--- a/wavis-backend/tests/ws_ticket_gate_integration.rs
+++ b/wavis-backend/tests/ws_ticket_gate_integration.rs
@@ -1,0 +1,220 @@
+#![cfg(feature = "test-support")]
+//! Integration tests for issue #267: the `/ws` pre-auth ticket gate.
+//!
+//! Covers the WS-level acceptance criteria:
+//!   - `/ws` without a ticket fails before upgrade
+//!   - `/ws` with an unknown/invalid ticket fails before upgrade
+//!   - `/ws` with a replayed (already-consumed) ticket fails before upgrade
+//!   - `/ws` with a valid ticket succeeds once, and the ticket is consumed
+//!   - a successfully-ticketed connection is pre-authenticated (no separate
+//!     `Auth` message required — sending one is rejected as "already authenticated")
+//!
+//! Ticket expiry is covered at the unit level (`auth::ws_ticket::tests`, with
+//! clock injection) rather than here — waiting out a real 60s TTL in an
+//! integration test would be slow for no additional coverage.
+//!
+//! No Postgres required: `WsTicketStore` is in-memory, and the dummy lazy
+//! pool below is never queried by anything this file exercises.
+//!
+//! Run: cargo test -p wavis-backend --test ws_ticket_gate_integration --features test-support -- --test-threads=1
+
+use serde_json::{Value, json};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use uuid::Uuid;
+
+use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
+use wavis_backend::app_state::AppState;
+use wavis_backend::auth::auth_rate_limiter::{AuthRateLimiter, AuthRateLimiterConfig};
+use wavis_backend::channel::invite::{InviteStore, InviteStoreConfig};
+use wavis_backend::ip::IpConfig;
+use wavis_backend::voice::mock_sfu_bridge::MockSfuBridge;
+use wavis_backend::voice::sfu_bridge::{SfuRoomManager, SfuSignalingProxy};
+use wavis_backend::ws::ws::ws_handler;
+
+use axum::Router;
+use axum::routing::get;
+
+use futures_util::{SinkExt, StreamExt};
+
+// ============================================================
+// Server setup helper (mirrors abuse_controls_integration.rs)
+// ============================================================
+
+async fn start_server() -> (SocketAddr, AppState) {
+    unsafe {
+        std::env::set_var("SFU_JWT_SECRET", "dev-secret-32-bytes-minimum!!!XX");
+        std::env::set_var("MAX_ROOM_PARTICIPANTS", "6");
+        std::env::set_var("REQUIRE_INVITE_CODE", "false");
+    }
+
+    let mock = Arc::new(MockSfuBridge::new());
+    let invite_store = Arc::new(InviteStore::new(InviteStoreConfig::default()));
+    let join_rate_limiter = Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::default()));
+    let ip_config = IpConfig {
+        trust_proxy_headers: false,
+        trusted_proxy_cidrs: vec![],
+    };
+
+    let app_state = AppState::new(
+        mock.clone() as Arc<dyn SfuRoomManager>,
+        Some(mock as Arc<dyn SfuSignalingProxy>),
+        "sfu://localhost".to_string(),
+        invite_store,
+        join_rate_limiter,
+        ip_config,
+        Arc::new(b"dev-secret-32-bytes-minimum!!!XX".to_vec()),
+        None,
+        "wavis-backend".to_string(),
+        sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://dummy")
+            .unwrap(),
+        Arc::new(b"test-auth-secret-at-least-32-bytes!!".to_vec()),
+        None,
+        Arc::new(AuthRateLimiter::new(AuthRateLimiterConfig::default())),
+        30,
+        72,
+        Arc::new(b"test-pepper-at-least-32-bytes!!!!!!".to_vec()),
+        None,
+        Arc::new(wavis_backend::auth::phrase::generate_dummy_verifier(
+            &wavis_backend::auth::phrase::PhraseConfig::default(),
+        )),
+        Arc::new(b"test-pairing-pepper-32-bytes!!XX".to_vec()),
+        Arc::new(
+            wavis_backend::auth::recovery_rate_limiter::RecoveryRateLimiter::new(
+                wavis_backend::auth::recovery_rate_limiter::RecoveryRateLimiterConfig::default(),
+            ),
+        ),
+        Arc::new(wavis_backend::auth::phrase::PhraseConfig::default()),
+        Arc::new(vec![0u8; 32]),
+        24,
+        7,
+        Arc::new(wavis_backend::diagnostics::bug_report::MockGitHubClient::new()),
+        "owner/test-repo".to_string(),
+        Arc::new(wavis_backend::diagnostics::llm_client::NoOpLlmClient),
+    );
+
+    {
+        let health = app_state.sfu_room_manager.health_check().await.unwrap();
+        *app_state.sfu_health_status.write().await = health;
+    }
+
+    let app = Router::new()
+        .route("/ws", get(ws_handler))
+        .with_state(app_state.clone());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, app_state)
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+#[tokio::test]
+async fn ws_without_ticket_fails_before_upgrade() {
+    let (addr, _state) = start_server().await;
+    let url = format!("ws://{addr}/ws");
+
+    let result = connect_async(&url).await;
+    assert!(
+        result.is_err(),
+        "connection without a ticket query param must be rejected before upgrade"
+    );
+}
+
+#[tokio::test]
+async fn ws_with_empty_ticket_fails_before_upgrade() {
+    let (addr, _state) = start_server().await;
+    let url = format!("ws://{addr}/ws?ticket=");
+
+    let result = connect_async(&url).await;
+    assert!(
+        result.is_err(),
+        "connection with an empty ticket value must be rejected before upgrade"
+    );
+}
+
+#[tokio::test]
+async fn ws_with_unknown_ticket_fails_before_upgrade() {
+    let (addr, _state) = start_server().await;
+    let url = format!("ws://{addr}/ws?ticket=totally-made-up-ticket-value-not-issued");
+
+    let result = connect_async(&url).await;
+    assert!(
+        result.is_err(),
+        "connection with a ticket the server never issued must be rejected before upgrade"
+    );
+}
+
+#[tokio::test]
+async fn ws_with_valid_ticket_succeeds_once_then_replay_fails() {
+    let (addr, state) = start_server().await;
+    let ticket = state.ws_ticket_store.issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
+
+    // First use of a freshly-issued, valid ticket must succeed.
+    let first = connect_async(&url).await;
+    assert!(first.is_ok(), "first use of a valid ticket must succeed");
+    drop(first);
+
+    // Replaying the same (now-consumed) ticket must be rejected.
+    let second = connect_async(&url).await;
+    assert!(
+        second.is_err(),
+        "a replayed (already-consumed) ticket must be rejected before upgrade"
+    );
+}
+
+#[tokio::test]
+async fn ws_ticket_authenticates_connection_without_a_separate_auth_message() {
+    let (addr, state) = start_server().await;
+    let ticket = state.ws_ticket_store.issue(Uuid::new_v4(), Uuid::new_v4());
+    let url = format!("ws://{addr}/ws?ticket={ticket}");
+
+    let (ws, _) = connect_async(&url)
+        .await
+        .expect("a valid ticket must be accepted");
+    let (mut sink, mut stream) = ws.split();
+
+    // The connection is already authenticated by the ticket at upgrade time,
+    // so a client-sent Auth message must be rejected as redundant — proving
+    // the server didn't wait for one to mark the session authenticated.
+    sink.send(Message::Text(
+        json!({"type": "auth", "accessToken": "irrelevant"}).to_string(),
+    ))
+    .await
+    .unwrap();
+
+    let msg = timeout(Duration::from_secs(3), stream.next())
+        .await
+        .expect("expected a response before timeout")
+        .expect("stream closed unexpectedly")
+        .expect("ws-level error");
+
+    let Message::Text(text) = msg else {
+        panic!("expected a text message, got {msg:?}");
+    };
+    let v: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(v["type"], "error");
+    assert_eq!(
+        v["message"], "already authenticated",
+        "ticket-derived auth must already be in effect at connection start"
+    );
+}

--- a/wavis-backend/tests/ws_ticket_rest_integration.rs
+++ b/wavis-backend/tests/ws_ticket_rest_integration.rs
@@ -1,0 +1,234 @@
+#![cfg(feature = "test-support")]
+//! HTTP-level integration tests for `POST /auth/ws-ticket` (issue #267).
+//!
+//! Covers the REST-level acceptance criteria:
+//!   - Authenticated ticket request succeeds
+//!   - Unauthenticated ticket request fails
+//!
+//! All tests require a running Postgres instance.
+//! Run with: `cargo test --test ws_ticket_rest_integration --features test-support -- --ignored --test-threads=1`
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::routing::post;
+use serde_json::Value;
+use serial_test::serial;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use wavis_backend::abuse::join_rate_limiter::{JoinRateLimiter, JoinRateLimiterConfig};
+use wavis_backend::app_state::AppState;
+use wavis_backend::auth::auth_rate_limiter::{AuthRateLimiter, AuthRateLimiterConfig};
+use wavis_backend::auth::jwt::sign_access_token;
+use wavis_backend::auth::routes as auth_routes;
+use wavis_backend::ip::IpConfig;
+use wavis_backend::voice::mock_sfu_bridge::MockSfuBridge;
+use wavis_backend::voice::sfu_bridge::SfuRoomManager;
+
+const TEST_AUTH_SECRET: &[u8] = b"test-auth-secret-at-least-32-bytes!!";
+const TEST_PEPPER: &[u8] = b"test-pepper-at-least-32-bytes!!!!!!";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async fn test_pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://wavis:wavis@localhost:5432/wavis".to_string());
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(5)
+        .connect(&url)
+        .await
+        .expect("Failed to connect to test database");
+    sqlx::migrate!()
+        .run(&pool)
+        .await
+        .expect("Failed to run migrations");
+    pool
+}
+
+async fn truncate_tables(pool: &PgPool) {
+    sqlx::query("TRUNCATE refresh_tokens, devices, users CASCADE")
+        .execute(pool)
+        .await
+        .expect("Failed to truncate tables");
+}
+
+/// Register a test device and return (user_id, device_id).
+async fn register_test_user(pool: &PgPool) -> (Uuid, Uuid) {
+    let reg =
+        wavis_backend::auth::auth::register_device(pool, TEST_AUTH_SECRET, 30, 30, TEST_PEPPER)
+            .await
+            .expect("register_device failed");
+    (reg.user_id, reg.device_id)
+}
+
+fn sign_test_token(user_id: &Uuid, device_id: &Uuid) -> String {
+    sign_access_token(user_id, device_id, TEST_AUTH_SECRET, 3600, 0)
+        .expect("signing should succeed")
+}
+
+/// Build a minimal AppState backed by a real DB pool (mirrors channel_rest_integration.rs).
+fn build_test_app_state(pool: PgPool) -> AppState {
+    let mock = Arc::new(MockSfuBridge::new());
+    AppState::new(
+        mock.clone() as Arc<dyn SfuRoomManager>,
+        None,
+        "sfu://localhost".to_string(),
+        Arc::new(wavis_backend::channel::invite::InviteStore::new(
+            wavis_backend::channel::invite::InviteStoreConfig::default(),
+        )),
+        Arc::new(JoinRateLimiter::new(JoinRateLimiterConfig::default())),
+        IpConfig {
+            trust_proxy_headers: false,
+            trusted_proxy_cidrs: vec![],
+        },
+        Arc::new(b"dev-secret-32-bytes-minimum!!!XX".to_vec()),
+        None,
+        "wavis-backend".to_string(),
+        pool,
+        Arc::new(TEST_AUTH_SECRET.to_vec()),
+        None,
+        Arc::new(AuthRateLimiter::new(AuthRateLimiterConfig::default())),
+        30,
+        72,
+        Arc::new(TEST_PEPPER.to_vec()),
+        None,
+        Arc::new(wavis_backend::auth::phrase::generate_dummy_verifier(
+            &wavis_backend::auth::phrase::PhraseConfig::default(),
+        )),
+        Arc::new(b"test-pairing-pepper-32-bytes!!XX".to_vec()),
+        Arc::new(
+            wavis_backend::auth::recovery_rate_limiter::RecoveryRateLimiter::new(
+                wavis_backend::auth::recovery_rate_limiter::RecoveryRateLimiterConfig::default(),
+            ),
+        ),
+        Arc::new(wavis_backend::auth::phrase::PhraseConfig::default()),
+        Arc::new(vec![0u8; 32]),
+        24,
+        7,
+        Arc::new(wavis_backend::diagnostics::bug_report::MockGitHubClient::new()),
+        "owner/test-repo".to_string(),
+        Arc::new(wavis_backend::diagnostics::llm_client::NoOpLlmClient),
+    )
+}
+
+fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/auth/ws-ticket", post(auth_routes::issue_ws_ticket))
+        .with_state(state)
+}
+
+async fn send_json(app: &Router, req: Request<Body>) -> (StatusCode, Value) {
+    let response = app.clone().oneshot(req).await.unwrap();
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), 1024 * 64)
+        .await
+        .unwrap();
+    let body: Value = if body_bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body_bytes).unwrap_or(Value::Null)
+    };
+    (status, body)
+}
+
+fn post_empty_with_auth(uri: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method("POST").uri(uri);
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Authenticated ticket request succeeds
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn authenticated_ws_ticket_request_succeeds_and_consumes_once() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let (user_id, device_id) = register_test_user(&pool).await;
+    let token = sign_test_token(&user_id, &device_id);
+
+    let state = build_test_app_state(pool);
+    let app = build_router(state.clone());
+
+    let (status, body) =
+        send_json(&app, post_empty_with_auth("/auth/ws-ticket", Some(&token))).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let ticket = body["ticket"]
+        .as_str()
+        .expect("response must include a ticket string")
+        .to_string();
+    assert!(!ticket.is_empty(), "ticket must not be empty");
+    assert!(
+        body["expires_in"].as_u64().unwrap() > 0,
+        "expires_in must be positive"
+    );
+
+    // The minted ticket must resolve to the authenticated caller's identity,
+    // and be consumable exactly once.
+    let resolved = state
+        .ws_ticket_store
+        .validate_and_consume(&ticket)
+        .expect("freshly-issued ticket must validate");
+    assert_eq!(resolved, (user_id, device_id));
+
+    let replay = state.ws_ticket_store.validate_and_consume(&ticket);
+    assert!(replay.is_err(), "ticket must not be consumable twice");
+}
+
+// ---------------------------------------------------------------------------
+// Unauthenticated ticket request fails
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn unauthenticated_ws_ticket_request_fails() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let state = build_test_app_state(pool);
+    let app = build_router(state);
+
+    let (status, _body) = send_json(&app, post_empty_with_auth("/auth/ws-ticket", None)).await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "missing Authorization header must be rejected"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn ws_ticket_request_with_garbage_bearer_token_fails() {
+    let pool = test_pool().await;
+    truncate_tables(&pool).await;
+
+    let state = build_test_app_state(pool);
+    let app = build_router(state);
+
+    let (status, _body) = send_json(
+        &app,
+        post_empty_with_auth("/auth/ws-ticket", Some("not-a-real-jwt")),
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        StatusCode::UNAUTHORIZED,
+        "an invalid Bearer token must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `POST /auth/ws-ticket` (Bearer-authenticated) — mints a high-entropy, 60-second, one-use ticket via an in-memory `WsTicketStore` (`wavis-backend/src/auth/ws_ticket.rs`), keyed by an HMAC-SHA256 hash of the raw ticket (only the hash is ever stored). Chose in-memory over a Postgres table: a 60s TTL has no value across restarts, and every other pre-upgrade abuse control (temp ban, IP cap, global ceiling) is already an in-memory `RwLock<HashMap<..>>` — this follows that pattern rather than adding a DB round-trip to the hot `/ws` upgrade path.
- `/ws` now requires `?ticket=<raw>`. The ticket is validated and atomically consumed **before** the per-IP connection-cap increment, so a rejected ticket never burns a connection-count slot. A valid ticket authenticates the WebSocket immediately at upgrade time — before the message loop starts, satisfying "successful ticket validation initializes the WebSocket as authenticated for that user/device."
- This closes the actual gap #239 was filed over: previously, any client could open `/ws` and send `Join`/`CreateRoom` without ever authenticating, since the signaling-level `Auth` message was optional. Every `/ws` connection now requires a Bearer-authenticated REST call first.

## Test fallout across the existing suite (large, but necessary)
All 14 existing WS integration test files connected to `/ws` with no ticket — valid before this change, not after. Fixed all of them:
- 13 files: mint a fresh ticket per connection inside the existing `ws_connect`/`try_ws_connect` helper (using the `AppState` each test already had in scope). Pure connection-plumbing change, zero assertion/logic changes.
- `voice_ws_integration.rs` needed a deeper fix, not just plumbing: 12 of its tests used the old connect-then-send-signaling-`Auth`-message flow, which a ticket-authenticated connection now rejects with `"already authenticated"` (`ws/validation.rs`, unchanged, pre-existing rule — a ticket now proves identity before any `Auth` message could). Those tests now connect pre-authenticated via a ticket issued for the *specific* registered identity the test already set up in Postgres, and skip the now-redundant `Auth` message.
- One test, `test_28_2_join_voice_requires_auth`, is retired: its premise (a WS-connected-but-unauthenticated client) is no longer constructible — ticket validation and authentication now happen together at upgrade time. The invariant it checked is covered earlier and unconditionally by `ws_ticket_gate_integration.rs`'s `ws_without_ticket_fails_before_upgrade`.

**Note for #268** (GUI ticket integration): the real client's existing post-connect signaling `Auth` message will be rejected the same way once it adopts tickets — that send needs to be **dropped**, not layered on top of the new ticket flow.

## Test plan
- [x] New unit tests (`auth::ws_ticket::tests`, 7 cases incl. proptests): issue→consume-once, replay rejected, unknown ticket rejected, expiry via clock injection, prune behavior.
- [x] New `ws_ticket_gate_integration.rs` (5 tests, no DB needed): missing/empty/unknown ticket rejected before upgrade, valid ticket succeeds once then replay fails, ticket-authenticated connection rejects a redundant `Auth` message.
- [x] New `ws_ticket_rest_integration.rs` (3 `#[ignore]`d DB tests): authenticated request succeeds and the ticket resolves to the caller's real identity and is consumable once; unauthenticated/garbage-Bearer requests fail with 401.
- [x] Full crate suite green: `cargo test -p wavis-backend --features test-support -- --test-threads=1` (521 lib tests + all non-ignored integration tests, 0 failed) and `-- --ignored --test-threads=1` against local Postgres (all touched integration files pass, including the full 14-test `voice_ws_integration.rs` suite and `test_metrics_integration.rs` under `--features test-support,test-metrics`).
- [x] `cargo fmt --all --check` and `cargo clippy -p wavis-backend --tests --features test-support -- -D warnings` — both clean.
- Pre-existing, unrelated: 5 `chat::chat_persistence` lib tests fail under `--ignored` with "Cannot start a runtime from within a runtime" — confirmed via `git diff --stat origin/pre-dev -- wavis-backend/src/chat/chat_persistence.rs` (zero diff) and reproduces identically in complete isolation; a pre-existing nested-tokio-runtime test-harness issue, unrelated to this change.

Closes #267 (sub-task of #239, backend gate for `/auth/register` landed in #264/#281; GUI-side invite-code collection landed in #266/#324).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8kBgRkugg4qotr9JvBMQ1