### PR TITLE
fix(e2e): auto-seed alpha invite in VS Code E2E task, fix flaky spec timeouts

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -552,13 +552,20 @@
       "name": "Test: GUI E2E (WebdriverIO)",
       // Brings the docker stack up — rebuilt with test-no-rate-limits and
       // raised auth register/recover limits (see "Ensure E2E Backend Stack"
-      // in tasks.json) — and waits for /health before running. postDebugTask
-      // rebuilds the backend back to normal afterward either way, so the
-      // shared local dev backend never stays rate-limit-free.
+      // in tasks.json) — installs e2e-tooling's own npm deps (isolated
+      // package.json, absent in a fresh checkout/worktree), seeds a
+      // multi-use closed-alpha invite so REST auth seeding never dies with
+      // "ALPHA_INVITE_CODE must be set", and waits for /health before
+      // running (see "E2E Stack Ready" in tasks.json for the full chain).
+      // postDebugTask rebuilds the backend back to normal afterward either
+      // way, so the shared local dev backend never stays rate-limit-free.
       "preLaunchTask": "E2E Stack Ready",
       "postDebugTask": "Restore Normal Backend",
       "command": "npm run test",
       "cwd": "${workspaceFolder}/clients/wavis-gui/e2e-tooling",
+      "env": {
+        "ALPHA_INVITE_CODE": "E2EALPHA174"
+      },
       "presentation": { "group": "7_gui-tauri", "order": 1 }
     },
     {
@@ -574,6 +581,7 @@
       // the e2e-webdriver Cargo feature, so the resulting exe has no
       // embedded WebDriver server and "Test: GUI E2E" can't drive it on
       // Windows.
+      "preLaunchTask": "Ensure E2E Tooling Deps",
       "command": "npm run build:app",
       "cwd": "${workspaceFolder}/clients/wavis-gui/e2e-tooling",
       "presentation": { "group": "7_gui-tauri", "order": 2 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,8 +35,7 @@
         "cwd": "${workspaceFolder}"
       },
       "presentation": {
-        "reveal": "silent",
-        "close": true
+        "reveal": "silent"
       },
       "problemMatcher": []
     },
@@ -50,6 +49,10 @@
       // running container matches these env vars and any local backend code
       // changes; paired with "Restore Normal Backend" as this launch
       // config's postDebugTask so the dev backend isn't left rate-limit-free.
+      // NOTE: no "close":true here on purpose — if this fails (e.g. port 3000
+      // already held by another process's dev server), the panel needs to
+      // stay open with "reveal":"silent" showing the real docker error
+      // instead of flashing and closing before it can be read.
       "label": "Ensure E2E Backend Stack",
       "type": "shell",
       "command": "docker compose up -d --build",
@@ -62,14 +65,51 @@
         }
       },
       "presentation": {
-        "reveal": "silent",
-        "close": true
+        "reveal": "silent"
+      },
+      "problemMatcher": []
+    },
+    {
+      // e2e-tooling has its own isolated package.json (see its comment on
+      // why) so a fresh checkout/worktree never has @wdio/tauri-service etc.
+      // installed. `npm install` is a fast no-op when already satisfied, so
+      // this is safe to run on every launch rather than assuming it's done.
+      "label": "Ensure E2E Tooling Deps",
+      "type": "shell",
+      "command": "npm install",
+      "options": {
+        "cwd": "${workspaceFolder}/clients/wavis-gui/e2e-tooling"
+      },
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": []
+    },
+    {
+      // Idempotent: (re)inserts a multi-use closed-alpha invite (code
+      // E2EALPHA174) into the local postgres so live-backend-helpers.mjs's
+      // registerDevice() never dies with "ALPHA_INVITE_CODE must be set" —
+      // every live-backend spec needs one seeded before npm run test starts.
+      // Runs after "Wait for Backend Ready" so migrations (which create the
+      // alpha_invites table) have applied. Logic lives in
+      // seed-alpha-invite.mjs (uses execFileSync, no shell) rather than
+      // inline here — an inline `node -e "..."` with nested double-quotes
+      // gets its quoting eaten by VS Code's Windows task runner, which wraps
+      // the whole command in an extra powershell.exe -Command "..." layer.
+      "label": "Seed E2E Alpha Invite",
+      "type": "shell",
+      "command": "node seed-alpha-invite.mjs",
+      "options": {
+        "cwd": "${workspaceFolder}/clients/wavis-gui/e2e-tooling"
+      },
+      "presentation": {
+        "reveal": "silent"
       },
       "problemMatcher": []
     },
     {
       "label": "E2E Stack Ready",
-      "dependsOn": ["Ensure E2E Backend Stack", "Wait for Backend Ready"],
+      "dependsOn": ["Ensure E2E Backend Stack", "Ensure E2E Tooling Deps", "Wait for Backend Ready", "Seed E2E Alpha Invite"],
       "dependsOrder": "sequence",
       "problemMatcher": []
     },
@@ -85,8 +125,7 @@
         "cwd": "${workspaceFolder}"
       },
       "presentation": {
-        "reveal": "silent",
-        "close": true
+        "reveal": "silent"
       },
       "problemMatcher": []
     },

--- a/clients/wavis-gui/e2e-tooling/seed-alpha-invite.mjs
+++ b/clients/wavis-gui/e2e-tooling/seed-alpha-invite.mjs
@@ -23,8 +23,12 @@ const hex = createHmac('sha256', pepper).update(`alpha-invite:v1:${CODE}`).diges
 
 const sql = `INSERT INTO alpha_invites (code_hash, max_redemptions) VALUES (decode('${hex}','hex'), 100000) ON CONFLICT (code_hash) DO UPDATE SET max_redemptions=100000, redemption_count=0, disabled_at=NULL, expires_at=NULL;`;
 
-execFileSync('docker', ['exec', 'wavis-postgres', 'psql', '-U', 'wavis', '-d', 'wavis', '-c', sql], {
-  stdio: 'inherit',
-});
+execFileSync(
+  'docker',
+  ['exec', 'wavis-postgres', 'psql', '-U', 'wavis', '-d', 'wavis', '-c', sql],
+  {
+    stdio: 'inherit',
+  },
+);
 
 console.log(`Seeded alpha invite "${CODE}"`);

--- a/clients/wavis-gui/e2e-tooling/seed-alpha-invite.mjs
+++ b/clients/wavis-gui/e2e-tooling/seed-alpha-invite.mjs
@@ -1,0 +1,30 @@
+// Idempotently (re)inserts a multi-use closed-alpha invite into the local
+// postgres so live-backend-helpers.mjs's registerDevice() never dies with
+// "ALPHA_INVITE_CODE must be set". Pulls ALPHA_INVITE_CODE_PEPPER from the
+// running wavis-backend container rather than hardcoding it, so this stays
+// correct even if the pepper is ever overridden.
+//
+// Runs via execFileSync (no shell), so this is immune to the Windows
+// VS Code task quoting bug where an inline `node -e "..."` inside a
+// tasks.json shell command gets its nested double-quotes eaten by the
+// extra powershell.exe -Command "..." wrapper VS Code adds.
+import { execFileSync } from 'node:child_process';
+import { createHmac } from 'node:crypto';
+
+const CODE = process.argv[2] || 'E2EALPHA174';
+
+const pepper = execFileSync(
+  'docker',
+  ['exec', 'wavis-backend', 'printenv', 'ALPHA_INVITE_CODE_PEPPER'],
+  { encoding: 'utf8' },
+).trim();
+
+const hex = createHmac('sha256', pepper).update(`alpha-invite:v1:${CODE}`).digest('hex');
+
+const sql = `INSERT INTO alpha_invites (code_hash, max_redemptions) VALUES (decode('${hex}','hex'), 100000) ON CONFLICT (code_hash) DO UPDATE SET max_redemptions=100000, redemption_count=0, disabled_at=NULL, expires_at=NULL;`;
+
+execFileSync('docker', ['exec', 'wavis-postgres', 'psql', '-U', 'wavis', '-d', 'wavis', '-c', sql], {
+  stdio: 'inherit',
+});
+
+console.log(`Seeded alpha invite "${CODE}"`);

--- a/clients/wavis-gui/e2e-tooling/tests/camera.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/camera.spec.mjs
@@ -97,4 +97,8 @@ test('toggling the camera publishes and un-publishes a real local video tile', a
   } finally {
     await leaveRoomIfActive(main);
   }
-});
+  // Default 30s isn't enough headroom: registerAndLoginViaUi + joinChannelViaUi
+  // + enterChannelRoom + joinDefaultSubRoomViaUi (up to a 10s poll plus a 15s
+  // wait on their own) already eat most of it before the real camera
+  // getUserMedia round-trip even starts.
+}, { timeoutMs: 90_000 });

--- a/clients/wavis-gui/e2e-tooling/tests/camera.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/camera.spec.mjs
@@ -45,60 +45,64 @@ function cameraButton(page, label) {
     .or(page.locator(`button[title="${label}"]:visible`));
 }
 
-test('toggling the camera publishes and un-publishes a real local video tile', async ({ app }) => {
-  await waitForBackendHealth();
+test(
+  'toggling the camera publishes and un-publishes a real local video tile',
+  async ({ app }) => {
+    await waitForBackendHealth();
 
-  const suffix = Date.now().toString(36);
-  const channelName = `e2e-camera-${suffix}`;
-  const { invite } = await seedChannelWithInvite(channelName);
+    const suffix = Date.now().toString(36);
+    const channelName = `e2e-camera-${suffix}`;
+    const { invite } = await seedChannelWithInvite(channelName);
 
-  const main = await app.page();
-  await leaveRoomIfActive(main);
-  const pathname = new URL(await main.url()).pathname;
-
-  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
-  }
-
-  await joinChannelViaUi(main, invite.code);
-  await enterChannelRoom(main, channelName);
-  await joinDefaultSubRoomViaUi(main);
-
-  try {
-    // Flake note: if another app already holds the webcam, the GUI toasts
-    // "camera device is already in use" instead of publishing, and the
-    // assertion below times out visibly rather than hanging silently.
-    await cameraButton(main, '/camera-on').click();
-    await expect(visibleIcon(main, 'your camera is on')).toBeVisible({ timeout: 10_000 });
-
-    await main
-      .locator('button:visible', { hasText: /^VIDEOS?\b/ })
-      .first()
-      .click();
-    await expect(visibleText(main, 'No video active')).toHaveCount(0);
-
-    await cameraButton(main, '/camera-off').click();
-    await expect(main.getByRole('img', { name: 'your camera is on' })).toHaveCount(0);
-
-    // By design (ActiveRoom.tsx's groupedPanelVideoActivityKey effect), the
-    // grouped panel auto-switches itself away from VIDEO the instant
-    // videoTilesById empties — so "No video active" never becomes visible
-    // right here: the tab itself switches away before the placeholder would
-    // render. Assert that designed auto-switch instead of a state this tier
-    // never reaches on its own.
-    const videoTab = main.locator('button:visible', { hasText: /^VIDEOS?\b/ }).first();
-    await expect(videoTab).toHaveAttribute('aria-selected', 'false');
-
-    // Re-select VIDEO explicitly — the effect only fires on tile-activity
-    // transitions, so a manual re-click sticks — and confirm the
-    // placeholder appears once the tab is actually being viewed.
-    await videoTab.click();
-    await expect(visibleText(main, 'No video active')).toBeVisible({ timeout: 10_000 });
-  } finally {
+    const main = await app.page();
     await leaveRoomIfActive(main);
-  }
-  // Default 30s isn't enough headroom: registerAndLoginViaUi + joinChannelViaUi
-  // + enterChannelRoom + joinDefaultSubRoomViaUi (up to a 10s poll plus a 15s
-  // wait on their own) already eat most of it before the real camera
-  // getUserMedia round-trip even starts.
-}, { timeoutMs: 90_000 });
+    const pathname = new URL(await main.url()).pathname;
+
+    if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+      await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
+    }
+
+    await joinChannelViaUi(main, invite.code);
+    await enterChannelRoom(main, channelName);
+    await joinDefaultSubRoomViaUi(main);
+
+    try {
+      // Flake note: if another app already holds the webcam, the GUI toasts
+      // "camera device is already in use" instead of publishing, and the
+      // assertion below times out visibly rather than hanging silently.
+      await cameraButton(main, '/camera-on').click();
+      await expect(visibleIcon(main, 'your camera is on')).toBeVisible({ timeout: 10_000 });
+
+      await main
+        .locator('button:visible', { hasText: /^VIDEOS?\b/ })
+        .first()
+        .click();
+      await expect(visibleText(main, 'No video active')).toHaveCount(0);
+
+      await cameraButton(main, '/camera-off').click();
+      await expect(main.getByRole('img', { name: 'your camera is on' })).toHaveCount(0);
+
+      // By design (ActiveRoom.tsx's groupedPanelVideoActivityKey effect), the
+      // grouped panel auto-switches itself away from VIDEO the instant
+      // videoTilesById empties — so "No video active" never becomes visible
+      // right here: the tab itself switches away before the placeholder would
+      // render. Assert that designed auto-switch instead of a state this tier
+      // never reaches on its own.
+      const videoTab = main.locator('button:visible', { hasText: /^VIDEOS?\b/ }).first();
+      await expect(videoTab).toHaveAttribute('aria-selected', 'false');
+
+      // Re-select VIDEO explicitly — the effect only fires on tile-activity
+      // transitions, so a manual re-click sticks — and confirm the
+      // placeholder appears once the tab is actually being viewed.
+      await videoTab.click();
+      await expect(visibleText(main, 'No video active')).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await leaveRoomIfActive(main);
+    }
+    // Default 30s isn't enough headroom: registerAndLoginViaUi + joinChannelViaUi
+    // + enterChannelRoom + joinDefaultSubRoomViaUi (up to a 10s poll plus a 15s
+    // wait on their own) already eat most of it before the real camera
+    // getUserMedia round-trip even starts.
+  },
+  { timeoutMs: 90_000 },
+);

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
@@ -41,87 +41,92 @@ async function goToChannelsList(page) {
   await page.getByRole('heading', { name: 'channels' }).waitFor({ state: 'visible' });
 }
 
-test('rejoining participant sees both video-share and audio-share badges for a concurrent sharer', async ({
-  app,
-}) => {
-  await waitForBackendHealth();
+test(
+  'rejoining participant sees both video-share and audio-share badges for a concurrent sharer',
+  async ({ app }) => {
+    await waitForBackendHealth();
 
-  const suffix = Date.now().toString(36);
-  const channelName = `e2e-share-rejoin-${suffix}`;
-  const { owner, channel, invite } = await seedChannelWithInvite(channelName);
+    const suffix = Date.now().toString(36);
+    const channelName = `e2e-share-rejoin-${suffix}`;
+    const { owner, channel, invite } = await seedChannelWithInvite(channelName);
 
-  const main = await app.page();
-  await leaveRoomIfActive(main);
-  const pathname = new URL(await main.url()).pathname;
-
-  if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
-    await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
-  }
-
-  await joinChannelViaUi(main, invite.code);
-  await enterChannelRoom(main, channelName);
-  await joinDefaultSubRoomViaUi(main);
-
-  const peer = await spawnPeer({ accessToken: owner.access_token });
-  try {
-    await joinVoiceAsPeer(peer, {
-      channelId: channel.channel_id,
-      displayName: 'SharerBot',
-    });
-    // Participant rows only render for sub-room members.
-    await joinDefaultSubRoomAsPeer(peer);
-    // Role-based, not visibleText: the room's event log also renders a
-    // "SharerBot joined" line, which a plain text match ambiguously matches
-    // too. The participant row itself is the only `role="button"` element
-    // with this name (see ParticipantRow.tsx).
-    await expect(
-      main.getByRole('button', { name: /SharerBot/ }).and(main.locator(':visible')),
-    ).toBeVisible({ timeout: 10_000 });
-
-    /* ── Peer starts a video-type share (no companion audio) ──────────── */
-    peer.send({ type: 'start_share', shareType: 'window' });
-    await peer.waitForOutput(/"type":"share_started"/, 15_000);
-    await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
-
-    /* ── Peer ALSO starts an independent standalone audio-only share ──── */
-    peer.send({ type: 'start_share', shareType: 'audio_only' });
-    // Lookaheads, not an ordered pattern: ws-sfu-test's print_text roundtrips
-    // through serde_json::Value (no preserve_order feature), which sorts
-    // object keys alphabetically — "shareType" ends up before "type" on the
-    // wire line, same phenomenon chatMessageReceivedPattern works around above.
-    await peer.waitForOutput(/(?=.*"type":"share_started")(?=.*"shareType":"audio_only")/, 15_000);
-
-    // Both badges must render at once: the audio-only start must not hide
-    // the still-active video share, and vice versa.
-    await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
-    await expect(visibleTitle(main, 'mute audio share')).toBeVisible({ timeout: 10_000 });
-
-    /* ── Regression: leave and rejoin — only the ShareState snapshot ──── */
-    // now describes the sharer's state to the rejoining client. Both slots
-    // must still be reflected, not just whichever share started last.
+    const main = await app.page();
     await leaveRoomIfActive(main);
-    await goToChannelsList(main);
+    const pathname = new URL(await main.url()).pathname;
+
+    if (pathname.startsWith('/login') || pathname.startsWith('/setup')) {
+      await registerAndLoginViaUi(main, { serverUrl: SERVER_URL });
+    }
+
+    await joinChannelViaUi(main, invite.code);
     await enterChannelRoom(main, channelName);
-    // SharerBot never leaves the sub-room (it shares continuously across
-    // main's leave/rejoin — that's the point of this regression test), so
-    // main's rejoin brings the sub-room to 2 occupants, not 1.
-    await joinDefaultSubRoomViaUi(main, { expectedCount: 2 });
-    // Role-based, not visibleText: the room's event log also renders a
-    // "SharerBot joined" line, which a plain text match ambiguously matches
-    // too. The participant row itself is the only `role="button"` element
-    // with this name (see ParticipantRow.tsx).
-    await expect(
-      main.getByRole('button', { name: /SharerBot/ }).and(main.locator(':visible')),
-    ).toBeVisible({ timeout: 10_000 });
+    await joinDefaultSubRoomViaUi(main);
 
-    await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
-    await expect(visibleTitle(main, 'mute audio share')).toBeVisible({ timeout: 10_000 });
-  } finally {
-    await peer.close();
-    await leaveRoomIfActive(main);
-  }
-  // Default 30s isn't enough headroom: this is the only spec that runs the
-  // full join flow (joinChannelViaUi + enterChannelRoom +
-  // joinDefaultSubRoomViaUi, up to a 10s poll plus a 15s wait each) twice —
-  // once before the leave, once after the rejoin.
-}, { timeoutMs: 90_000 });
+    const peer = await spawnPeer({ accessToken: owner.access_token });
+    try {
+      await joinVoiceAsPeer(peer, {
+        channelId: channel.channel_id,
+        displayName: 'SharerBot',
+      });
+      // Participant rows only render for sub-room members.
+      await joinDefaultSubRoomAsPeer(peer);
+      // Role-based, not visibleText: the room's event log also renders a
+      // "SharerBot joined" line, which a plain text match ambiguously matches
+      // too. The participant row itself is the only `role="button"` element
+      // with this name (see ParticipantRow.tsx).
+      await expect(
+        main.getByRole('button', { name: /SharerBot/ }).and(main.locator(':visible')),
+      ).toBeVisible({ timeout: 10_000 });
+
+      /* ── Peer starts a video-type share (no companion audio) ──────────── */
+      peer.send({ type: 'start_share', shareType: 'window' });
+      await peer.waitForOutput(/"type":"share_started"/, 15_000);
+      await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
+
+      /* ── Peer ALSO starts an independent standalone audio-only share ──── */
+      peer.send({ type: 'start_share', shareType: 'audio_only' });
+      // Lookaheads, not an ordered pattern: ws-sfu-test's print_text roundtrips
+      // through serde_json::Value (no preserve_order feature), which sorts
+      // object keys alphabetically — "shareType" ends up before "type" on the
+      // wire line, same phenomenon chatMessageReceivedPattern works around above.
+      await peer.waitForOutput(
+        /(?=.*"type":"share_started")(?=.*"shareType":"audio_only")/,
+        15_000,
+      );
+
+      // Both badges must render at once: the audio-only start must not hide
+      // the still-active video share, and vice versa.
+      await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
+      await expect(visibleTitle(main, 'mute audio share')).toBeVisible({ timeout: 10_000 });
+
+      /* ── Regression: leave and rejoin — only the ShareState snapshot ──── */
+      // now describes the sharer's state to the rejoining client. Both slots
+      // must still be reflected, not just whichever share started last.
+      await leaveRoomIfActive(main);
+      await goToChannelsList(main);
+      await enterChannelRoom(main, channelName);
+      // SharerBot never leaves the sub-room (it shares continuously across
+      // main's leave/rejoin — that's the point of this regression test), so
+      // main's rejoin brings the sub-room to 2 occupants, not 1.
+      await joinDefaultSubRoomViaUi(main, { expectedCount: 2 });
+      // Role-based, not visibleText: the room's event log also renders a
+      // "SharerBot joined" line, which a plain text match ambiguously matches
+      // too. The participant row itself is the only `role="button"` element
+      // with this name (see ParticipantRow.tsx).
+      await expect(
+        main.getByRole('button', { name: /SharerBot/ }).and(main.locator(':visible')),
+      ).toBeVisible({ timeout: 10_000 });
+
+      await expect(visibleTitle(main, 'waiting for stream...')).toBeVisible({ timeout: 10_000 });
+      await expect(visibleTitle(main, 'mute audio share')).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await peer.close();
+      await leaveRoomIfActive(main);
+    }
+    // Default 30s isn't enough headroom: this is the only spec that runs the
+    // full join flow (joinChannelViaUi + enterChannelRoom +
+    // joinDefaultSubRoomViaUi, up to a 10s poll plus a 15s wait each) twice —
+    // once before the leave, once after the rejoin.
+  },
+  { timeoutMs: 90_000 },
+);

--- a/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
+++ b/clients/wavis-gui/e2e-tooling/tests/screen-share-rejoin-badges.spec.mjs
@@ -102,7 +102,10 @@ test('rejoining participant sees both video-share and audio-share badges for a c
     await leaveRoomIfActive(main);
     await goToChannelsList(main);
     await enterChannelRoom(main, channelName);
-    await joinDefaultSubRoomViaUi(main);
+    // SharerBot never leaves the sub-room (it shares continuously across
+    // main's leave/rejoin — that's the point of this regression test), so
+    // main's rejoin brings the sub-room to 2 occupants, not 1.
+    await joinDefaultSubRoomViaUi(main, { expectedCount: 2 });
     // Role-based, not visibleText: the room's event log also renders a
     // "SharerBot joined" line, which a plain text match ambiguously matches
     // too. The participant row itself is the only `role="button"` element
@@ -117,4 +120,8 @@ test('rejoining participant sees both video-share and audio-share badges for a c
     await peer.close();
     await leaveRoomIfActive(main);
   }
-});
+  // Default 30s isn't enough headroom: this is the only spec that runs the
+  // full join flow (joinChannelViaUi + enterChannelRoom +
+  // joinDefaultSubRoomViaUi, up to a 10s poll plus a 15s wait each) twice —
+  // once before the leave, once after the rejoin.
+}, { timeoutMs: 90_000 });


### PR DESCRIPTION
## Summary

- The "Test: GUI E2E (WebdriverIO)" Run & Debug config had no way to seed
  `ALPHA_INVITE_CODE`, so every live-backend spec died at setup with
  `ALPHA_INVITE_CODE must be set for REST auth seeding` unless a developer
  manually exported it and seeded the invite by hand first.
- Two specs (`camera.spec.mjs`, `screen-share-rejoin-badges.spec.mjs`)
  were flaky/failing under a full 18-spec sequential run; root-caused and
  fixed at the test-infra level.

## Changes

- **`clients/wavis-gui/e2e-tooling/seed-alpha-invite.mjs`** (new): idempotently
  seeds a multi-use closed-alpha invite (`E2EALPHA174`) into the local
  postgres, deriving the HMAC pepper live from the running `wavis-backend`
  container rather than hardcoding it. Uses `execFileSync` (no shell) — an
  earlier inline `node -e "..."` version broke under VS Code's Windows task
  runner, which wraps every task command in an extra
  `powershell.exe -Command "..."` layer that eats nested double-quotes.
- **`.vscode/tasks.json`**: new `Seed E2E Alpha Invite` and
  `Ensure E2E Tooling Deps` tasks (the latter guards against
  `e2e-tooling`'s isolated `package.json` being uninstalled in a fresh
  checkout/worktree — it has its own dependency tree, separate from
  `clients/wavis-gui`'s), wired into the `E2E Stack Ready` chain. Also
  dropped `"close": true` from the backend-stack/wait tasks' terminal
  presentation — it was closing the panel immediately after a task
  failure, before a real error (e.g. a port-3000 conflict from another
  process) could actually be read.
- **`.vscode/launch.json`**: bakes `ALPHA_INVITE_CODE=E2EALPHA174` into the
  `Test: GUI E2E (WebdriverIO)` launch env, and adds
  `Ensure E2E Tooling Deps` as a `preLaunchTask` for
  `Build GUI Debug Exe (for E2E tests)`.
- **`camera.spec.mjs`**: extended `timeoutMs` from the 30s default to 90s.
  Confirmed via repro: it was completing in ~28.3s, right at the edge of
  the old budget — matches the convention every other spec with comparable
  step count (real login + channel join + sub-room join) already follows
  (`audio-received`, `reconnect`, `screen-share-audio-not-heard-until-opened`,
  `leave-rejoin`, `zz-disconnect-sound`, `two-instances`, `zz-network-quality`
  all already extend past 30s).
- **`screen-share-rejoin-badges.spec.mjs`**: same `timeoutMs` extension
  (it's the only spec that runs the full join flow *twice* in one test —
  join, leave, rejoin, join again — yet was still on the 30s default).
  Also fixed a real bug found along the way: the post-rejoin
  `joinDefaultSubRoomViaUi(main)` call asserted `expectedCount: 1`, but the
  peer sharer never leaves the sub-room during the test, so the real count
  after `main` rejoins is always 2 — same pattern `two-instances.spec.mjs`
  already handles correctly for its second joiner.

## Known issue surfaced, tracked separately

Fixing the above got `screen-share-rejoin-badges.spec.mjs` past setup and
onto its actual regression assertion — which now fails for real: the
audio-share badge doesn't survive a rejoin (the video-share badge does).
This looks like a genuine product bug distinct from anything in this PR.
Filed as #346 with full repro + code pointers; not fixed here.

## Test plan

- [x] `room-join.spec.mjs` standalone — passes (confirms the invite-seed
      fix end-to-end from a wiped `alpha_invites` table)
- [x] `camera.spec.mjs` standalone — passes at ~28.3s (was timing out at 30s)
- [ ] `screen-share-rejoin-badges.spec.mjs` — reaches its real assertion now
      (was previously failing at setup) but still fails there; tracked as #346
- [x] `.vscode/tasks.json` / `launch.json` validated as parseable JSONC after
      edits (comment-aware parse check, not just eyeballing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCqa9hQwLauThCXmHebUzr