### PR TITLE
fix(voice): clarify passthrough room notifications

### DIFF
--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
@@ -294,7 +294,7 @@ describe('sub_room_state', () => {
     expect(getState().passthrough).toBeNull();
   });
 
-  it('appends passthrough set event when passthrough becomes active', async () => {
+  it('logs the relevant rooms when passthrough is turned on', async () => {
     await setupActiveSession();
     inject({
       type: 'sub_room_state',
@@ -303,10 +303,14 @@ describe('sub_room_state', () => {
       passthroughVolumePercent: 20,
     });
     const events = getState().events;
-    expect(events.some((e) => e.type === 'passthrough' && e.message.includes('set'))).toBe(true);
+    expect(
+      events.some(
+        (e) => e.type === 'passthrough' && e.message === 'Passthrough turned on for rooms 1 - 2',
+      ),
+    ).toBe(true);
   });
 
-  it('appends passthrough cleared event when passthrough is removed', async () => {
+  it('logs the prior relevant rooms when passthrough is turned off', async () => {
     await setupActiveSession();
     inject({
       type: 'sub_room_state',
@@ -316,7 +320,22 @@ describe('sub_room_state', () => {
     });
     inject({ type: 'sub_room_state', rooms: [], passthroughVolumePercent: 20 });
     const events = getState().events;
-    expect(events.some((e) => e.type === 'passthrough' && e.message === 'cleared')).toBe(true);
+    expect(
+      events.some(
+        (e) => e.type === 'passthrough' && e.message === 'Passthrough turned off for rooms 1 - 2',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not log a passthrough event for an unchanged room pair', async () => {
+    await setupActiveSession();
+    const passthrough = { sourceSubRoomId: 'sr-1', targetSubRoomId: 'sr-2', label: '1 - 2' };
+    inject({ type: 'sub_room_state', rooms: [], passthrough, passthroughVolumePercent: 20 });
+    const eventCount = getState().events.filter((event) => event.type === 'passthrough').length;
+
+    inject({ type: 'sub_room_state', rooms: [], passthrough, passthroughVolumePercent: 30 });
+
+    expect(getState().events.filter((event) => event.type === 'passthrough')).toHaveLength(eventCount);
   });
 
   it('clamps passthroughVolumePercent to 0–100', async () => {

--- a/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/voice-room-dispatch.test.ts
@@ -335,7 +335,9 @@ describe('sub_room_state', () => {
 
     inject({ type: 'sub_room_state', rooms: [], passthrough, passthroughVolumePercent: 30 });
 
-    expect(getState().events.filter((event) => event.type === 'passthrough')).toHaveLength(eventCount);
+    expect(getState().events.filter((event) => event.type === 'passthrough')).toHaveLength(
+      eventCount,
+    );
   });
 
   it('clamps passthroughVolumePercent to 0–100', async () => {

--- a/clients/wavis-gui/src/features/voice/voice-room.ts
+++ b/clients/wavis-gui/src/features/voice/voice-room.ts
@@ -3295,21 +3295,21 @@ function dispatchMessage(raw: unknown): void {
             id: makeEventId(),
             timestamp: timestamp(),
             type: 'passthrough',
-            message: `set ${newPassthrough.label}`,
+            message: `Passthrough turned on for rooms ${newPassthrough.label}`,
           });
         } else if (wasActive && !isActive) {
           appendEvent({
             id: makeEventId(),
             timestamp: timestamp(),
             type: 'passthrough',
-            message: `cleared`,
+            message: `Passthrough turned off for rooms ${previousPassthrough.label}`,
           });
         } else if (pairChanged) {
           appendEvent({
             id: makeEventId(),
             timestamp: timestamp(),
             type: 'passthrough',
-            message: `set ${newPassthrough.label}`,
+            message: `Passthrough turned on for rooms ${newPassthrough.label}`,
           });
         }
       }


### PR DESCRIPTION
## Summary
- Show the affected room pair when passthrough is enabled, changed, or disabled.
- Cover enable, disable, and unchanged-pair notification behavior.

## Validation
- Confirmed manually by the user: cargo test --workspace; cargo clippy --workspace -- -D warnings; node scripts/arch-check.mjs; GUI format, lint, dependency, typecheck, and test gates.