### PR TITLE
feat(gui): connect GUI WebSocket with pre-auth ticket

### DIFF
--- a/clients/wavis-gui/src/features/auth/__tests__/auth.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/auth.test.ts
@@ -106,6 +106,8 @@ let mockKeychain: Record<string, string> = {};
 let deleteTokenCalls: Array<{ key: string }> = [];
 let mockFetchBehavior: 'network_error' | '401' | '400' | '429' | '500' | '200' = '200';
 let mockRetryAfterHeader: string | null = null;
+let mockWsTicketBehavior: 'network_error' | '401' | '200' = '200';
+let wsTicketAuthHeaders: string[] = [];
 
 /* ─── Module Mocks ──────────────────────────────────────────────── */
 
@@ -140,7 +142,27 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 vi.mock('@tauri-apps/plugin-http', () => ({
-  fetch: vi.fn(async (url: string) => {
+  fetch: vi.fn(async (url: string, options?: { headers?: Record<string, string> }) => {
+    if (typeof url === 'string' && url.includes('/auth/ws-ticket')) {
+      wsTicketAuthHeaders.push(options?.headers?.Authorization ?? '');
+      if (mockWsTicketBehavior === 'network_error') {
+        throw new Error('Network error: connection refused');
+      }
+      if (mockWsTicketBehavior === '401') {
+        return {
+          ok: false,
+          status: 401,
+          headers: { get: () => null },
+          json: async () => ({ error: 'authentication failed' }),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => null },
+        json: async () => ({ ticket: 'raw-ws-ticket-abc123', expires_in: 60 }),
+      };
+    }
     if (typeof url === 'string' && url.includes('/auth/refresh')) {
       if (mockFetchBehavior === 'network_error') {
         throw new Error('Network error: connection refused');
@@ -514,5 +536,61 @@ describe('refreshTokens RefreshResult mapping', () => {
     expect(result2.status).toBe('success');
     // Both should be the exact same promise resolution
     expect(result1).toEqual(result2);
+  });
+});
+
+/* ═══ fetchWsTicket Tests ═════════════════════════════════════════════
+ *
+ * Issue #268: connect GUI WebSocket with pre-auth ticket.
+ */
+describe('fetchWsTicket', () => {
+  beforeEach(() => {
+    mockStore = {};
+    mockKeychain = {};
+    deleteTokenCalls = [];
+    mockWsTicketBehavior = '200';
+    wsTicketAuthHeaders = [];
+    vi.resetModules();
+  });
+
+  it('returns the raw ticket on success, sent with the access token as a Bearer header', async () => {
+    mockStore = { server_url: 'https://wavis.example.com', access_token: 'my-access-token' };
+    mockWsTicketBehavior = '200';
+
+    const auth = await import('../auth');
+    const ticket = await auth.fetchWsTicket();
+
+    expect(ticket).toBe('raw-ws-ticket-abc123');
+    expect(wsTicketAuthHeaders).toContainEqual('Bearer my-access-token');
+  });
+
+  it('throws when no server URL is configured', async () => {
+    mockStore = { access_token: 'my-access-token' };
+
+    const auth = await import('../auth');
+    await expect(auth.fetchWsTicket()).rejects.toThrow('No server URL configured');
+  });
+
+  it('throws when not authenticated (no access token)', async () => {
+    mockStore = { server_url: 'https://wavis.example.com' };
+
+    const auth = await import('../auth');
+    await expect(auth.fetchWsTicket()).rejects.toThrow('Not authenticated');
+  });
+
+  it('throws a descriptive error on a non-ok server response', async () => {
+    mockStore = { server_url: 'https://wavis.example.com', access_token: 'my-access-token' };
+    mockWsTicketBehavior = '401';
+
+    const auth = await import('../auth');
+    await expect(auth.fetchWsTicket()).rejects.toThrow('401');
+  });
+
+  it('throws a descriptive error on a network failure', async () => {
+    mockStore = { server_url: 'https://wavis.example.com', access_token: 'my-access-token' };
+    mockWsTicketBehavior = 'network_error';
+
+    const auth = await import('../auth');
+    await expect(auth.fetchWsTicket()).rejects.toThrow('Network error');
   });
 });

--- a/clients/wavis-gui/src/features/auth/auth.ts
+++ b/clients/wavis-gui/src/features/auth/auth.ts
@@ -589,6 +589,43 @@ export async function rotatePhrase(currentPhrase: string, newPhrase: string): Pr
   }
 }
 
+// --- WS Pre-Auth Ticket (exported) ---
+
+/**
+ * Mint a short-lived, one-use ticket for the /ws upgrade (closed-alpha
+ * pre-auth gate, issue #267/#268). Bearer-authenticated REST call; the raw
+ * ticket is only ever sent back to the caller and as the WS `?ticket=`
+ * query param -- never over the WS connection itself.
+ */
+export async function fetchWsTicket(): Promise<string> {
+  const serverUrl = await getServerUrl();
+  if (!serverUrl) throw new Error('No server URL configured');
+  const accessToken = await getAccessToken();
+  if (!accessToken) throw new Error('Not authenticated');
+  const insecure = await getInsecureTls();
+
+  let res: Response;
+  try {
+    res = await tauriFetch(serverUrl.replace(/\/+$/, '') + '/auth/ws-ticket', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${accessToken}` },
+      ...(insecure ? { dangerouslyIgnoreCertificateErrors: true } : {}),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Network error -- could not reach server for WS ticket: ${message}`, {
+      cause: err,
+    });
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch WS ticket -- server returned ${res.status}`);
+  }
+
+  const body = (await res.json()) as { ticket: string; expires_in: number };
+  return body.ticket;
+}
+
 // --- Token Refresh (exported) ---
 
 export async function refreshTokens(): Promise<RefreshResult> {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -4333,6 +4333,32 @@ export function initSession(
 
   // Detect disconnection during active session for reconnection flow
   unsubStatusChange = client.onStatusChange((status) => {
+    if (status === 'connected') {
+      // A ws-ticket authenticates the connection at upgrade time (#268), so
+      // there is no post-connect auth_success signal to wait for anymore —
+      // the socket opening IS the authentication success signal.
+      if (state.machineState === 'connecting' || state.machineState === 'reconnecting') {
+        authRefreshRetries = 0;
+        // On reconnect: clear peer-bound state before re-joining
+        if (state.machineState === 'reconnecting') {
+          wasReconnecting = true;
+          state.participants = [];
+          state.subRooms = [];
+          state.participantSubRoomById = {};
+          state.joinedSubRoomId = null;
+          state.passthrough = null;
+          state.selfParticipantId = null;
+          state.error = null;
+          state.rejectionReason = null;
+          state.sharePermission = 'anyone'; // reset stale permission; joined message will set authoritative value
+        }
+        state.machineState = 'authenticated';
+        state.machineState = 'joining';
+        sendJoinVoiceRequest();
+        notify();
+      }
+      return;
+    }
     if (status === 'disconnected') {
       stopColdStartRetry();
       if (state.machineState === 'active' || state.machineState === 'joining') {

--- a/clients/wavis-gui/src/shared/__tests__/websocket.test.ts
+++ b/clients/wavis-gui/src/shared/__tests__/websocket.test.ts
@@ -14,6 +14,7 @@ vi.mock('@features/auth/auth', () => ({
   getAccessToken: vi.fn().mockResolvedValue('test-access-token'),
   isTokenExpired: vi.fn().mockResolvedValue(false),
   refreshTokens: vi.fn().mockResolvedValue({ status: 'success' }),
+  fetchWsTicket: vi.fn().mockResolvedValue('test-ws-ticket'),
 }));
 
 // ─── Mock ws-message-buffer ────────────────────────────────────────
@@ -422,18 +423,59 @@ describe('reconnect backoff', () => {
 // ─── connectWithAuth() ────────────────────────────────────────────
 
 describe('connectWithAuth()', () => {
-  it('sends Auth message on open', async () => {
+  it('fetches a ticket before constructing WebSocket', async () => {
+    const { fetchWsTicket } = await import('@features/auth/auth');
     const client = new SignalingClient();
-    // connectWithAuth is async — it awaits isTokenExpired then opens WS
     const connectPromise = client.connectWithAuth('ws://localhost/ws');
-    // Flush the isTokenExpired + getAccessToken microtasks so the WS is created
+    // Flush the isTokenExpired + fetchWsTicket microtasks so the WS is created
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    lastWsInstance!.simulate('open');
+    await connectPromise;
+
+    expect(fetchWsTicket).toHaveBeenCalled();
+    expect(wsConstructorCalls.length).toBeGreaterThan(0);
+  });
+
+  it('WebSocket URL includes ?ticket=...', async () => {
+    const client = new SignalingClient();
+    const connectPromise = client.connectWithAuth('ws://localhost/ws');
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    lastWsInstance!.simulate('open');
+    await connectPromise;
+    expect(wsConstructorCalls.at(-1)).toBe('ws://localhost/ws?ticket=test-ws-ticket');
+  });
+
+  it('does not send the initial signaling auth message', async () => {
+    const client = new SignalingClient();
+    const connectPromise = client.connectWithAuth('ws://localhost/ws');
+    await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
     lastWsInstance!.simulate('open');
     await connectPromise;
     const sentMessages = lastWsInstance!.send.mock.calls.map((c) => JSON.parse(c[0] as string));
-    expect(sentMessages.some((m) => m.type === 'auth')).toBe(true);
-    expect(sentMessages.find((m) => m.type === 'auth')?.accessToken).toBe('test-access-token');
+    expect(sentMessages.some((m) => m.type === 'auth')).toBe(false);
+  });
+
+  it('sets status to disconnected and throws when the ticket request fails, without opening a socket', async () => {
+    const { fetchWsTicket } = await import('@features/auth/auth');
+    vi.mocked(fetchWsTicket).mockRejectedValueOnce(new Error('server returned 401'));
+
+    const client = new SignalingClient();
+    const prevCount = wsConstructorCalls.length;
+    let threw = false;
+    try {
+      await client.connectWithAuth('ws://localhost/ws');
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    expect(client.status).toBe('disconnected');
+    expect(wsConstructorCalls.length).toBe(prevCount);
   });
 
   it('refreshes token when expired before connecting', async () => {
@@ -507,19 +549,23 @@ describe('reconnectWithNewToken()', () => {
     expect(wsConstructorCalls.length).toBe(2);
   });
 
-  it('sends Auth message on the new connection', async () => {
+  it('fetches a fresh ticket for the new connection', async () => {
+    const { fetchWsTicket } = await import('@features/auth/auth');
     const client = new SignalingClient();
     client.connect('ws://localhost/ws');
     lastWsInstance!.simulate('open');
+    vi.mocked(fetchWsTicket).mockClear();
+    vi.mocked(fetchWsTicket).mockResolvedValueOnce('fresh-ws-ticket');
 
     const reconnectPromise = client.reconnectWithNewToken('ws://localhost/ws');
+    await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
     lastWsInstance!.simulate('open');
     await reconnectPromise;
 
-    const sentMessages = lastWsInstance!.send.mock.calls.map((c) => JSON.parse(c[0] as string));
-    expect(sentMessages.some((m) => m.type === 'auth')).toBe(true);
+    expect(fetchWsTicket).toHaveBeenCalledTimes(1);
+    expect(wsConstructorCalls.at(-1)).toBe('ws://localhost/ws?ticket=fresh-ws-ticket');
   });
 });
 

--- a/clients/wavis-gui/src/shared/websocket.ts
+++ b/clients/wavis-gui/src/shared/websocket.ts
@@ -5,7 +5,7 @@
  * Standard WebSocket API works in Tauri webview.
  */
 
-import { getAccessToken, isTokenExpired, refreshTokens } from '@features/auth/auth';
+import { fetchWsTicket, isTokenExpired, refreshTokens } from '@features/auth/auth';
 import { wsMessageBuffer } from './ws-message-buffer';
 
 // ─── Types ─────────────────────────────────────────────────────────
@@ -88,10 +88,12 @@ export class SignalingClient {
   }
 
   /**
-   * Connect with auth bootstrap:
+   * Connect with pre-auth ticket bootstrap:
    * 1. If token expired, refreshTokens() first
-   * 2. Open WebSocket connection
-   * 3. On open, send Auth message with current access token
+   * 2. Fetch a short-lived, one-use ws-ticket via POST /auth/ws-ticket
+   * 3. Open the WebSocket with ?ticket=... — the ticket authenticates the
+   *    connection at upgrade time, so no post-connect signaling auth
+   *    message is sent (the backend rejects one as "already authenticated").
    */
   async connectWithAuth(wsUrl: string): Promise<void> {
     if (await isTokenExpired()) {
@@ -102,21 +104,26 @@ export class SignalingClient {
       }
     }
 
-    const token = await getAccessToken();
+    let ticket: string;
+    try {
+      ticket = await fetchWsTicket();
+    } catch (err) {
+      this.setStatus('disconnected');
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(`WS ticket fetch failed — cannot connect (${message})`, { cause: err });
+    }
+
     if (this.ws) this.disconnect();
 
     this.intentionalDisconnect = false;
     this.setStatus('connecting');
-    this.ws = new WebSocket(wsUrl);
+    this.ws = new WebSocket(`${wsUrl}?ticket=${encodeURIComponent(ticket)}`);
 
     this.ws.onopen = () => {
       this.setStatus('connected');
       this.reconnectAttempt = 0;
       this.reconnectExhausted = false;
       this.stopPeriodicRetry();
-      // Send Auth message as first message
-      this.send({ type: 'auth', accessToken: token });
-      console.log(LOG_PREFIX, 'Auth message sent');
     };
 
     this.ws.onmessage = (event) => {


### PR DESCRIPTION
## Summary
- `connectWithAuth()` now calls `POST /auth/ws-ticket` (Bearer-authenticated, refreshing the access token first if expired) and opens the socket at `?ticket=...` instead of sending the `{ type: "auth", accessToken }` bootstrap message.
- Every reconnect path (`scheduleReconnect`'s fast/periodic retry, `reconnectWithNewToken`) funnels through `connectWithAuth`, so each attempt mints and uses a fresh ticket automatically.
- A failed ticket fetch (network error or non-2xx) leaves the client `disconnected` and throws a descriptive error without ever constructing a `WebSocket`.
- Since a ws-ticket authenticates the connection at upgrade time, the backend no longer emits `auth_success` post-connect (that message is only sent in reply to the client-initiated `Auth` message this PR removes). The `join_voice` request that used to fire on `auth_success` now fires on the `SignalingClient` `'connected'` status transition instead — otherwise the join flow would hang forever after every connect/reconnect once the `Auth` send is dropped. This was found during implementation, not called out in the original issue text, but required for the feature to actually work end-to-end (confirmed against `#267`'s own integration tests, which connect via ticket and send `join_voice` directly with no `Auth`/`AuthSuccess` round trip).

## Requirement status
| Requirement | Status | Evidence |
|---|---|---|
| `connectWithAuth` refreshes the access token if needed | Done (pre-existing, unchanged) | `websocket.ts` `isTokenExpired`/`refreshTokens` check retained |
| Client calls `POST /auth/ws-ticket` before opening the socket | Done | `auth.ts: fetchWsTicket()`, called at `websocket.ts:109` before `new WebSocket(...)` |
| Client connects to `/ws?ticket=...` | Done | `websocket.ts:120` |
| GUI no longer sends the initial `{ type: "auth", accessToken }` message | Done | removed from `connectWithAuth`'s `onopen` |
| Reconnects request a fresh ticket | Done | all reconnect paths call `connectWithAuth`, which always re-fetches |
| Ticket fetch failure leaves the client disconnected and reports a useful error | Done | `websocket.ts:107-114` |
| Test: ticket fetched before constructing `WebSocket` | Done | `websocket.test.ts` `connectWithAuth() > fetches a ticket before constructing WebSocket` |
| Test: WS URL includes `?ticket=...` | Done | `websocket.test.ts` `connectWithAuth() > WebSocket URL includes ?ticket=...` |
| Test: initial auth message not sent | Done | `websocket.test.ts` `connectWithAuth() > does not send the initial signaling auth message` |
| Test: reconnect gets a new ticket | Done | `websocket.test.ts` `reconnectWithNewToken() > fetches a fresh ticket for the new connection` |
| Test: ticket request failure does not open a socket | Done | `websocket.test.ts` `connectWithAuth() > sets status to disconnected and throws when the ticket request fails, without opening a socket` |

## Validation
- `npm run typecheck` — clean
- `npx eslint <touched files>` + full `npm run lint` — 0 errors (pre-existing baseline warnings only, no new ones)
- `npm run format:check` — clean
- `npm run lint:deps` — no violations
- `node scripts/arch-check.mjs` — OK
- `npx vitest run` on `websocket.test.ts`, `auth.test.ts`, and the four `voice-room-*` suites that exercise the connect→join flow — 241/241 passing

## Dependency
This PR requires **#267** (`feat/backend-ws-ticket-267`, draft PR #325) to be merged first (or in the same deploy) — against the *current* pre-dev backend, which doesn't yet require a ticket, this client would connect but never authenticate (the `Auth` send is gone) and `join_voice` would be rejected. Opening as draft for that reason, mirroring #266/#267.

Closes #268