### PR TITLE
feat(website): make the AppMock preview interactive

### DIFF
--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -215,6 +215,13 @@
   animation: wavis-share-pulse 2s ease-in-out infinite;
 }
 
+/* Passthrough-volume slider on an expanded participant row. */
+.wavis-volume-slider {
+  accent-color: var(--color-blue);
+  height: 3px;
+  cursor: pointer;
+}
+
 /* Respect users who ask for less motion: freeze the waveform and caret. */
 @media (prefers-reduced-motion: reduce) {
   *,

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -768,6 +768,9 @@ function ParticipantMockRow({
           <Mic size={9} strokeWidth={2} className="text-muted" aria-hidden="true" />
         </span>
         <span className="inline-flex items-center gap-1">
+          {participant.hasAudioShare && (
+            <Music size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
+          )}
           {participant.hasShare && (
             <ScreenShare size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
           )}

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -28,10 +28,10 @@ const CHAT = [
 ];
 
 const LOGS = [
-  { time: "09:41:08", text: "alex joined Room 1", tone: "text-accent" },
-  { time: "09:42:05", text: "sam started sharing", tone: "text-purple" },
-  { time: "09:43:10", text: "Room 2 created", tone: "text-warn" },
-  { time: "09:45:31", text: "nora joined Room 2", tone: "text-accent" },
+  { time: "09:41:08", text: "alex joined Room 1", tone: "text-purple" },
+  { time: "09:41:45", text: "alex started sharing", tone: "text-purple" },
+  { time: "09:42:05", text: "sam joined Room 1", tone: "text-warn" },
+  { time: "09:42:31", text: "sam started sharing", tone: "text-warn" },
 ];
 
 type RoomId = "room1" | "room2";
@@ -52,7 +52,6 @@ interface Participant {
   id: string;
   name: string;
   tone: string;
-  hasCamera?: boolean;
   hasShare?: boolean;
 }
 
@@ -104,7 +103,7 @@ interface ExpandState {
 
 const ROOM_SEEDS: Record<RoomId, Participant[]> = {
   room1: [
-    { id: "alex", name: "alex", tone: "text-purple", hasCamera: true, hasShare: true },
+    { id: "alex", name: "alex", tone: "text-purple", hasShare: true },
     { id: "sam", name: "sam", tone: "text-warn", hasShare: true },
   ],
   room2: [],
@@ -624,11 +623,10 @@ function MainAppWindow({
                 </span>
               </>
             ) : (
-              // Matches ChannelDetail.tsx's real handleJoinVoice button styling.
               <button
                 type="button"
                 onClick={roomActions.onJoinVoice}
-                className="block w-full border border-accent px-1 py-0.5 text-center text-accent transition-colors hover:bg-accent hover:text-bg"
+                className="block w-full border border-accent/60 bg-accent/10 px-2 py-1 text-center text-[1.08em] font-bold text-accent shadow-black/30"
               >
                 /join voice
               </button>
@@ -745,14 +743,8 @@ function ParticipantMockRow({
           <Mic size={9} strokeWidth={2} className="text-muted" aria-hidden="true" />
         </span>
         <span className="inline-flex items-center gap-1">
-          {participant.hasCamera && (
-            <Camera size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
-          )}
           {participant.hasShare && (
-            <>
-              <Music size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
-              <ScreenShare size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
-            </>
+            <ScreenShare size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
           )}
         </span>
       </button>

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -34,12 +34,19 @@ const LOGS = [
   { time: "09:45:31", text: "nora joined Room 2", tone: "text-accent" },
 ];
 
-const SHARE_QUALITY_LABEL = "1440p60 · 7.6 Mbps";
-
 type RoomId = "room1" | "room2";
 type ActivePanel = "main" | "watchAll";
 type ActivityTab = "logs" | "videos";
+type ShareQuality = "low" | "high" | "max";
 type DragPosition = { x: number; y: number };
+
+// Matches the real quality picker in ActiveRoom.tsx (a <select> that appears
+// under /stopshare, not an overlay on the Watch All tiles).
+const SHARE_QUALITY_LABELS: Record<ShareQuality, string> = {
+  low: "Smooth  1080p @ 60fps",
+  high: "Sharp   1440p @ 30fps",
+  max: "Max     1440p @ 60fps",
+};
 
 interface Participant {
   id: string;
@@ -53,7 +60,6 @@ interface WatchAllStream {
   id: string;
   name: string;
   tone: string;
-  isYou?: boolean;
 }
 
 interface SelfState {
@@ -61,6 +67,7 @@ interface SelfState {
   isDeafened: boolean;
   cameraOn: boolean;
   isSharing: boolean;
+  shareQuality: ShareQuality;
 }
 
 interface SelfActions {
@@ -68,6 +75,7 @@ interface SelfActions {
   toggleDeafen: () => void;
   toggleCamera: () => void;
   toggleSharing: () => void;
+  setShareQuality: (quality: ShareQuality) => void;
 }
 
 interface RoomState {
@@ -280,6 +288,7 @@ export function AppMock() {
     isDeafened: false,
     cameraOn: false,
     isSharing: false,
+    shareQuality: "max",
   });
   const [activityTab, setActivityTab] = useState<ActivityTab>("logs");
 
@@ -320,6 +329,7 @@ export function AppMock() {
         return { ...s, cameraOn };
       }),
     toggleSharing: () => setSelf((s) => ({ ...s, isSharing: !s.isSharing })),
+    setShareQuality: (quality) => setSelf((s) => ({ ...s, shareQuality: quality })),
   };
 
   const expand: ExpandState = {
@@ -332,9 +342,7 @@ export function AppMock() {
   const sharingMembers = currentRoomMembers.filter((p) => p.hasShare);
   const streams: WatchAllStream[] = [
     ...sharingMembers.map((p) => ({ id: p.id, name: p.name, tone: p.tone })),
-    ...(youConnected && self.isSharing
-      ? [{ id: "you", name: "you", tone: "text-blue", isYou: true }]
-      : []),
+    ...(youConnected && self.isSharing ? [{ id: "you", name: "you", tone: "text-blue" }] : []),
   ];
 
   return (
@@ -560,6 +568,26 @@ function MainAppWindow({
                 >
                   {self.isSharing ? "/stop-sharing" : "/share-screen"}
                 </button>
+                {self.isSharing && (
+                  // Matches ActiveRoom.tsx's real quality <select>, which sits
+                  // directly under /stopshare rather than on a Watch All tile.
+                  <select
+                    value={self.shareQuality}
+                    onChange={(event) =>
+                      selfActions.setShareQuality(event.target.value as ShareQuality)
+                    }
+                    className="w-full cursor-pointer border border-muted bg-panel px-1 py-0.5 text-text"
+                    aria-label="Share quality"
+                  >
+                    {(Object.entries(SHARE_QUALITY_LABELS) as [ShareQuality, string][]).map(
+                      ([quality, label]) => (
+                        <option key={quality} value={quality}>
+                          {label}
+                        </option>
+                      ),
+                    )}
+                  </select>
+                )}
                 <span className="block border border-muted px-1 py-0.5 text-center text-text">
                   /settings
                 </span>
@@ -638,7 +666,7 @@ function MainAppWindow({
           ) : (
             <div className="overflow-hidden p-3">
               {self.cameraOn ? (
-                <div className="grid h-full grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel">
+                <div className="grid aspect-[16/10] w-20 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel sm:w-24 lg:w-28">
                   <div className="wavis-stream-preview min-h-0" />
                   <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px]">
                     <span className="truncate text-blue">you</span>
@@ -759,28 +787,20 @@ function WatchAllMock({
 
       <div
         className={`grid aspect-[1.05/1] gap-1.5 bg-bg p-1.5 sm:p-2 ${
-          streams.length <= 1
-            ? "grid-rows-1"
-            : streams.length === 2
-              ? "grid-rows-2"
-              : "grid-cols-2 grid-rows-2"
+          streams.length <= 1 ? "grid-rows-1" : "grid-cols-2 grid-rows-2"
         }`}
       >
         {streams.length === 0 ? (
           <p className="flex items-center justify-center text-muted">no active shares</p>
         ) : (
-          streams.map((stream) => (
+          streams.map((stream, index) => (
             <div
               key={stream.id}
-              className="grid min-w-0 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel"
+              className={`grid min-w-0 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel ${
+                streams.length === 3 && index === 2 ? "col-span-2" : ""
+              }`}
             >
-              <div className="wavis-stream-preview min-h-0">
-                {stream.isYou && (
-                  <span className="absolute bottom-1 left-1 rounded border border-blue/50 bg-crust/85 px-1 py-0.5 text-[6px] text-blue sm:text-[7px]">
-                    {SHARE_QUALITY_LABEL}
-                  </span>
-                )}
-              </div>
+              <div className="wavis-stream-preview min-h-0" />
               <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px] sm:text-[8px]">
                 <span className={`truncate ${stream.tone}`}>{stream.name}</span>
                 <span className="text-accent">live</span>

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -527,15 +527,12 @@ function MainAppWindow({
                       <Camera size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
                     )}
                     {self.isSharing && (
-                      <>
-                        <Music size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
-                        <ScreenShare
-                          size={9}
-                          strokeWidth={2}
-                          className="wavis-share-pulse"
-                          aria-hidden="true"
-                        />
-                      </>
+                      <ScreenShare
+                        size={9}
+                        strokeWidth={2}
+                        className="wavis-share-pulse"
+                        aria-hidden="true"
+                      />
                     )}
                   </span>
                 </div>

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -666,7 +666,7 @@ function MainAppWindow({
           ) : (
             <div className="overflow-hidden p-3">
               {self.cameraOn ? (
-                <div className="grid aspect-[16/10] w-20 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel sm:w-24 lg:w-28">
+                <div className="grid aspect-[16/10] w-full grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel">
                   <div className="wavis-stream-preview min-h-0" />
                   <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px]">
                     <span className="truncate text-blue">you</span>

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -36,7 +36,7 @@ const LOGS = [
 
 type RoomId = "room1" | "room2";
 type ActivePanel = "main" | "watchAll";
-type ActivityTab = "logs" | "videos";
+type ActivityTab = "chat" | "logs" | "videos";
 type ShareQuality = "low" | "high" | "max";
 type DragPosition = { x: number; y: number };
 
@@ -331,7 +331,7 @@ export function AppMock() {
     isSharing: false,
     shareQuality: "max",
   });
-  const [activityTab, setActivityTab] = useState<ActivityTab>("logs");
+  const [activityTab, setActivityTab] = useState<ActivityTab>("chat");
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [volumes, setVolumes] = useState<Record<string, number>>({});
@@ -371,7 +371,12 @@ export function AppMock() {
         if (cameraOn) setActivityTab("videos");
         return { ...s, cameraOn };
       }),
-    toggleSharing: () => setSelf((s) => ({ ...s, isSharing: !s.isSharing })),
+    toggleSharing: () =>
+      setSelf((s) => {
+        const isSharing = !s.isSharing;
+        if (isSharing) setActivePanel("watchAll");
+        return { ...s, isSharing };
+      }),
     setShareQuality: (quality) => setSelf((s) => ({ ...s, shareQuality: quality })),
   };
 
@@ -656,35 +661,69 @@ function MainAppWindow({
           </div>
         </aside>
 
-        {/* Chat */}
-        <section className="grid min-w-0 grid-rows-[auto_1fr_auto] bg-bg">
-          <div className="border-b border-border px-3 py-3 font-bold text-muted">CHAT</div>
-
-          <div className="space-y-1.5 overflow-hidden p-3">
-            {CHAT.map((item) => (
-              <p key={`${item.time}-${item.user}`} className="truncate text-text">
-                <span className="text-muted">[{item.time}] </span>
-                <span className={item.color}>{item.user}</span>
-                <span>: </span>
-                <span>{item.text}</span>
-              </p>
-            ))}
+        {/* Chat/Logs/Videos — combined into one tabbed pane below sm (matches
+            ActiveRoom.tsx's groupedPanel), split into separate columns at sm+ */}
+        <section className="grid min-w-0 grid-rows-[auto_1fr_auto] bg-bg sm:hidden">
+          <div className="grid grid-cols-3 border-b border-border text-center font-bold">
+            <button
+              type="button"
+              onClick={() => onSetActivityTab("chat")}
+              className={`border-r border-border px-1 py-3 transition-colors ${
+                activityTab === "chat" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
+              }`}
+            >
+              CHAT
+            </button>
+            <button
+              type="button"
+              onClick={() => onSetActivityTab("logs")}
+              className={`border-r border-border px-1 py-3 transition-colors ${
+                activityTab === "logs" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
+              }`}
+            >
+              LOGS
+            </button>
+            <button
+              type="button"
+              onClick={() => onSetActivityTab("videos")}
+              className={`px-1 py-3 transition-colors ${
+                activityTab === "videos" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
+              }`}
+            >
+              VIDEOS
+            </button>
           </div>
 
+          {activityTab === "chat" && <ChatMessages />}
+          {activityTab === "logs" && <LogsList />}
+          {activityTab === "videos" && <VideosPanel cameraOn={self.cameraOn} />}
+
+          <div className="border-t border-border px-3 py-1.5">
+            <span className="mr-3 text-accent">&gt;</span>
+            <span className="text-muted">
+              {activityTab === "chat" ? "type message..." : "type command..."}
+            </span>
+          </div>
+        </section>
+
+        {/* Chat — desktop column (sm+) */}
+        <section className="hidden min-w-0 grid-rows-[auto_1fr_auto] bg-bg sm:grid">
+          <div className="border-b border-border px-3 py-3 font-bold text-muted">CHAT</div>
+          <ChatMessages />
           <div className="border-t border-border px-3 py-1.5">
             <span className="mr-3 text-accent">&gt;</span>
             <span className="text-muted">type message...</span>
           </div>
         </section>
 
-        {/* Activity */}
+        {/* Activity — desktop column (sm+) */}
         <aside className="hidden min-w-0 grid-rows-[auto_1fr_auto] border-l border-border bg-panel sm:grid">
           <div className="grid grid-cols-2 border-b border-border text-center font-bold">
             <button
               type="button"
               onClick={() => onSetActivityTab("logs")}
               className={`border-r border-border px-2 py-3 transition-colors ${
-                activityTab === "logs" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
+                activityTab !== "videos" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
               }`}
             >
               LOGS
@@ -700,34 +739,10 @@ function MainAppWindow({
             </button>
           </div>
 
-          {activityTab === "logs" ? (
-            <div className="space-y-1.5 overflow-hidden p-3">
-              <div className="flex items-center gap-2 text-muted">
-                <span className="h-px flex-1 bg-muted" />
-                <span>today</span>
-                <span className="h-px flex-1 bg-muted" />
-              </div>
-              {LOGS.map((log) => (
-                <p key={`${log.time}-${log.text}`} className="text-text">
-                  <span className="text-muted">[{log.time}] </span>
-                  <span className={log.tone}>{log.text}</span>
-                </p>
-              ))}
-            </div>
+          {activityTab === "videos" ? (
+            <VideosPanel cameraOn={self.cameraOn} />
           ) : (
-            <div className="overflow-hidden p-3">
-              {self.cameraOn ? (
-                <div className="grid aspect-[16/10] w-full grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel">
-                  <div className="wavis-stream-preview min-h-0" />
-                  <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px]">
-                    <span className="truncate text-blue">you</span>
-                    <span className="text-accent">live</span>
-                  </div>
-                </div>
-              ) : (
-                <p className="text-muted">no active cameras</p>
-              )}
-            </div>
+            <LogsList />
           )}
 
           <div className="border-t border-border px-3 py-1.5">
@@ -736,6 +751,57 @@ function MainAppWindow({
           </div>
         </aside>
       </div>
+    </div>
+  );
+}
+
+function ChatMessages() {
+  return (
+    <div className="space-y-1.5 overflow-hidden p-3">
+      {CHAT.map((item) => (
+        <p key={`${item.time}-${item.user}`} className="truncate text-text">
+          <span className="text-muted">[{item.time}] </span>
+          <span className={item.color}>{item.user}</span>
+          <span>: </span>
+          <span>{item.text}</span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function LogsList() {
+  return (
+    <div className="space-y-1.5 overflow-hidden p-3">
+      <div className="flex items-center gap-2 text-muted">
+        <span className="h-px flex-1 bg-muted" />
+        <span>today</span>
+        <span className="h-px flex-1 bg-muted" />
+      </div>
+      {LOGS.map((log) => (
+        <p key={`${log.time}-${log.text}`} className="text-text">
+          <span className="text-muted">[{log.time}] </span>
+          <span className={log.tone}>{log.text}</span>
+        </p>
+      ))}
+    </div>
+  );
+}
+
+function VideosPanel({ cameraOn }: { cameraOn: boolean }) {
+  return (
+    <div className="overflow-hidden p-3">
+      {cameraOn ? (
+        <div className="grid aspect-[16/10] w-full grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel">
+          <div className="wavis-stream-preview min-h-0" />
+          <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px]">
+            <span className="truncate text-blue">you</span>
+            <span className="text-accent">live</span>
+          </div>
+        </div>
+      ) : (
+        <p className="text-muted">no active cameras</p>
+      )}
     </div>
   );
 }

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -136,6 +136,24 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
 }
 
+// Literal strings (not built from interpolation) so Tailwind's scanner picks
+// them up regardless of which index is actually used at runtime.
+const GRID_COLS_CLASS = ["", "grid-cols-1", "grid-cols-2", "grid-cols-3", "grid-cols-4"];
+const GRID_ROWS_CLASS = ["", "grid-rows-1", "grid-rows-2", "grid-rows-3", "grid-rows-4"];
+
+/** Auto-fit gallery layout (Discord/Zoom-style): pick the col/row count that
+ * keeps tiles closest to square for however many streams are live, instead
+ * of a hardcoded template per count. */
+function watchAllGridLayout(count: number) {
+  const cols = count <= 1 ? 1 : Math.min(Math.ceil(Math.sqrt(count)), 4);
+  const rows = count <= 1 ? 1 : Math.min(Math.ceil(count / cols), 4);
+  const lastRowCount = count - (rows - 1) * cols;
+  return {
+    gridClass: `${GRID_COLS_CLASS[cols]} ${GRID_ROWS_CLASS[rows]}`,
+    isLonelyLastTile: (index: number) => cols > 1 && lastRowCount === 1 && index === count - 1,
+  };
+}
+
 function handlePanelKeyDown(
   event: KeyboardEvent<HTMLDivElement>,
   focusPanel: () => void,
@@ -785,30 +803,31 @@ function WatchAllMock({
         </span>
       </div>
 
-      <div
-        className={`grid aspect-[1.05/1] gap-1.5 bg-bg p-1.5 sm:p-2 ${
-          streams.length <= 1 ? "grid-rows-1" : "grid-cols-2 grid-rows-2"
-        }`}
-      >
-        {streams.length === 0 ? (
-          <p className="flex items-center justify-center text-muted">no active shares</p>
-        ) : (
-          streams.map((stream, index) => (
-            <div
-              key={stream.id}
-              className={`grid min-w-0 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel ${
-                streams.length === 3 && index === 2 ? "col-span-2" : ""
-              }`}
-            >
-              <div className="wavis-stream-preview min-h-0" />
-              <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px] sm:text-[8px]">
-                <span className={`truncate ${stream.tone}`}>{stream.name}</span>
-                <span className="text-accent">live</span>
-              </div>
-            </div>
-          ))
-        )}
-      </div>
+      {(() => {
+        const { gridClass, isLonelyLastTile } = watchAllGridLayout(streams.length);
+        return (
+          <div className={`grid aspect-[1.05/1] gap-1.5 bg-bg p-1.5 sm:p-2 ${gridClass}`}>
+            {streams.length === 0 ? (
+              <p className="flex items-center justify-center text-muted">no active shares</p>
+            ) : (
+              streams.map((stream, index) => (
+                <div
+                  key={stream.id}
+                  className={`grid min-w-0 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel ${
+                    isLonelyLastTile(index) ? "col-span-full" : ""
+                  }`}
+                >
+                  <div className="wavis-stream-preview min-h-0" />
+                  <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px] sm:text-[8px]">
+                    <span className={`truncate ${stream.tone}`}>{stream.name}</span>
+                    <span className="text-accent">live</span>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Camera, Mic, Music, ScreenShare } from "lucide-react";
+import { Camera, HeadphoneOff, Mic, MicOff, Music, ScreenShare } from "lucide-react";
 import {
   useEffect,
   useRef,
@@ -12,7 +12,10 @@ import {
 
 // A functional mock of the Wavis window — the page's main product signal.
 // Built as one component with a fixed aspect-ratio frame, so a real screenshot
-// <img> can replace it later without shifting the layout.
+// <img> can replace it later without shifting the layout. The room/participant
+// state below is a self-contained faux demo, not a real client — it exists so
+// visitors can click mute/deafen/camera/share/join and see the UI actually
+// respond, instead of staring at a static screenshot.
 
 const CHAT = [
   { time: "09:42:05", user: "sam", color: "text-warn", text: "starting screen share" },
@@ -31,8 +34,88 @@ const LOGS = [
   { time: "09:45:31", text: "nora joined Room 2", tone: "text-accent" },
 ];
 
+const SHARE_QUALITY_LABEL = "1440p60 · 7.6 Mbps";
+
+type RoomId = "room1" | "room2";
 type ActivePanel = "main" | "watchAll";
+type ActivityTab = "logs" | "videos";
 type DragPosition = { x: number; y: number };
+
+interface Participant {
+  id: string;
+  name: string;
+  tone: string;
+  hasCamera?: boolean;
+  hasShare?: boolean;
+}
+
+interface WatchAllStream {
+  id: string;
+  name: string;
+  tone: string;
+  isYou?: boolean;
+}
+
+interface SelfState {
+  isMuted: boolean;
+  isDeafened: boolean;
+  cameraOn: boolean;
+  isSharing: boolean;
+}
+
+interface SelfActions {
+  toggleMute: () => void;
+  toggleDeafen: () => void;
+  toggleCamera: () => void;
+  toggleSharing: () => void;
+}
+
+interface RoomState {
+  currentRoomNumber: number;
+  currentRoomCount: number;
+  currentRoomMembers: Participant[];
+  otherRoomCreated: boolean;
+  otherRoomNumber: number;
+  otherRoomCount: number;
+  youConnected: boolean;
+}
+
+interface RoomActions {
+  onJoinVoice: () => void;
+  onCreateOtherRoom: () => void;
+  onSwitchRoom: () => void;
+  onWatchAll: () => void;
+}
+
+interface ExpandState {
+  expandedId: string | null;
+  onToggle: (id: string) => void;
+  volumeFor: (id: string) => number;
+  onVolumeChange: (id: string, value: number) => void;
+}
+
+const ROOM_SEEDS: Record<RoomId, Participant[]> = {
+  room1: [
+    { id: "alex", name: "alex", tone: "text-purple", hasCamera: true, hasShare: true },
+    { id: "sam", name: "sam", tone: "text-warn", hasShare: true },
+  ],
+  room2: [],
+};
+
+const COMMAND_BUTTON_TONE = {
+  neutral: "border-muted text-text",
+  danger: "border-danger bg-danger/10 text-danger",
+  "danger-glow":
+    "border-danger bg-danger/10 text-danger text-[1.08em] font-bold shadow-[0_0_14px_rgba(243,139,168,0.22)]",
+  accent: "border-accent bg-accent/10 text-accent",
+  purple:
+    "border-purple bg-purple/10 text-purple text-[1.08em] font-bold shadow-[0_0_14px_rgba(203,166,247,0.18)]",
+  blue: "border-blue/50 text-blue",
+} as const;
+
+function commandButtonClass(tone: keyof typeof COMMAND_BUTTON_TONE) {
+  return `border px-1 py-0.5 text-center transition-colors hover:opacity-80 ${COMMAND_BUTTON_TONE[tone]}`;
+}
 
 function isDesktopDragPointer() {
   return (
@@ -186,21 +269,97 @@ export function AppMock() {
   const mainDrag = useDesktopPanelDrag(() => setActivePanel("main"));
   const watchAllDrag = useDesktopPanelDrag(() => setActivePanel("watchAll"));
 
+  // null = the visitor (a third participant, distinct from the alex/sam NPCs
+  // already in the room) hasn't connected yet. /join voice sets this to the
+  // room they're joining; connecting and switching rooms are the same action.
+  const [connectedRoomId, setConnectedRoomId] = useState<RoomId | null>(null);
+  const [otherRoomCreated, setOtherRoomCreated] = useState(false);
+
+  const [self, setSelf] = useState<SelfState>({
+    isMuted: true,
+    isDeafened: false,
+    cameraOn: false,
+    isSharing: false,
+  });
+  const [activityTab, setActivityTab] = useState<ActivityTab>("logs");
+
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [volumes, setVolumes] = useState<Record<string, number>>({});
+
+  const youConnected = connectedRoomId !== null;
+  const viewedRoomId: RoomId = connectedRoomId ?? "room1";
+  const currentRoomMembers = ROOM_SEEDS[viewedRoomId];
+  const otherRoomId: RoomId = viewedRoomId === "room1" ? "room2" : "room1";
+  const otherRoomMembers = ROOM_SEEDS[otherRoomId];
+  const otherRoomExists = otherRoomId === "room1" ? true : otherRoomCreated;
+
+  const room: RoomState = {
+    currentRoomNumber: viewedRoomId === "room1" ? 1 : 2,
+    currentRoomCount: currentRoomMembers.length + (youConnected ? 1 : 0),
+    currentRoomMembers,
+    otherRoomCreated: otherRoomExists,
+    otherRoomNumber: otherRoomId === "room1" ? 1 : 2,
+    otherRoomCount: otherRoomMembers.length,
+    youConnected,
+  };
+
+  const roomActions: RoomActions = {
+    onJoinVoice: () => setConnectedRoomId(viewedRoomId),
+    onCreateOtherRoom: () => setOtherRoomCreated(true),
+    onSwitchRoom: () => setConnectedRoomId(otherRoomId),
+    onWatchAll: () => setActivePanel("watchAll"),
+  };
+
+  const selfActions: SelfActions = {
+    toggleMute: () => setSelf((s) => ({ ...s, isMuted: !s.isMuted })),
+    toggleDeafen: () => setSelf((s) => ({ ...s, isDeafened: !s.isDeafened })),
+    toggleCamera: () =>
+      setSelf((s) => {
+        const cameraOn = !s.cameraOn;
+        if (cameraOn) setActivityTab("videos");
+        return { ...s, cameraOn };
+      }),
+    toggleSharing: () => setSelf((s) => ({ ...s, isSharing: !s.isSharing })),
+  };
+
+  const expand: ExpandState = {
+    expandedId,
+    onToggle: (id) => setExpandedId((cur) => (cur === id ? null : id)),
+    volumeFor: (id) => volumes[id] ?? 70,
+    onVolumeChange: (id, value) => setVolumes((cur) => ({ ...cur, [id]: value })),
+  };
+
+  const sharingMembers = currentRoomMembers.filter((p) => p.hasShare);
+  const streams: WatchAllStream[] = [
+    ...sharingMembers.map((p) => ({ id: p.id, name: p.name, tone: p.tone })),
+    ...(youConnected && self.isSharing
+      ? [{ id: "you", name: "you", tone: "text-blue", isYou: true }]
+      : []),
+  ];
+
   return (
     <div
       className="relative isolate z-40 mx-auto w-full max-w-[840px] overflow-visible pb-[clamp(44px,7vw,76px)]"
       role="group"
-      aria-label="The Wavis app preview: a private room window in front of a Watch All screen sharing panel. Drag either panel anywhere on the page; double-click to reset its position."
+      aria-label="The Wavis app preview: a private room window in front of a Watch All screen sharing panel. Drag either panel by its title bar anywhere on the page; double-click the title bar to reset its position."
     >
       <WatchAllMock
         isActive={activePanel === "watchAll"}
         onFocus={() => setActivePanel("watchAll")}
         drag={watchAllDrag}
+        streams={streams}
       />
       <MainAppWindow
         isActive={activePanel === "main"}
         onFocus={() => setActivePanel("main")}
         drag={mainDrag}
+        self={self}
+        selfActions={selfActions}
+        room={room}
+        roomActions={roomActions}
+        activityTab={activityTab}
+        onSetActivityTab={setActivityTab}
+        expand={expand}
       />
     </div>
   );
@@ -210,30 +369,48 @@ function MainAppWindow({
   isActive,
   onFocus,
   drag,
+  self,
+  selfActions,
+  room,
+  roomActions,
+  activityTab,
+  onSetActivityTab,
+  expand,
 }: {
   isActive: boolean;
   onFocus: () => void;
   drag: ReturnType<typeof useDesktopPanelDrag>;
+  self: SelfState;
+  selfActions: SelfActions;
+  room: RoomState;
+  roomActions: RoomActions;
+  activityTab: ActivityTab;
+  onSetActivityTab: (tab: ActivityTab) => void;
+  expand: ExpandState;
 }) {
   return (
     <div
       ref={drag.panelRef}
       style={drag.panelStyle}
-      className={`wavis-main-panel relative w-full overflow-hidden rounded-lg border bg-panel shadow-2xl transition-[border-color,box-shadow,transform] duration-200 lg:cursor-grab ${
+      className={`wavis-main-panel relative w-full overflow-hidden rounded-lg border bg-panel shadow-2xl transition-[border-color,box-shadow,transform] duration-200 ${
         isActive
           ? "z-30 border-blue/70 shadow-black/65"
           : "z-20 border-blue/40 shadow-black/45"
-      } ${drag.isDragging ? "lg:cursor-grabbing lg:transition-none lg:will-change-transform" : ""}`}
+      } ${drag.isDragging ? "lg:transition-none lg:will-change-transform" : ""}`}
       role="button"
       tabIndex={0}
       aria-pressed={isActive}
-      aria-label="Focus the main Wavis app preview. Double-click to reset its position."
+      aria-label="Focus the main Wavis app preview"
       onClick={onFocus}
       onKeyDown={(event) => handlePanelKeyDown(event, onFocus)}
-      onPointerDown={drag.onPointerDown}
     >
-      {/* Title bar */}
-      <div className="flex items-center justify-between border-b border-border bg-panel px-3 py-2">
+      {/* Title bar — the only draggable region; double-click resets position */}
+      <div
+        className={`flex items-center justify-between border-b border-border bg-panel px-3 py-2 lg:cursor-grab ${
+          drag.isDragging ? "lg:cursor-grabbing" : ""
+        }`}
+        onPointerDown={drag.onPointerDown}
+      >
         <div className="flex items-center gap-3">
           <span className="text-sm text-muted">
             <span className="text-accent">▸</span> wavis
@@ -255,7 +432,7 @@ function MainAppWindow({
               <span className="h-1.5 w-1.5 rounded-full bg-accent shadow-[0_0_8px_#a6e3a1]" />
               <span className="h-1.5 w-1.5 rounded-full bg-accent shadow-[0_0_8px_#a6e3a1]" />
               <span className="text-accent">LIVE</span>
-              <span className="text-muted">2/6</span>
+              <span className="text-muted">{room.currentRoomCount}/6</span>
               <span className="hidden text-accent sm:inline">77ms</span>
             </div>
             <div className="flex items-center justify-between gap-2">
@@ -265,60 +442,144 @@ function MainAppWindow({
           </div>
 
           <div className="border-b border-border p-2">
-            <div className="mb-1.5 flex items-center justify-between text-muted">
-              <span>[-] ROOM 1 (4)</span>
-              <span className="border border-border px-1.5 py-0.5">””</span>
+            <div className="mb-1.5 text-muted">
+              [-] ROOM {room.currentRoomNumber} ({room.currentRoomCount})
             </div>
-            <div className="mb-1 flex items-center justify-between text-purple">
-              <span className="inline-flex items-center gap-1">
-                [+] alex
-                <Mic size={9} strokeWidth={2} className="text-muted" aria-hidden="true" />
-              </span>
-              <span className="inline-flex items-center gap-1">
-                <Camera size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
-                <ScreenShare size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
-              </span>
+
+            <div className="max-h-[92px] space-y-1 overflow-y-auto pr-0.5 sm:max-h-[104px] lg:max-h-[118px]">
+              {room.youConnected && (
+                <div className="flex items-center justify-between text-blue">
+                  <span className="inline-flex items-center gap-1">
+                    <span className="text-accent">&gt;</span> you
+                    {self.isDeafened ? (
+                      <HeadphoneOff size={9} strokeWidth={2} className="text-danger" aria-hidden="true" />
+                    ) : self.isMuted ? (
+                      <MicOff size={9} strokeWidth={2} className="text-danger" aria-hidden="true" />
+                    ) : (
+                      <Mic size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
+                    )}
+                  </span>
+                  <span className="inline-flex items-center gap-1">
+                    {self.cameraOn && (
+                      <Camera size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
+                    )}
+                    {self.isSharing && (
+                      <>
+                        <Music size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
+                        <ScreenShare
+                          size={9}
+                          strokeWidth={2}
+                          className="wavis-share-pulse"
+                          aria-hidden="true"
+                        />
+                      </>
+                    )}
+                  </span>
+                </div>
+              )}
+
+              {room.currentRoomMembers.map((p) => (
+                <ParticipantMockRow
+                  key={p.id}
+                  participant={p}
+                  isExpanded={expand.expandedId === p.id}
+                  onToggleExpand={() => expand.onToggle(p.id)}
+                  volume={expand.volumeFor(p.id)}
+                  onVolumeChange={(value) => expand.onVolumeChange(p.id, value)}
+                />
+              ))}
             </div>
-            <div className="mb-1 flex items-center justify-between text-blue">
-              <span className="inline-flex items-center gap-1">
-                <span className="text-accent">&gt;</span> sam
-                <Mic size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
-              </span>
-              <span className="inline-flex items-center gap-1">
-                <Music size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
-                <ScreenShare size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
-              </span>
-            </div>
-            <div>
-              <span className="block border border-blue/60 bg-blue/10 px-2 py-1 text-center text-[1.08em] font-bold text-blue shadow-black/30">
-                /watch-all
-              </span>
-            </div>
+
+            <button
+              type="button"
+              onClick={roomActions.onWatchAll}
+              className="mt-1.5 block w-full border border-blue/60 bg-blue/10 px-2 py-1 text-center text-[1.08em] font-bold text-blue shadow-black/30"
+            >
+              /watch-all
+            </button>
           </div>
 
           <div className="border-b border-border p-2">
-            <span className="border border-blue/50 px-1.5 py-0.5 text-blue">/create room</span>
+            {room.otherRoomCreated ? (
+              <>
+                <div className="mb-1.5 flex items-center justify-between text-muted">
+                  <span>
+                    [+] ROOM {room.otherRoomNumber} ({room.otherRoomCount})
+                  </span>
+                </div>
+                <button
+                  type="button"
+                  onClick={roomActions.onSwitchRoom}
+                  className={`block w-full ${commandButtonClass("blue")}`}
+                >
+                  /join room {room.otherRoomNumber}
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                onClick={roomActions.onCreateOtherRoom}
+                className={`block w-full ${commandButtonClass("blue")}`}
+              >
+                /create room
+              </button>
+            )}
           </div>
 
           <div className="space-y-1 p-2">
-            <div className="text-blue">[-] sam</div>
-            <div className="grid grid-cols-2 gap-1">
-              <span className="border border-danger bg-danger/10 px-1 py-0.5 text-center text-danger">/unmute</span>
-              <span className="border border-muted px-1 py-0.5 text-center text-text">/deafen</span>
-            </div>
-            <span className="block border border-muted px-1 py-0.5 text-center text-text">/camera-on</span>
-            <span className="block border border-purple bg-purple/10 px-2 py-1 text-center text-[1.08em] font-bold text-purple shadow-[0_0_14px_rgba(203,166,247,0.18)]">
-              /share-screen
-            </span>
-            <span className="block border border-muted px-1 py-0.5 text-center text-text">/settings</span>
+            {room.youConnected ? (
+              <>
+                <div className="text-blue">[-] you</div>
+                <div className="grid grid-cols-2 gap-1">
+                  <button
+                    type="button"
+                    onClick={selfActions.toggleMute}
+                    className={commandButtonClass(self.isMuted ? "danger" : "neutral")}
+                  >
+                    {self.isMuted ? "/unmute" : "/mute"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={selfActions.toggleDeafen}
+                    className={commandButtonClass(self.isDeafened ? "danger" : "neutral")}
+                  >
+                    {self.isDeafened ? "/undeafen" : "/deafen"}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  onClick={selfActions.toggleCamera}
+                  className={`block w-full ${commandButtonClass(self.cameraOn ? "accent" : "neutral")}`}
+                >
+                  {self.cameraOn ? "/camera-off" : "/camera-on"}
+                </button>
+                <button
+                  type="button"
+                  onClick={selfActions.toggleSharing}
+                  className={`block w-full ${commandButtonClass(self.isSharing ? "danger-glow" : "purple")}`}
+                >
+                  {self.isSharing ? "/stop-sharing" : "/share-screen"}
+                </button>
+                <span className="block border border-muted px-1 py-0.5 text-center text-text">
+                  /settings
+                </span>
+              </>
+            ) : (
+              // Matches ChannelDetail.tsx's real handleJoinVoice button styling.
+              <button
+                type="button"
+                onClick={roomActions.onJoinVoice}
+                className="block w-full border border-accent px-1 py-0.5 text-center text-accent transition-colors hover:bg-accent hover:text-bg"
+              >
+                /join voice
+              </button>
+            )}
           </div>
         </aside>
 
         {/* Chat */}
         <section className="grid min-w-0 grid-rows-[auto_1fr_auto] bg-bg">
-          <div className="border-b border-border px-3 py-3 font-bold text-muted">
-            CHAT
-          </div>
+          <div className="border-b border-border px-3 py-3 font-bold text-muted">CHAT</div>
 
           <div className="space-y-1.5 overflow-hidden p-3">
             {CHAT.map((item) => (
@@ -340,25 +601,55 @@ function MainAppWindow({
         {/* Activity */}
         <aside className="hidden min-w-0 grid-rows-[auto_1fr_auto] border-l border-border bg-panel sm:grid">
           <div className="grid grid-cols-2 border-b border-border text-center font-bold">
-            <span className="border-r border-border bg-teal/10 px-2 py-3 text-accent">
+            <button
+              type="button"
+              onClick={() => onSetActivityTab("logs")}
+              className={`border-r border-border px-2 py-3 transition-colors ${
+                activityTab === "logs" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
+              }`}
+            >
               LOGS
-            </span>
-            <span className="px-2 py-3 text-muted">VIDEOS</span>
+            </button>
+            <button
+              type="button"
+              onClick={() => onSetActivityTab("videos")}
+              className={`px-2 py-3 transition-colors ${
+                activityTab === "videos" ? "bg-teal/10 text-accent" : "text-muted hover:text-text"
+              }`}
+            >
+              VIDEOS
+            </button>
           </div>
 
-          <div className="space-y-1.5 overflow-hidden p-3">
-            <div className="flex items-center gap-2 text-muted">
-              <span className="h-px flex-1 bg-muted" />
-              <span>today</span>
-              <span className="h-px flex-1 bg-muted" />
+          {activityTab === "logs" ? (
+            <div className="space-y-1.5 overflow-hidden p-3">
+              <div className="flex items-center gap-2 text-muted">
+                <span className="h-px flex-1 bg-muted" />
+                <span>today</span>
+                <span className="h-px flex-1 bg-muted" />
+              </div>
+              {LOGS.map((log) => (
+                <p key={`${log.time}-${log.text}`} className="text-text">
+                  <span className="text-muted">[{log.time}] </span>
+                  <span className={log.tone}>{log.text}</span>
+                </p>
+              ))}
             </div>
-            {LOGS.map((log) => (
-              <p key={`${log.time}-${log.text}`} className="text-text">
-                <span className="text-muted">[{log.time}] </span>
-                <span className={log.tone}>{log.text}</span>
-              </p>
-            ))}
-          </div>
+          ) : (
+            <div className="overflow-hidden p-3">
+              {self.cameraOn ? (
+                <div className="grid h-full grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel">
+                  <div className="wavis-stream-preview min-h-0" />
+                  <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px]">
+                    <span className="truncate text-blue">you</span>
+                    <span className="text-accent">live</span>
+                  </div>
+                </div>
+              ) : (
+                <p className="text-muted">no active cameras</p>
+              )}
+            </div>
+          )}
 
           <div className="border-t border-border px-3 py-1.5">
             <span className="mr-3 text-accent">&gt;</span>
@@ -370,59 +661,133 @@ function MainAppWindow({
   );
 }
 
+function ParticipantMockRow({
+  participant,
+  isExpanded,
+  onToggleExpand,
+  volume,
+  onVolumeChange,
+}: {
+  participant: Participant;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  volume: number;
+  onVolumeChange: (value: number) => void;
+}) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        className={`flex w-full items-center justify-between text-left hover:opacity-80 ${participant.tone}`}
+      >
+        <span className="inline-flex items-center gap-1">
+          {isExpanded ? "[-]" : "[+]"} {participant.name}
+          <Mic size={9} strokeWidth={2} className="text-muted" aria-hidden="true" />
+        </span>
+        <span className="inline-flex items-center gap-1">
+          {participant.hasCamera && (
+            <Camera size={9} strokeWidth={2} className="text-accent" aria-hidden="true" />
+          )}
+          {participant.hasShare && (
+            <>
+              <Music size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
+              <ScreenShare size={9} strokeWidth={2} className="wavis-share-pulse" aria-hidden="true" />
+            </>
+          )}
+        </span>
+      </button>
+      {isExpanded && (
+        <div className="mt-1 flex items-center gap-1.5 pl-3">
+          <span className="shrink-0 text-muted">vol</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={volume}
+            onChange={(event) => onVolumeChange(Number(event.target.value))}
+            className="wavis-volume-slider w-full"
+            aria-label={`passthrough volume for ${participant.name}`}
+          />
+          <span className="w-6 shrink-0 text-right text-muted">{volume}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
 function WatchAllMock({
   isActive,
   onFocus,
   drag,
+  streams,
 }: {
   isActive: boolean;
   onFocus: () => void;
   drag: ReturnType<typeof useDesktopPanelDrag>;
+  streams: WatchAllStream[];
 }) {
-  const streams = [
-    { name: "alex", tone: "text-purple" },
-    { name: "sam", tone: "text-blue" },
-  ];
-
   return (
     <div
       ref={drag.panelRef}
       style={drag.panelStyle}
-      className={`wavis-watch-panel absolute bottom-0 -right-3 w-[52%] min-w-[180px] max-w-[330px] overflow-hidden rounded-lg border bg-crust shadow-2xl transition-[border-color,box-shadow,transform] duration-200 sm:-right-4 sm:w-[48%] lg:-right-5 lg:w-[44%] lg:cursor-grab ${
+      className={`wavis-watch-panel absolute bottom-0 -right-3 w-[52%] min-w-[180px] max-w-[330px] overflow-hidden rounded-lg border bg-crust shadow-2xl transition-[border-color,box-shadow,transform] duration-200 sm:-right-4 sm:w-[48%] lg:-right-5 lg:w-[44%] ${
         isActive
           ? "z-40 border-blue/70 shadow-black/65"
           : "z-10 border-blue/40 shadow-black/45"
-      } ${drag.isDragging ? "lg:cursor-grabbing lg:transition-none lg:will-change-transform" : ""}`}
+      } ${drag.isDragging ? "lg:transition-none lg:will-change-transform" : ""}`}
       role="button"
       tabIndex={0}
       aria-pressed={isActive}
-      aria-label="Focus the Watch All preview panel. Double-click to reset its position."
+      aria-label="Focus the Watch All preview panel"
       onClick={onFocus}
       onKeyDown={(event) => handlePanelKeyDown(event, onFocus)}
-      onPointerDown={drag.onPointerDown}
     >
-      <div className="flex items-center justify-between border-b border-border bg-panel/95 px-2.5 py-1.5 text-[8px] text-muted sm:text-[9px]">
+      <div
+        className={`flex items-center justify-between border-b border-border bg-panel/95 px-2.5 py-1.5 text-[8px] text-muted sm:text-[9px] lg:cursor-grab ${
+          drag.isDragging ? "lg:cursor-grabbing" : ""
+        }`}
+        onPointerDown={drag.onPointerDown}
+      >
         <span>
           <span className="text-accent">&gt;</span> watch all
         </span>
-        <span className="text-blue">2 streams</span>
+        <span className="text-blue">
+          {streams.length} stream{streams.length === 1 ? "" : "s"}
+        </span>
       </div>
 
-      <div className="grid aspect-[1.05/1] grid-rows-2 gap-1.5 bg-bg p-1.5 sm:p-2">
-        {streams.map((stream, index) => (
-          <div
-            key={stream.name}
-            className="grid min-w-0 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel"
-          >
-            <div className="wavis-stream-preview min-h-0" />
-            <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px] sm:text-[8px]">
-              <span className={`truncate ${stream.tone}`}>{stream.name}</span>
-              <span className={index === 0 ? "text-accent" : "text-muted"}>
-                {index === 0 ? "live" : "view"}
-              </span>
+      <div
+        className={`grid aspect-[1.05/1] gap-1.5 bg-bg p-1.5 sm:p-2 ${
+          streams.length <= 1
+            ? "grid-rows-1"
+            : streams.length === 2
+              ? "grid-rows-2"
+              : "grid-cols-2 grid-rows-2"
+        }`}
+      >
+        {streams.length === 0 ? (
+          <p className="flex items-center justify-center text-muted">no active shares</p>
+        ) : (
+          streams.map((stream) => (
+            <div
+              key={stream.id}
+              className="grid min-w-0 grid-rows-[1fr_auto] overflow-hidden border border-border bg-panel"
+            >
+              <div className="wavis-stream-preview min-h-0">
+                {stream.isYou && (
+                  <span className="absolute bottom-1 left-1 rounded border border-blue/50 bg-crust/85 px-1 py-0.5 text-[6px] text-blue sm:text-[7px]">
+                    {SHARE_QUALITY_LABEL}
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center justify-between gap-2 border-t border-border px-1.5 py-1 text-[7px] sm:text-[8px]">
+                <span className={`truncate ${stream.tone}`}>{stream.name}</span>
+                <span className="text-accent">live</span>
+              </div>
             </div>
-          </div>
-        ))}
+          ))
+        )}
       </div>
     </div>
   );

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -143,10 +143,23 @@ const GRID_ROWS_CLASS = ["", "grid-rows-1", "grid-rows-2", "grid-rows-3", "grid-
 
 /** Auto-fit gallery layout (Discord/Zoom-style): pick the col/row count that
  * keeps tiles closest to square for however many streams are live, instead
- * of a hardcoded template per count. */
+ * of a hardcoded template per count. The panel itself is roughly square, so
+ * a plain sqrt(count) split would put 2 tiles side by side and make them
+ * tall and narrow — the wrong way round for landscape share/camera content
+ * — so 2 is special-cased to stack top/bottom instead. */
 function watchAllGridLayout(count: number) {
-  const cols = count <= 1 ? 1 : Math.min(Math.ceil(Math.sqrt(count)), 4);
-  const rows = count <= 1 ? 1 : Math.min(Math.ceil(count / cols), 4);
+  let cols: number;
+  let rows: number;
+  if (count <= 1) {
+    cols = 1;
+    rows = 1;
+  } else if (count === 2) {
+    cols = 1;
+    rows = 2;
+  } else {
+    cols = Math.min(Math.ceil(Math.sqrt(count)), 4);
+    rows = Math.min(Math.ceil(count / cols), 4);
+  }
   const lastRowCount = count - (rows - 1) * cols;
   return {
     gridClass: `${GRID_COLS_CLASS[cols]} ${GRID_ROWS_CLASS[rows]}`,

--- a/website/components/AppMock.tsx
+++ b/website/components/AppMock.tsx
@@ -53,6 +53,7 @@ interface Participant {
   name: string;
   tone: string;
   hasShare?: boolean;
+  hasAudioShare?: boolean;
 }
 
 interface WatchAllStream {
@@ -101,10 +102,20 @@ interface ExpandState {
   onVolumeChange: (id: string, value: number) => void;
 }
 
+/** Watch All's audio-only shares strip (below the video grid), mirroring
+ * AudioOnlyTile.tsx in the real app. */
+interface AudioShareState {
+  streams: Participant[];
+  mutedFor: (id: string) => boolean;
+  volumeFor: (id: string) => number;
+  onToggleMute: (id: string) => void;
+  onVolumeChange: (id: string, value: number) => void;
+}
+
 const ROOM_SEEDS: Record<RoomId, Participant[]> = {
   room1: [
     { id: "alex", name: "alex", tone: "text-purple", hasShare: true },
-    { id: "sam", name: "sam", tone: "text-warn", hasShare: true },
+    { id: "sam", name: "sam", tone: "text-warn", hasShare: true, hasAudioShare: true },
   ],
   room2: [],
 };
@@ -324,6 +335,8 @@ export function AppMock() {
 
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [volumes, setVolumes] = useState<Record<string, number>>({});
+  const [audioShareMuted, setAudioShareMuted] = useState<Record<string, boolean>>({});
+  const [audioShareVolumes, setAudioShareVolumes] = useState<Record<string, number>>({});
 
   const youConnected = connectedRoomId !== null;
   const viewedRoomId: RoomId = connectedRoomId ?? "room1";
@@ -375,6 +388,17 @@ export function AppMock() {
     ...(youConnected && self.isSharing ? [{ id: "you", name: "you", tone: "text-blue" }] : []),
   ];
 
+  const audioShares: AudioShareState = {
+    streams: currentRoomMembers.filter((p) => p.hasAudioShare),
+    mutedFor: (id) => audioShareMuted[id] ?? false,
+    volumeFor: (id) => audioShareVolumes[id] ?? 70,
+    onToggleMute: (id) => setAudioShareMuted((cur) => ({ ...cur, [id]: !cur[id] })),
+    onVolumeChange: (id, value) => {
+      setAudioShareVolumes((cur) => ({ ...cur, [id]: value }));
+      if (value === 0) setAudioShareMuted((cur) => ({ ...cur, [id]: true }));
+    },
+  };
+
   return (
     <div
       className="relative isolate z-40 mx-auto w-full max-w-[840px] overflow-visible pb-[clamp(44px,7vw,76px)]"
@@ -386,6 +410,7 @@ export function AppMock() {
         onFocus={() => setActivePanel("watchAll")}
         drag={watchAllDrag}
         streams={streams}
+        audioShares={audioShares}
       />
       <MainAppWindow
         isActive={activePanel === "main"}
@@ -772,11 +797,13 @@ function WatchAllMock({
   onFocus,
   drag,
   streams,
+  audioShares,
 }: {
   isActive: boolean;
   onFocus: () => void;
   drag: ReturnType<typeof useDesktopPanelDrag>;
   streams: WatchAllStream[];
+  audioShares: AudioShareState;
 }) {
   return (
     <div
@@ -833,6 +860,57 @@ function WatchAllMock({
           </div>
         );
       })()}
+
+      {/* Audio-only shares strip — below the video grid, mirrors AudioOnlyTile.tsx */}
+      {audioShares.streams.length > 0 && (
+        <div className="divide-y divide-border border-t border-border bg-panel/95">
+          {audioShares.streams.map((p) => {
+            const muted = audioShares.mutedFor(p.id);
+            const volume = audioShares.volumeFor(p.id);
+            return (
+              <div
+                key={p.id}
+                className="flex items-center gap-1.5 px-2 py-1.5 text-[7px] sm:text-[8px]"
+              >
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    audioShares.onToggleMute(p.id);
+                  }}
+                  className="shrink-0"
+                  aria-label={muted ? `Unmute ${p.name} audio` : `Mute ${p.name} audio`}
+                  title={muted ? "click to unmute" : "click to mute"}
+                >
+                  <Music
+                    size={11}
+                    strokeWidth={1.8}
+                    fill={muted ? "currentColor" : "none"}
+                    className={muted ? "wavis-share-pulse" : "text-danger"}
+                    aria-hidden="true"
+                  />
+                </button>
+                <span className={`min-w-0 truncate ${p.tone}`}>{p.name}</span>
+                <span className="ml-auto hidden text-muted sm:inline">audio vol</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={volume}
+                  onChange={(event) => {
+                    event.stopPropagation();
+                    audioShares.onVolumeChange(p.id, Number(event.target.value));
+                  }}
+                  onClick={(event) => event.stopPropagation()}
+                  className="wavis-volume-slider w-10 shrink-0 sm:w-14"
+                  aria-label={`${p.name} audio volume`}
+                />
+                <span className="w-5 shrink-0 text-right text-muted">{muted ? 0 : volume}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #344 (merged early, only captured the icon swap + drag/reset — this PR carries the rest of that work). Turns the static `AppMock` preview on the marketing site into a working faux demo:

- **Interactive faux app**: join voice as a third participant (distinct from the alex/sam NPCs already in the room), mute/deafen/camera-on/share-screen, create + switch between rooms, expand a participant for a passthrough-volume slider — all wired to real UI feedback, no backend
- **Watch All**: auto-fit gallery grid (Discord/Zoom-style, scales to any stream count instead of hardcoded cases), an audio-only shares strip mirroring the real `AudioOnlyTile.tsx`, and the real quality `<select>` from `ActiveRoom.tsx` (moved off the tile, matching where it actually lives — under `/stopshare`)
- **Mobile**: the LOGS/VIDEOS tabs were entirely hidden below the `sm` breakpoint with no replacement, so camera-on had no visible effect on narrow widths. Added a mobile-only combined CHAT/LOGS/VIDEOS tab pane matching `ActiveRoom.tsx`'s real `groupedPanel` pattern, sharing state with the desktop columns
- Share-screen now focuses the Watch All panel, matching what a user would expect after starting a share
- Dragging is now restricted to each panel's title bar (previously the whole panel body was a drag handle)

## Test plan
- [x] `npx tsc --noEmit` and `npm run build` pass in `website/`
- [x] Verified interactively in a live `next dev` session: join/mute/deafen/camera/share, room create/switch, Watch All grid at 1/2/3 streams, audio-share mute/volume, passthrough-volume slider, drag-by-title-bar-only, double-click reset
- [x] Verified mobile responsiveness via DOM inspection (computed `display` values confirm the mobile pane and desktop columns toggle correctly at the `sm` breakpoint, mirroring the pre-existing working pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jG6UAexP9e96GSt1CeHWK