### PR TITLE
fix(gui): replace filled Music icon with icon swap for audio-only mute badge

### DIFF
--- a/clients/wavis-gui/src/features/voice/ParticipantRow.tsx
+++ b/clients/wavis-gui/src/features/voice/ParticipantRow.tsx
@@ -6,6 +6,7 @@ import {
   ScreenShare,
   ScreenShareOff,
   Music,
+  VolumeX,
   type LucideIcon,
 } from 'lucide-react';
 import { LoadingBars } from '@shared/LoadingBars';
@@ -191,16 +192,22 @@ export function ParticipantRow({
                   }}
                   title={shareMuted ? 'unmute audio share' : 'mute audio share'}
                 >
-                  <Music
-                    size={14}
-                    strokeWidth={1.8}
-                    color="var(--wavis-danger)"
-                    fill={shareMuted ? 'var(--wavis-danger)' : 'none'}
-                    style={{
-                      animation: shareMuted ? 'watchPulse 2s ease-in-out infinite' : undefined,
-                    }}
-                    aria-hidden="true"
-                  />
+                  {shareMuted ? (
+                    <VolumeX
+                      size={14}
+                      strokeWidth={1.8}
+                      color="var(--wavis-danger)"
+                      style={{ animation: 'watchPulse 2s ease-in-out infinite' }}
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <Music
+                      size={14}
+                      strokeWidth={1.8}
+                      color="var(--wavis-danger)"
+                      aria-hidden="true"
+                    />
+                  )}
                 </button>
               )}
               {p.hasVideoShare && (


### PR DESCRIPTION
## Summary
- The audio-only sharer badge in `ParticipantRow.tsx` indicated its local-mute state by toggling SVG `fill` on lucide-react's `Music` icon (a stem path + two separate note circles) — the only mute/watch toggle in this file that relies on a solid fill rather than swapping to a dedicated icon (every sibling toggle — `Mic`/`MicOff`, `ScreenShare`/`ScreenShareOff` — swaps components instead).
- Filling that multi-path icon at 14px renders as a shapeless blob on Windows 10's WebView2 (per the reporter's screenshot); not reproducible on Windows 11, which renders it fine — this dev machine is Windows 11, so the fix could not be visually diffed against the actual Win10 bug, only reasoned from the SVG structure and the codebase's own established pattern.
- Fix: swap to `VolumeX` for the muted state instead of filling `Music`, matching the icon-swap pattern already used for every other on/off badge in this component. No more `fill` prop on this icon at all.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/features/voice/ParticipantRow.tsx` — 0 errors (2 pre-existing complexity/length warnings on the whole component, unrelated to this change)
- [x] `npx prettier --check src/features/voice/ParticipantRow.tsx` — clean
- [x] Live verification: built the debug exe against the local docker backend, drove a real two-participant voice room via Playwright (owner + a `ws-sfu-test` peer starting an `audio_only` share), toggled the badge, and inspected the rendered DOM in both states:
  - Unmuted: `<svg class="lucide-music" fill="none" ...>`
  - Muted: `<svg class="lucide-volume-x" fill="none" ...>` (previously `lucide-music fill="var(--wavis-danger)"`)
  - Screenshots attached below.
- [ ] Cannot be visually confirmed on real Windows 10 hardware/VM — the reported bug is Windows-10-specific and this dev machine is Windows 11. If a Windows 10 machine is available, worth a manual spot-check of the muted/unmuted badge in a live audio-only share.

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YY4DvxJX1HtndMzYea1Sk