### PR TITLE
feat(gui): skip Server URL prompt for closed-alpha auth flows

### DIFF
--- a/clients/wavis-gui/.env.example
+++ b/clients/wavis-gui/.env.example
@@ -82,3 +82,6 @@ VITE_DEBUG_TRAY=false
 # Video-feed diagnostics: track subscription timing, first-frame latency,
 # quality-update submissions, screenShareActiveInRoom transitions, replaceCameraDevice traces.
 VITE_DEBUG_VIDEO_FEED=false
+
+VITE_DEFAULT_SERVER_URL=
+VITE_ALLOW_SERVER_OVERRIDE=false

--- a/clients/wavis-gui/e2e-tooling/README.md
+++ b/clients/wavis-gui/e2e-tooling/README.md
@@ -182,7 +182,7 @@ a manual wait. Tear down when done:
 docker compose down
 ```
 
-**2. A debug exe built for live-backend use.** Two build-time env vars, on
+**2. A debug exe built for live-backend use.** Three build-time env vars, on
 top of the usual `npx tauri build --debug`:
 
 - `VITE_ALLOW_INSECURE_TLS=true` — the local backend serves plain HTTP
@@ -197,9 +197,13 @@ top of the usual `npx tauri build --debug`:
   var is the baseline for a single instance; two-instance specs additionally
   override it per-launch at runtime — see "Two simultaneous GUI instances"
   below.)
+- `VITE_ALLOW_SERVER_OVERRIDE=true` — release builds hide the Server URL
+  field entirely and silently use `VITE_DEFAULT_SERVER_URL` (see issue #332);
+  this flag brings the field back so `registerViaUi`/`loginViaUi` can keep
+  filling it by its `"Server URL"` accessible label.
 
 ```powershell
-$env:VITE_ALLOW_INSECURE_TLS="true"; $env:VITE_AUTH_STORE_NAME="wavis-auth-e2e.json"; npx tauri build --debug
+$env:VITE_ALLOW_INSECURE_TLS="true"; $env:VITE_AUTH_STORE_NAME="wavis-auth-e2e.json"; $env:VITE_ALLOW_SERVER_OVERRIDE="true"; npx tauri build --debug
 ```
 
 This **replaces** `target/debug/wavis-gui.exe` — the 4 backend-independent

--- a/clients/wavis-gui/src/features/auth/DeviceSetup.tsx
+++ b/clients/wavis-gui/src/features/auth/DeviceSetup.tsx
@@ -6,6 +6,8 @@ import {
   registerUser,
   setUsername,
   INSECURE_TLS_ALLOWED,
+  DEFAULT_SERVER_URL,
+  SERVER_OVERRIDE_ALLOWED,
   deleteStoredRecoveryId,
 } from './auth';
 import { useCopyToClipboardFeedback } from '@shared/hooks/useCopyToClipboardFeedback';
@@ -150,7 +152,7 @@ export default function DeviceSetup() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const [step, setStep] = useState<SetupStep>(1);
-  const [serverUrl, setServerUrl] = useState('');
+  const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER_URL);
   const [username, setUsernameValue] = useState('');
   const [phrase, setPhrase] = useState('');
   const [confirmPhrase, setConfirmPhrase] = useState('');
@@ -220,7 +222,14 @@ export default function DeviceSetup() {
 
     const validation = validateServerUrl(serverUrl, insecureTls);
     if (!validation.valid) {
-      setUrlError(validation.reason ?? 'Invalid server URL');
+      // Field is hidden when SERVER_OVERRIDE_ALLOWED is false, so a failure
+      // here (e.g. DEFAULT_SERVER_URL unset) has no urlError field to render
+      // next to — route it through the visible registerError banner instead.
+      if (SERVER_OVERRIDE_ALLOWED) {
+        setUrlError(validation.reason ?? 'Invalid server URL');
+      } else {
+        setRegisterError(validation.reason ?? 'Invalid server URL');
+      }
       return;
     }
 
@@ -358,29 +367,35 @@ export default function DeviceSetup() {
       {step === 2 && (
         <>
           <div className="px-4 sm:px-6 py-4">
-            <AuthFieldRow
-              label="Server URL:"
-              placeholder="https://wavis.example.com"
-              value={serverUrl}
-              onChange={(value) => {
-                setServerUrl(value);
-                setUrlError(null);
-              }}
-              onKeyDown={handleKeyDown}
-              error={urlError}
-              disabled={registering}
-              inputRef={inputRef}
-              autoFocus
-            />
+            {SERVER_OVERRIDE_ALLOWED && (
+              <>
+                <AuthFieldRow
+                  label="Server URL:"
+                  placeholder="https://wavis.example.com"
+                  value={serverUrl}
+                  onChange={(value) => {
+                    setServerUrl(value);
+                    setUrlError(null);
+                  }}
+                  onKeyDown={handleKeyDown}
+                  error={urlError}
+                  disabled={registering}
+                  inputRef={inputRef}
+                  autoFocus
+                />
 
-            <div className="mb-6 border border-wavis-text-secondary bg-wavis-bg p-3 text-sm text-wavis-text-secondary">
-              <div className="mb-2 font-bold text-wavis-text">What is the Server URL?</div>
-              <p>
-                The address of your Wavis server. Your admin will share it with you, or you can get
-                a hosted server at wavis.io.
-              </p>
-              <p className="mt-2 text-wavis-accent">It looks like: https://wavis.yourteam.com</p>
-            </div>
+                <div className="mb-6 border border-wavis-text-secondary bg-wavis-bg p-3 text-sm text-wavis-text-secondary">
+                  <div className="mb-2 font-bold text-wavis-text">What is the Server URL?</div>
+                  <p>
+                    The address of your Wavis server. Your admin will share it with you, or you can
+                    get a hosted server at wavis.io.
+                  </p>
+                  <p className="mt-2 text-wavis-accent">
+                    It looks like: https://wavis.yourteam.com
+                  </p>
+                </div>
+              </>
+            )}
 
             <AuthFieldRow
               label="Invite Code:"
@@ -393,6 +408,8 @@ export default function DeviceSetup() {
               onKeyDown={handleKeyDown}
               error={inviteCodeError}
               disabled={registering}
+              inputRef={SERVER_OVERRIDE_ALLOWED ? undefined : inputRef}
+              autoFocus={!SERVER_OVERRIDE_ALLOWED}
             />
 
             <InsecureTlsToggle

--- a/clients/wavis-gui/src/features/auth/Login.tsx
+++ b/clients/wavis-gui/src/features/auth/Login.tsx
@@ -10,6 +10,8 @@ import {
   getInsecureTls,
   getStoredRecoveryId,
   INSECURE_TLS_ALLOWED,
+  DEFAULT_SERVER_URL,
+  SERVER_OVERRIDE_ALLOWED,
 } from './auth';
 import { AuthFieldRow } from './AuthFieldRow';
 import { AuthLogPanel } from './AuthLogPanel';
@@ -25,7 +27,7 @@ export default function Login() {
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [serverUrl, setServerUrl] = useState('');
+  const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER_URL);
   const [recoveryId, setRecoveryId] = useState('');
   const [phrase, setPhrase] = useState('');
   const [insecureTls, setInsecureTls] = useState(false);
@@ -92,7 +94,14 @@ export default function Login() {
 
     const validation = validateServerUrl(serverUrl, insecureTls);
     if (!validation.valid) {
-      setUrlError(validation.reason ?? 'Invalid server URL');
+      // Field is hidden when SERVER_OVERRIDE_ALLOWED is false, so a failure
+      // here (e.g. DEFAULT_SERVER_URL unset) has no urlError field to render
+      // next to — route it through the visible loginError banner instead.
+      if (SERVER_OVERRIDE_ALLOWED) {
+        setUrlError(validation.reason ?? 'Invalid server URL');
+      } else {
+        setLoginError(validation.reason ?? 'Invalid server URL');
+      }
       return;
     }
 
@@ -213,19 +222,21 @@ export default function Login() {
 
         {!trustedDevice && (
           <>
-            <AuthFieldRow
-              label="Server:"
-              placeholder="https://wavis.example.com"
-              value={serverUrl}
-              onChange={(value) => {
-                setServerUrl(value);
-                setUrlError(null);
-              }}
-              onKeyDown={handleKeyDown}
-              error={urlError}
-              disabled={logging}
-              ariaLabel="Server URL"
-            />
+            {SERVER_OVERRIDE_ALLOWED && (
+              <AuthFieldRow
+                label="Server:"
+                placeholder="https://wavis.example.com"
+                value={serverUrl}
+                onChange={(value) => {
+                  setServerUrl(value);
+                  setUrlError(null);
+                }}
+                onKeyDown={handleKeyDown}
+                error={urlError}
+                disabled={logging}
+                ariaLabel="Server URL"
+              />
+            )}
 
             {INSECURE_TLS_ALLOWED && (
               <div className="mb-6">

--- a/clients/wavis-gui/src/features/auth/RecoverAccount.tsx
+++ b/clients/wavis-gui/src/features/auth/RecoverAccount.tsx
@@ -6,6 +6,8 @@ import {
   recoverAccount,
   setUsername,
   INSECURE_TLS_ALLOWED,
+  DEFAULT_SERVER_URL,
+  SERVER_OVERRIDE_ALLOWED,
 } from './auth';
 import { AuthFieldRow } from './AuthFieldRow';
 import { AuthLogPanel } from './AuthLogPanel';
@@ -18,7 +20,7 @@ export default function RecoverAccount() {
   const navigate = useNavigate();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const [serverUrl, setServerUrl] = useState('');
+  const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER_URL);
   const [recoveryId, setRecoveryId] = useState('');
   const [phrase, setPhrase] = useState('');
   const [username, setUsernameValue] = useState('');
@@ -69,7 +71,14 @@ export default function RecoverAccount() {
 
     const validation = validateServerUrl(serverUrl, insecureTls);
     if (!validation.valid) {
-      setUrlError(validation.reason ?? 'Invalid server URL');
+      // Field is hidden when SERVER_OVERRIDE_ALLOWED is false, so a failure
+      // here (e.g. DEFAULT_SERVER_URL unset) has no urlError field to render
+      // next to — route it through the visible recoverError banner instead.
+      if (SERVER_OVERRIDE_ALLOWED) {
+        setUrlError(validation.reason ?? 'Invalid server URL');
+      } else {
+        setRecoverError(validation.reason ?? 'Invalid server URL');
+      }
       return;
     }
 
@@ -167,18 +176,20 @@ export default function RecoverAccount() {
           maxLength={MAX_USERNAME_LENGTH}
         />
 
-        <AuthFieldRow
-          label="Server URL:"
-          placeholder="https://wavis.example.com"
-          value={serverUrl}
-          onChange={(value) => {
-            setServerUrl(value);
-            setUrlError(null);
-          }}
-          onKeyDown={handleKeyDown}
-          error={urlError}
-          disabled={recovering}
-        />
+        {SERVER_OVERRIDE_ALLOWED && (
+          <AuthFieldRow
+            label="Server URL:"
+            placeholder="https://wavis.example.com"
+            value={serverUrl}
+            onChange={(value) => {
+              setServerUrl(value);
+              setUrlError(null);
+            }}
+            onKeyDown={handleKeyDown}
+            error={urlError}
+            disabled={recovering}
+          />
+        )}
 
         {INSECURE_TLS_ALLOWED && (
           <div className="mb-6">

--- a/clients/wavis-gui/src/features/auth/__tests__/auth-server-url-defaults.test.ts
+++ b/clients/wavis-gui/src/features/auth/__tests__/auth-server-url-defaults.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+/**
+ * DEFAULT_SERVER_URL / SERVER_OVERRIDE_ALLOWED are read from import.meta.env
+ * at module load time (same pattern as INSECURE_TLS_ALLOWED), so each case
+ * needs vi.resetModules() + vi.stubEnv() + a fresh dynamic import to see a
+ * different env combination — see auth.test.ts's "Mocked Integration Tests"
+ * header comment for the same pattern applied to store/keychain state.
+ */
+describe('DEFAULT_SERVER_URL / SERVER_OVERRIDE_ALLOWED', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('DEFAULT_SERVER_URL falls back to empty string when VITE_DEFAULT_SERVER_URL is unset', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_DEFAULT_SERVER_URL', undefined);
+    const auth = await import('../auth');
+
+    expect(auth.DEFAULT_SERVER_URL).toBe('');
+  });
+
+  it('DEFAULT_SERVER_URL reflects VITE_DEFAULT_SERVER_URL when set', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_DEFAULT_SERVER_URL', 'https://d1d06fp0adg6ml.cloudfront.net');
+    const auth = await import('../auth');
+
+    expect(auth.DEFAULT_SERVER_URL).toBe('https://d1d06fp0adg6ml.cloudfront.net');
+  });
+
+  it('SERVER_OVERRIDE_ALLOWED defaults to false when VITE_ALLOW_SERVER_OVERRIDE is unset', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_ALLOW_SERVER_OVERRIDE', undefined);
+    const auth = await import('../auth');
+
+    expect(auth.SERVER_OVERRIDE_ALLOWED).toBe(false);
+  });
+
+  it('SERVER_OVERRIDE_ALLOWED is true only for the exact string "true"', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_ALLOW_SERVER_OVERRIDE', 'yes');
+    const authWrongValue = await import('../auth');
+    expect(authWrongValue.SERVER_OVERRIDE_ALLOWED).toBe(false);
+
+    vi.resetModules();
+    vi.stubEnv('VITE_ALLOW_SERVER_OVERRIDE', 'true');
+    const authTrue = await import('../auth');
+    expect(authTrue.SERVER_OVERRIDE_ALLOWED).toBe(true);
+  });
+});

--- a/clients/wavis-gui/src/features/auth/auth.ts
+++ b/clients/wavis-gui/src/features/auth/auth.ts
@@ -32,6 +32,20 @@ const LOG_PREFIX = '[wavis:auth]';
  */
 export const INSECURE_TLS_ALLOWED = import.meta.env.VITE_ALLOW_INSECURE_TLS === 'true';
 
+/**
+ * Build-time default server URL, used silently when the Server URL field is
+ * hidden (closed alpha has exactly one backend). Empty string if unset.
+ * Controlled by VITE_DEFAULT_SERVER_URL.
+ */
+export const DEFAULT_SERVER_URL = import.meta.env.VITE_DEFAULT_SERVER_URL || '';
+
+/**
+ * Whether the Server URL field is shown at all (letting DEFAULT_SERVER_URL be
+ * overridden). Controlled by VITE_ALLOW_SERVER_OVERRIDE. Defaults to false —
+ * same gating pattern as INSECURE_TLS_ALLOWED above.
+ */
+export const SERVER_OVERRIDE_ALLOWED = import.meta.env.VITE_ALLOW_SERVER_OVERRIDE === 'true';
+
 // --- Types ---
 export type AuthLogEntry = {
   time: string;


### PR DESCRIPTION
## Summary

- Registration (`DeviceSetup`), new-device login (`Login`), and account
  recovery (`RecoverAccount`) no longer ask the user to type a Server URL.
  During closed alpha there's exactly one backend, so this was pure friction.
- New `VITE_DEFAULT_SERVER_URL` build-time env var supplies the URL silently.
- New `VITE_ALLOW_SERVER_OVERRIDE` build-time env var (default `false`,
  mirrors `INSECURE_TLS_ALLOWED`'s gating) brings the field back for
  local dev / e2e / future self-hosted use.
- `e2e-tooling`'s `registerViaUi`/`loginViaUi` keep driving a real field
  unchanged — the debug-exe build command in `e2e-tooling/README.md` now
  also sets `VITE_ALLOW_SERVER_OVERRIDE=true`.
- When the field is hidden, a `validateServerUrl` failure (e.g. an unset
  default) now surfaces through the existing visible error banner instead of
  the now-absent field-level error, so misconfiguration fails loudly, not
  silently.

Closes #332

## Test plan

- [x] `npm test -- src/features/auth/__tests__` — 101/101 passing, including
      4 new tests for `DEFAULT_SERVER_URL`/`SERVER_OVERRIDE_ALLOWED`
      (`vi.stubEnv` + `vi.resetModules` pattern, same as `INSECURE_TLS_ALLOWED`)
- [x] `npm run typecheck` — clean
- [x] `npx eslint` on touched files — 0 new errors (pre-existing warnings only)
- [x] `npx prettier --check` — clean
- [x] `npm run lint:deps` — no dependency violations
- [x] `node scripts/arch-check.mjs` — OK
- [x] Live-app verification (real Tauri debug exe + real docker-compose
      backend + real Playwright, via the `run-wavis-gui`/`run-wavis-backend`
      skills), three build variants:
  - `VITE_ALLOW_SERVER_OVERRIDE=true`: Server URL field present on
    `/setup`, `/login`, `/recover`, pre-filled with `VITE_DEFAULT_SERVER_URL`,
    editable; full registration flow completes end-to-end (recovery ID
    screen reached).
  - `VITE_ALLOW_SERVER_OVERRIDE` unset, `VITE_DEFAULT_SERVER_URL` set:
    field absent on all three pages; registration succeeds silently against
    the default with the user never seeing a URL.
  - `VITE_ALLOW_SERVER_OVERRIDE` unset, `VITE_DEFAULT_SERVER_URL` unset:
    field absent; submit shows a visible "Server URL cannot be empty" error
    banner instead of failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)