### PR TITLE
fix(e2e-tooling): mint ws-tickets for spawnPeer() connections

### DIFF
--- a/clients/wavis-gui/e2e-tooling/tests/audio-received.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/audio-received.spec.mjs
@@ -99,11 +99,10 @@ test('audio published by a peer is decoded and reflected in the GUI as real rmsL
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   let tone;
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'TonePeer',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/chat.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/chat.spec.mjs
@@ -38,10 +38,9 @@ test('chat messages are exchanged between the GUI and a second participant', asy
   await joinChannelViaUi(main, invite.code);
   await enterChannelRoom(main, channelName);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'PeerBot',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/live-backend-helpers.mjs
@@ -440,17 +440,29 @@ export async function sendChatMessage(page, text) {
  * client — see scripts/ws-sfu-test/src/main.rs) as a scriptable second
  * participant. Chosen over `wavis-client`'s REPL because wavis-client has no
  * chat send/receive support at all (verified against its command parser);
- * ws-sfu-test lets the test send exact SignalingMessage JSON (auth,
- * join_voice, chat_send, ...) and read raw `<< {...}` echoes of whatever the
- * server sends back.
+ * ws-sfu-test lets the test send exact SignalingMessage JSON (join_voice,
+ * chat_send, ...) and read raw `<< {...}` echoes of whatever the server
+ * sends back.
+ *
+ * `accessToken` is required: `/ws` has required `?ticket=<raw>` since the
+ * closed-alpha ws-ticket gate (backend `ws/ws.rs`) — every connection must
+ * present a ticket minted by an authenticated `POST /auth/ws-ticket` call, or
+ * the upgrade 401s before the child process ever gets a socket. This mints
+ * one for the given identity first and connects the child pre-authenticated
+ * as that user/device (ticket validation sets the connection's authenticated
+ * user *before* the message loop starts — see `joinVoiceAsPeer`, which no
+ * longer sends an explicit `auth` message because of this).
  *
  * This verifies the GUI's own rendering reacts to a second real signaling
  * participant — it does not exercise a second real GUI instance.
  */
-export function spawnPeer() {
+export async function spawnPeer({ accessToken }) {
+  const { ticket } = await postJson('/auth/ws-ticket', undefined, accessToken);
+  const wsUrl = `${WS_URL}?ticket=${encodeURIComponent(ticket)}`;
+
   const child = spawn('cargo', ['run', '-p', 'ws-sfu-test'], {
     cwd: WORKSPACE_ROOT,
-    env: { ...process.env, WS_URL },
+    env: { ...process.env, WS_URL: wsUrl },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -511,10 +523,14 @@ export function spawnPeer() {
   return { send, waitForOutput, close, pid: child.pid };
 }
 
-/** auth -> join_voice against a channel, resolving once the server confirms both. */
-export async function joinVoiceAsPeer(peer, { accessToken, channelId, displayName }) {
-  peer.send({ type: 'auth', accessToken });
-  await peer.waitForOutput(/"type":\s*"auth_success"/);
+/**
+ * join_voice against a channel, resolving once the server confirms. No
+ * explicit `auth` message: spawnPeer()'s ws-ticket already authenticated the
+ * connection as its identity at upgrade time, and the server rejects `auth`
+ * afterward as "already authenticated" (ws/validation.rs) — see spawnPeer's
+ * doc comment.
+ */
+export async function joinVoiceAsPeer(peer, { channelId, displayName }) {
   peer.send({ type: 'join_voice', channelId, displayName });
   await peer.waitForOutput(/"type":\s*"joined"/);
 }

--- a/clients/wavis-gui/e2e-tooling/tests/participants.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/participants.spec.mjs
@@ -46,10 +46,9 @@ test('the participant count and row update when a second participant joins and l
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'PeerBot',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/reconnect.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/reconnect.spec.mjs
@@ -68,8 +68,8 @@ async function switchToLogTab(page) {
   }
 }
 
-async function connectPeerWithTone(peer, { accessToken, channelId, displayName }) {
-  await joinVoiceAsPeer(peer, { accessToken, channelId, displayName });
+async function connectPeerWithTone(peer, { channelId, displayName }) {
+  await joinVoiceAsPeer(peer, { channelId, displayName });
   await joinDefaultSubRoomAsPeer(peer);
   const { token, sfuUrl } = await waitForMediaToken(peer);
   return connectTonePeer({ sfuUrl, token });
@@ -106,9 +106,8 @@ test('a backend restart mid-call recovers automatically: no manual rejoin, no du
   let tone2;
   try {
     /* ── Baseline: a peer's tone is detected before any disruption ────── */
-    peer1 = spawnPeer();
+    peer1 = await spawnPeer({ accessToken: owner.access_token });
     tone1 = await connectPeerWithTone(peer1, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: PEER_DISPLAY_NAME,
     });
@@ -153,9 +152,8 @@ test('a backend restart mid-call recovers automatically: no manual rejoin, no du
      * actually cleaned up server-side, not left as a stale duplicate next
      * to the new one) and a fresh tone lands back in the decoded-audio band.
      */
-    peer2 = spawnPeer();
+    peer2 = await spawnPeer({ accessToken: owner.access_token });
     tone2 = await connectPeerWithTone(peer2, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: PEER_DISPLAY_NAME,
     });

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-audio-not-heard-until-opened.spec.mjs
@@ -97,11 +97,10 @@ test("a peer's screen-share audio stays silent until the user unmutes it", async
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   let tone;
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'AudioSharePeer',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
@@ -62,10 +62,9 @@ test('rejoining participant sees both video-share and audio-share badges for a c
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'SharerBot',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share.spec.mjs
@@ -64,10 +64,9 @@ test('GUI shares its screen and a peer observes start/stop; a peer signaling a s
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'PeerBot',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/two-instances.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/two-instances.spec.mjs
@@ -107,12 +107,11 @@ test('the SAME account joining the same voice room a second time IS displaced', 
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main, { expectedCount: 1 });
 
-  const peer = spawnPeer();
+  // Same account (identity.access_token), same channel -> server-side
+  // evict_stale_session evicts by user_id, displacing the GUI's session.
+  const peer = await spawnPeer({ accessToken: identity.access_token });
   try {
-    // Same account (identity.access_token), same channel -> server-side
-    // evict_stale_session evicts by user_id, displacing the GUI's session.
     await joinVoiceAsPeer(peer, {
-      accessToken: identity.access_token,
       channelId: channel.channel_id,
       displayName: 'DisplacerBot',
     });

--- a/clients/wavis-gui/e2e-tooling/tests/zz-debug-repro.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/zz-debug-repro.mjs
@@ -4,13 +4,13 @@ const token1 = process.argv[2];
 const token2 = process.argv[3];
 const channelId = process.argv[4];
 
-const peer1 = spawnPeer();
-const peer2 = spawnPeer();
+const peer1 = await spawnPeer({ accessToken: token1 });
+const peer2 = await spawnPeer({ accessToken: token2 });
 
 try {
-  await joinVoiceAsPeer(peer1, { accessToken: token1, channelId, displayName: 'Peer1' });
+  await joinVoiceAsPeer(peer1, { channelId, displayName: 'Peer1' });
   console.log('peer1 joined');
-  await joinVoiceAsPeer(peer2, { accessToken: token2, channelId, displayName: 'Peer2' });
+  await joinVoiceAsPeer(peer2, { channelId, displayName: 'Peer2' });
   console.log('peer2 joined');
 
   peer1.send({ type: 'chat_send', text: 'hello-from-peer1' });

--- a/clients/wavis-gui/e2e-tooling/tests/zz-network-quality.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/zz-network-quality.spec.mjs
@@ -106,11 +106,10 @@ test('media quality survives and reports a simulated bad network, then recovers'
   await enterChannelRoom(main, channelName);
   await joinDefaultSubRoomViaUi(main);
 
-  const peer = spawnPeer();
+  const peer = await spawnPeer({ accessToken: owner.access_token });
   let tone;
   try {
     await joinVoiceAsPeer(peer, {
-      accessToken: owner.access_token,
       channelId: channel.channel_id,
       displayName: 'NetQualityPeer',
     });


### PR DESCRIPTION
## Summary
- `spawnPeer()` in `live-backend-helpers.mjs` connected `ws-sfu-test` to `/ws` with a bare URL, which the closed-alpha ws-ticket gate (ad115e5) has 401'd since 2026-07-18 -- flagged during PR #334's review as a pre-existing gap unrelated to that PR's own changes.
- `spawnPeer({ accessToken })` now mints a ticket via `POST /auth/ws-ticket` first and connects with `?ticket=` appended, mirroring what a real Bearer-authenticated client does.
- `joinVoiceAsPeer` no longer sends the old post-connect `auth` signaling message: a valid ticket authenticates the connection at upgrade time (before the message loop starts), so the server now rejects `auth` as "already authenticated" -- the exact gotcha ad115e5's own commit message flagged for the real GUI client. Updated all 10 call sites (`chat`, `participants`, `screen-share*`, `audio-received`, `two-instances`, `zz-network-quality`, `reconnect`, `zz-debug-repro`).

## Test plan
- [x] `node --check` on all 11 modified files (this harness is deliberately outside `tsc`/`eslint`/CI per its own README)
- [x] Live verification against the real docker-compose backend (`tools/dev/start-backend-e2e.ps1`): registered two distinct identities, confirmed both `ws-sfu-test` peers connect through the ticket gate with no 401, `join_voice` succeeds with no `auth` message, and a chat message round-trips between them
- [x] Backend restored to normal rate-limited mode after verification (`-Restore`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_011LLT7cxbh4oAUL6SzUTRun