### PR TITLE
fix(gui): mitigate WebView2 paint-stall on chromeless windows

### DIFF
--- a/clients/wavis-gui/src-tauri/src/main.rs
+++ b/clients/wavis-gui/src-tauri/src/main.rs
@@ -26,6 +26,8 @@ mod external_share_helper;
 #[cfg(target_os = "linux")]
 mod linux_mic;
 #[cfg(target_os = "windows")]
+mod repaint;
+#[cfg(target_os = "windows")]
 mod taskbar_toolbar;
 #[cfg(not(target_os = "linux"))]
 mod external_share_helper {
@@ -519,6 +521,9 @@ fn main() {
                 if let Err(err) = taskbar_toolbar::setup_taskbar_toolbar(app) {
                     log::warn!("wavis: taskbar toolbar unavailable: {err}");
                 }
+
+                #[cfg(target_os = "windows")]
+                repaint::start_periodic_nudge(app.handle().clone());
             }
 
             #[cfg(target_os = "linux")]
@@ -573,6 +578,14 @@ fn main() {
                     }
                 }
                 tauri::WindowEvent::Focused(focused) => {
+                    #[cfg(target_os = "windows")]
+                    if *focused && repaint::is_repaint_nudge_target(window.label()) {
+                        if let Some(webview_window) =
+                            window.app_handle().get_webview_window(window.label())
+                        {
+                            repaint::nudge_repaint(&webview_window);
+                        }
+                    }
                     if window.label() == "main" {
                         let app = window.app_handle();
                         if let Some(vis) = app.try_state::<tray::WindowVisibility>() {

--- a/clients/wavis-gui/src-tauri/src/repaint.rs
+++ b/clients/wavis-gui/src-tauri/src/repaint.rs
@@ -1,0 +1,132 @@
+//! Mitigation for a WebView2-on-Windows compositor paint-stall: chromeless
+//! (`decorations:false`) windows occasionally stop repainting while sitting
+//! open, and only recover when the user manually resizes the window (#329).
+//! Every Wavis window is chromeless — the main window (`tauri.conf.json`) and
+//! the four child window types built from `CHILD_WINDOW_BASE_OPTIONS` in
+//! `share-window-bridge.ts` — so all are equally exposed.
+//!
+//! The mitigation is a trivial resize: growing a window by one physical
+//! pixel and immediately restoring it forces WebView2 to recreate its
+//! swap-chain surface and redraw, with no user-visible size change. It's
+//! applied on two triggers: a window regaining focus, and a periodic timer
+//! for windows that stay open and idle without ever being refocused (the
+//! reported case — the window went blank while nobody was interacting with
+//! it).
+//!
+//! Windows-only: this compositor bug has not been reported on macOS/Linux,
+//! and the fix is scoped to Windows only (#329).
+
+use std::time::Duration;
+use tauri::{AppHandle, Manager, PhysicalSize, Size};
+
+/// How often the periodic defensive nudge sweeps visible windows.
+const PERIODIC_NUDGE_INTERVAL: Duration = Duration::from_secs(180);
+
+/// Window labels affected by the chromeless-window paint-stall. Must stay in
+/// sync with every window label created via `WebviewWindowBuilder`/`new
+/// WebviewWindow` — see `share-window-bridge.ts`'s child window constructors
+/// and `tauri.conf.json`'s main window entry.
+pub fn is_repaint_nudge_target(label: &str) -> bool {
+    matches!(
+        label,
+        "main" | "watch-all" | "camera-popout" | "share-picker"
+    ) || label.starts_with("screen-share-")
+}
+
+/// Whether a periodic sweep should nudge this window: in scope, currently
+/// visible, and not minimized. A destroyed window never reaches this check —
+/// it's simply absent from `AppHandle::webview_windows()`.
+pub fn should_periodic_nudge(label: &str, visible: bool, minimized: bool) -> bool {
+    is_repaint_nudge_target(label) && visible && !minimized
+}
+
+/// Force a WebView2/compositor redraw without a visible size change: grow
+/// the window by one physical pixel, then immediately restore its original
+/// size.
+pub fn nudge_repaint(window: &tauri::WebviewWindow) {
+    let Ok(size) = window.inner_size() else {
+        return;
+    };
+    let nudged = PhysicalSize::new(size.width.saturating_add(1), size.height);
+    let _ = window.set_size(Size::Physical(nudged));
+    let _ = window.set_size(Size::Physical(size));
+}
+
+/// Start the periodic defensive nudge: every `PERIODIC_NUDGE_INTERVAL`,
+/// sweep all open windows and nudge the ones that are in scope, visible, and
+/// not minimized. Runs for the lifetime of the app process.
+pub fn start_periodic_nudge(app: AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let mut ticker = tokio::time::interval(PERIODIC_NUDGE_INTERVAL);
+        ticker.tick().await; // first tick fires immediately; skip it
+        loop {
+            ticker.tick().await;
+            for (label, window) in app.webview_windows() {
+                let visible = window.is_visible().unwrap_or(false);
+                let minimized = window.is_minimized().unwrap_or(false);
+                if should_periodic_nudge(&label, visible, minimized) {
+                    nudge_repaint(&window);
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn main_window_is_a_nudge_target() {
+        assert!(is_repaint_nudge_target("main"));
+    }
+
+    #[test]
+    fn watch_all_is_a_nudge_target() {
+        assert!(is_repaint_nudge_target("watch-all"));
+    }
+
+    #[test]
+    fn camera_popout_is_a_nudge_target() {
+        assert!(is_repaint_nudge_target("camera-popout"));
+    }
+
+    #[test]
+    fn share_picker_is_a_nudge_target() {
+        assert!(is_repaint_nudge_target("share-picker"));
+    }
+
+    #[test]
+    fn screen_share_popouts_are_nudge_targets_regardless_of_participant_id() {
+        assert!(is_repaint_nudge_target("screen-share-618368a7-d0ab-43ce"));
+        assert!(is_repaint_nudge_target("screen-share-"));
+    }
+
+    #[test]
+    fn unknown_labels_are_not_nudge_targets() {
+        assert!(!is_repaint_nudge_target("diagnostics"));
+        assert!(!is_repaint_nudge_target(""));
+        assert!(!is_repaint_nudge_target("screen-sharing"));
+    }
+
+    #[test]
+    fn periodic_nudge_skips_hidden_windows() {
+        assert!(!should_periodic_nudge("watch-all", false, false));
+    }
+
+    #[test]
+    fn periodic_nudge_skips_minimized_windows() {
+        assert!(!should_periodic_nudge("watch-all", true, true));
+    }
+
+    #[test]
+    fn periodic_nudge_skips_out_of_scope_windows() {
+        assert!(!should_periodic_nudge("diagnostics", true, false));
+    }
+
+    #[test]
+    fn periodic_nudge_fires_for_visible_non_minimized_in_scope_windows() {
+        assert!(should_periodic_nudge("watch-all", true, false));
+        assert!(should_periodic_nudge("main", true, false));
+    }
+}


### PR DESCRIPTION
## Summary

Chromeless (`decorations:false`) Wavis windows on Windows can stop compositing while sitting open and idle — the app keeps running underneath (JS logic, Rust capture) but the WebView2 surface goes blank until the user manually resizes the window. Every Wavis window is chromeless (main window + the four child window types), so all are equally exposed. This adds a Windows-only repaint-nudge mitigation: a trivial 1px resize forces WebView2 to redraw, triggered on window focus-regain and on a periodic (3 min) defensive sweep for windows that stay open and idle without ever being refocused — the reported case.

Closes #329

## Requirement status

| # | Requirement | Status | Evidence |
|---|---|---|---|
| 1 | Reusable repaint-nudge helper | DONE | `repaint::nudge_repaint` (`clients/wavis-gui/src-tauri/src/repaint.rs`), called from both the focus hook and the periodic sweep |
| 2 | Wired into `Focused(true)` for every window, main-window logic preserved | DONE | `main.rs` `on_window_event` — nudge call is additive, existing `label == "main"` tray-visibility branch untouched |
| 3 | Periodic defensive nudge, skips hidden/minimized/destroyed | DONE | `repaint::start_periodic_nudge` + `should_periodic_nudge`; destroyed windows are absent from `AppHandle::webview_windows()` |
| 4 | No visible flicker/size/position change | DESIGN INTENT — manual QA below | 1 physical-pixel resize-and-restore, imperceptible by design; cannot be asserted by an automated test |
| 5 | Rust logging conventions | DONE (N/A) | No new logging added; nothing to gate behind `log::` |

## Validation run

Rust-only change — no TS/React files touched, so `npm` gates and `scripts/arch-check.mjs` (backend `ws`-transport-scoped only) don't apply.

- `cargo fmt -p wavis-gui --check` — clean
- `cargo check -p wavis-gui --message-format=short` — clean
- `cargo clippy -p wavis-gui -- -D warnings` — clean
- `cargo test -p wavis-gui repaint::` — 10/10 passed (label-scoping + visibility/minimized-gating decision functions)
- Live smoke test (`run-wavis-gui` skill, debug build, isolated auth store): app launches, main + diagnostics windows both render correctly, closes cleanly — no regression from the new event hook or background task.

Note: `cargo check`/`clippy`/build had to be run from a temp branch in the main tree rather than the worktree — a fresh worktree build hits Windows' 260-char `MAX_PATH` limit on LiveKit/WebRTC's vendored C++ headers (pre-existing, documented, unrelated to this change).

## Manual QA (required before merge — cannot be automated)

Per the issue's resolved acceptance bar: this is a WebView2 compositor paint-stall that cannot be deterministically triggered in CI, so the actual fix needs manual confirmation:

- [ ] Open Watch-All (or another chromeless window) with an active remote share, leave it visible and idle (not focused) for at least 10 minutes — confirm it's still rendering, no manual resize needed.
- [ ] Put the display to sleep and wake it (or lock/unlock the Windows session) while a chromeless window is open — confirm it's still rendering after wake.
- [ ] Alt-tab away and back to a chromeless window — confirm no manual resize is needed.
- [ ] Confirm no visible flicker/size/position jump during normal use.

## Files changed

- `clients/wavis-gui/src-tauri/src/main.rs` — module registration, periodic-nudge startup, focus-hook wiring
- `clients/wavis-gui/src-tauri/src/repaint.rs` (new) — mitigation + unit tests