### PR TITLE
fix(voice): don't force-mute audio-only shares already active on rejoin

### DIFF
--- a/clients/wavis-gui/e2e-tooling/driver.mjs
+++ b/clients/wavis-gui/e2e-tooling/driver.mjs
@@ -18,6 +18,7 @@
 // bridge), which is out of scope for this ticket — basic element
 // interactions and window handles work without it.
 import { existsSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { startWdioSession, cleanupWdioSession, createTauriCapabilities } from '@wdio/tauri-service';
@@ -51,15 +52,15 @@ const DEFAULT_TAURI_DRIVER_PORT = 4444;
  * getPageByPath, page, close }. Always call close(), or the app process and
  * WebDriver session linger in the background.
  *
- * Each launch gets a fresh, unique WEBVIEW2_USER_DATA_FOLDER-equivalent
- * profile via WAVIS_AUTH_STORE_NAME/WAVIS_KEYRING_SERVICE isolation (same
- * scheme as before) so it never conflicts with a normally-running Wavis
- * instance's profile, and multiple harness launches can coexist — including
- * TWO REAL launches of the same debug exe at once (e.g. a two-instance
- * live-backend spec): give each its own `port` and, since they'd otherwise
- * share one Tauri store file and one OS keychain service, its own
- * `authStoreName` / `keyringService` too. See README.md's "Two simultaneous
- * GUI instances" section.
+ * Each launch gets its own WEBVIEW2_USER_DATA_FOLDER (keyed by `port`) so it
+ * never conflicts with a normally-running Wavis instance's profile — WebView2
+ * refuses to open a second environment against a folder another process
+ * already has open — and, since they'd otherwise share one Tauri store file
+ * and one OS keychain service, its own `authStoreName` / `keyringService`
+ * too. Together this is what lets multiple harness launches coexist,
+ * including TWO REAL launches of the same debug exe at once (e.g. a
+ * two-instance live-backend spec): give each its own `port`. See README.md's
+ * "Two simultaneous GUI instances" section.
  *
  * `settleMs` (default 4000) is how long to wait after connecting before
  * windows/content are expected to be meaningfully rendered — the app talks
@@ -77,6 +78,24 @@ export async function launchApp({
   const embeddedPort = port ?? DEFAULT_EMBEDDED_PORT;
   const tauriDriverPort = port ?? DEFAULT_TAURI_DRIVER_PORT;
 
+  // Everything below the `env` key on this options object — including `env`
+  // itself and `embeddedPort` above it — is silently dropped by
+  // @wdio/tauri-service@1.2.0's createTauriCapabilities: its implementation
+  // only copies appArgs/tauriDriverPort/logLevel/commandTimeout/startTimeout/
+  // driverProvider/autoInstallTauriDriver into the `wdio:tauriServiceOptions`
+  // object it returns (verified directly against
+  // node_modules/@wdio/tauri-service/dist/esm/index.js's createTauriCapabilities
+  // and the getEmbeddedPort/startEmbeddedDriver functions that later read
+  // `options.embeddedPort`/`options.env` from exactly that object — there is
+  // no other path either field could reach the spawned process through).
+  // Concretely this meant every launch fell back to the same default
+  // embedded-WebDriver port regardless of the `port` argument (fatal for two
+  // simultaneous instances — see two-instances.spec.mjs) AND every custom env
+  // var below (auth store name, keyring service, WebRTC test flags,
+  // diagnostics auto-open) was never actually applied, so every launch used
+  // the build's single default auth store — the real cause of stale
+  // wavis-auth-e2e.json cross-contaminating unrelated spec runs. Patched back
+  // in below until upstream forwards these itself.
   const capabilities = createTauriCapabilities(applicationPath, {
     driverProvider,
     embeddedPort,
@@ -85,43 +104,57 @@ export async function launchApp({
     // The embedded WebDriver server takes longer to come up on Windows CI-
     // like conditions; give it real headroom rather than racing the default.
     startTimeout: 60_000,
-    env: {
-      // --disable-features=WebRtcHideLocalIpsWithMdns: test-launches only —
-      // exposes real local IPs in ICE host candidates instead of Chromium's
-      // default randomly-generated ".local" mDNS obfuscation. Needed because
-      // the dockerized LiveKit used by live-backend media specs can't resolve
-      // those mDNS names (Docker's bridge network doesn't forward the UDP
-      // multicast mDNS needs), which otherwise breaks all real WebRTC media
-      // for the browser client. Must never move into tauri.conf.json —
-      // production/normal dev launches keep the default privacy behavior.
-      //
-      // --use-fake-ui-for-media-stream: test-launches only — auto-accepts
-      // getUserMedia permission requests, suppressing the WebView's own
-      // mic/camera permission bar. Without this, every live-backend media
-      // spec blocks on a manual click. "Fake" refers only to the permission
-      // UI — capture still uses real devices.
-      WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS:
-        '--disable-features=WebRtcHideLocalIpsWithMdns --use-fake-ui-for-media-stream',
-      // Keeps the OS keychain refresh-token entry (src-tauri/src/main.rs's
-      // keyring_service()) separate from a developer's real persisted login
-      // on this machine. Defaults to one shared e2e service; pass a distinct
-      // `keyringService` per launch when running two real instances at once
-      // so neither's token rotation can clobber the other's keychain entry.
-      WAVIS_KEYRING_SERVICE: keyringService,
-      // Runtime override for the Tauri store filename (auth.ts's
-      // resolveStoreName, read via src-tauri/src/main.rs's
-      // get_auth_store_name). Undefined `authStoreName` means "use the
-      // build-time VITE_AUTH_STORE_NAME baked into the exe" — explicit ''
-      // (not simply omitting the key) so a value inherited from the
-      // caller's own shell environment can't leak through.
-      WAVIS_AUTH_STORE_NAME: authStoreName ?? '',
-      // Runtime auto-open for the diagnostics window — separate from the
-      // build-time VITE_DIAGNOSTICS flag (build-app.mjs) which only
-      // controls whether it's bundled at all. multi-window.spec.mjs relies
-      // on it being open with no prior click needed.
-      WAVIS_DIAGNOSTICS_WINDOW: '1',
-    },
   });
+  capabilities['wdio:tauriServiceOptions'].embeddedPort = embeddedPort;
+  capabilities['wdio:tauriServiceOptions'].env = {
+    // --disable-features=WebRtcHideLocalIpsWithMdns: test-launches only —
+    // exposes real local IPs in ICE host candidates instead of Chromium's
+    // default randomly-generated ".local" mDNS obfuscation. Needed because
+    // the dockerized LiveKit used by live-backend media specs can't resolve
+    // those mDNS names (Docker's bridge network doesn't forward the UDP
+    // multicast mDNS needs), which otherwise breaks all real WebRTC media
+    // for the browser client. Must never move into tauri.conf.json —
+    // production/normal dev launches keep the default privacy behavior.
+    //
+    // --use-fake-ui-for-media-stream: test-launches only — auto-accepts
+    // getUserMedia permission requests, suppressing the WebView's own
+    // mic/camera permission bar. Without this, every live-backend media
+    // spec blocks on a manual click. "Fake" refers only to the permission
+    // UI — capture still uses real devices.
+    WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS:
+      '--disable-features=WebRtcHideLocalIpsWithMdns --use-fake-ui-for-media-stream',
+    // WebView2's user-data folder otherwise defaults to a location keyed
+    // purely off the Tauri app identifier (com.wavis.desktop) — shared by
+    // EVERY build of this app on the machine, including a developer's own
+    // long-running normal launch. A second WebView2 environment can't open
+    // against a folder another process already has open with different
+    // settings: confirmed via captureBackendLogs against a real run, the
+    // failure is WebView2 HRESULT 0x8007139F ("group or resource is not in
+    // the correct state") — not a crash in this app. Officially-supported
+    // WebView2 Loader env var (not Tauri-specific), so it's the actual fix
+    // rather than a workaround. Keyed by port so the two simultaneous
+    // instances a two-instance spec launches don't collide with each other
+    // either.
+    WEBVIEW2_USER_DATA_FOLDER: path.join(os.tmpdir(), 'wavis-e2e-webview2', `port-${embeddedPort}`),
+    // Keeps the OS keychain refresh-token entry (src-tauri/src/main.rs's
+    // keyring_service()) separate from a developer's real persisted login
+    // on this machine. Defaults to one shared e2e service; pass a distinct
+    // `keyringService` per launch when running two real instances at once
+    // so neither's token rotation can clobber the other's keychain entry.
+    WAVIS_KEYRING_SERVICE: keyringService,
+    // Runtime override for the Tauri store filename (auth.ts's
+    // resolveStoreName, read via src-tauri/src/main.rs's
+    // get_auth_store_name). Undefined `authStoreName` means "use the
+    // build-time VITE_AUTH_STORE_NAME baked into the exe" — explicit ''
+    // (not simply omitting the key) so a value inherited from the
+    // caller's own shell environment can't leak through.
+    WAVIS_AUTH_STORE_NAME: authStoreName ?? '',
+    // Runtime auto-open for the diagnostics window — separate from the
+    // build-time VITE_DIAGNOSTICS flag (build-app.mjs) which only
+    // controls whether it's bundled at all. multi-window.spec.mjs relies
+    // on it being open with no prior click needed.
+    WAVIS_DIAGNOSTICS_WINDOW: '1',
+  };
 
   const browser = await startWdioSession(capabilities);
 

--- a/clients/wavis-gui/src/features/voice/__tests__/share-viewer-windows-model.test.ts
+++ b/clients/wavis-gui/src/features/voice/__tests__/share-viewer-windows-model.test.ts
@@ -21,6 +21,7 @@ import {
   decideWatchAllOpenWhenClosed,
   decideWatchAllToggleWhenOpen,
   shouldCloseOnSubRoomChange,
+  planAudioOnlySharerBaselineSeed,
 } from '../share-viewer-windows-model';
 import type { ShareViewerScope } from '../useShareViewerWindows';
 
@@ -146,6 +147,49 @@ describe('shouldCloseOnSubRoomChange', () => {
           const decision = shouldCloseOnSubRoomChange(scope, participantId, scopeIds);
           const expected = scope === 'watch-all' && !includeSelf;
           expect(decision).toBe(expected);
+        },
+      ),
+      { numRuns: 30 },
+    );
+  });
+});
+
+/* ═══ Audio-only sharer baseline: rejoin regression (#346) ═════════ */
+
+describe('planAudioOnlySharerBaselineSeed', () => {
+  it('not yet joined a sub-room: defers (ShareState not guaranteed settled)', () => {
+    expect(planAudioOnlySharerBaselineSeed(false, null, new Set(['p1']))).toBeNull();
+  });
+
+  it('regression #346: a share already active when the sub-room settles seeds into the baseline, not treated as new', () => {
+    const seed = planAudioOnlySharerBaselineSeed(false, 'room-1', new Set(['p1']));
+    expect(seed).toEqual(new Set(['p1']));
+  });
+
+  it('already seeded: never reseeds, even if the sub-room id changes', () => {
+    expect(planAudioOnlySharerBaselineSeed(true, 'room-1', new Set(['p1']))).toBeNull();
+    expect(planAudioOnlySharerBaselineSeed(true, null, new Set())).toBeNull();
+  });
+
+  it('no active shares yet when the sub-room settles: seeds an empty baseline', () => {
+    expect(planAudioOnlySharerBaselineSeed(false, 'room-1', new Set())).toEqual(new Set());
+  });
+
+  it('property: seeding only ever happens once, exactly when unseeded and joined', () => {
+    fc.assert(
+      fc.property(
+        fc.boolean(),
+        fc.option(fc.string({ minLength: 1, maxLength: 8 }), { nil: null }),
+        fc.array(fc.string({ minLength: 1, maxLength: 8 })),
+        (alreadySeeded, joinedSubRoomId, curr) => {
+          const currSet = new Set(curr);
+          const seed = planAudioOnlySharerBaselineSeed(alreadySeeded, joinedSubRoomId, currSet);
+          const shouldSeed = !alreadySeeded && joinedSubRoomId !== null;
+          if (shouldSeed) {
+            expect(seed).toEqual(currSet);
+          } else {
+            expect(seed).toBeNull();
+          }
         },
       ),
       { numRuns: 30 },

--- a/clients/wavis-gui/src/features/voice/share-viewer-windows-model.ts
+++ b/clients/wavis-gui/src/features/voice/share-viewer-windows-model.ts
@@ -82,3 +82,33 @@ export function shouldCloseOnSubRoomChange(
   if (windowScope !== 'watch-all') return false;
   return !newScopeParticipantIds.has(participantId);
 }
+
+/* ─── Audio-only sharer baseline: which arrivals count as "new" ────── */
+
+/**
+ * Decide whether to (re)establish the "already active" baseline for
+ * audio-only sharers this effect pass, and what it should be.
+ *
+ * A share present in `curr` only counts as newly-arrived (and gets forced
+ * to start muted) if it appears *after* this baseline exists — otherwise a
+ * rejoin's ShareState snapshot, which reports every share already in
+ * progress, would make each of them look "new" to a freshly-mounted
+ * viewer and force-mute a share the user never actually just started.
+ *
+ * The baseline can't simply be seeded at mount: ShareState arrives
+ * asynchronously, so `curr` is still empty on the render that creates the
+ * ref holding it. Instead, seeding is deferred until `joinedSubRoomId` is
+ * non-null — SubRoomJoined/SubRoomState always arrive after ShareState in
+ * the join sequence (see voice_orchestrator.rs's join_voice signal order),
+ * so once it settles, `curr` is guaranteed to already reflect every share
+ * active at join time.
+ */
+export function planAudioOnlySharerBaselineSeed(
+  alreadySeeded: boolean,
+  joinedSubRoomId: string | null,
+  curr: ReadonlySet<string>,
+): Set<string> | null {
+  if (alreadySeeded) return null;
+  if (joinedSubRoomId === null) return null;
+  return new Set(curr);
+}

--- a/clients/wavis-gui/src/features/voice/useShareViewerWindows.ts
+++ b/clients/wavis-gui/src/features/voice/useShareViewerWindows.ts
@@ -66,6 +66,7 @@ import {
   decideWatchAllOpenWhenClosed,
   decideWatchAllToggleWhenOpen,
   shouldCloseOnSubRoomChange,
+  planAudioOnlySharerBaselineSeed,
 } from './share-viewer-windows-model';
 
 export type ShareViewerScope = 'direct' | 'watch-all';
@@ -138,6 +139,9 @@ export function useShareViewerWindows({
   const watchAllReadyRef = useRef(false);
   const prevWatchAllStreamsRef = useRef<Map<string, MediaStream | null>>(new Map());
   const prevAudioOnlySharersRef = useRef<Set<string>>(new Set());
+  // See planAudioOnlySharerBaselineSeed's doc comment for why this baseline
+  // can't just be seeded at mount.
+  const hasSeededAudioOnlySharersRef = useRef(false);
 
   // Mirrors pushed to child windows; assigned during render so the values
   // are always fresh when a viewer-ready callback fires.
@@ -968,6 +972,17 @@ export function useShareViewerWindows({
     const participants = roomState?.participants;
     if (!audioOnlySharers || !participants) return;
     const curr = audioOnlySharers;
+    const baselineSeed = planAudioOnlySharerBaselineSeed(
+      hasSeededAudioOnlySharersRef.current,
+      roomState?.joinedSubRoomId ?? null,
+      curr,
+    );
+    if (baselineSeed) {
+      prevAudioOnlySharersRef.current = baselineSeed;
+      hasSeededAudioOnlySharersRef.current = true;
+    } else if (!hasSeededAudioOnlySharersRef.current) {
+      return;
+    }
     const prev = prevAudioOnlySharersRef.current;
     for (const identity of curr) {
       if (prev.has(identity)) continue;
@@ -1001,7 +1016,13 @@ export function useShareViewerWindows({
       }
     }
     prevAudioOnlySharersRef.current = new Set(curr);
-  }, [getSavedShareVolume, watchAllOpen, roomState?.audioOnlySharers, roomState?.participants]);
+  }, [
+    getSavedShareVolume,
+    watchAllOpen,
+    roomState?.audioOnlySharers,
+    roomState?.participants,
+    roomState?.joinedSubRoomId,
+  ]);
 
   // Watch All: emit share-updated when participant info changes
   const prevParticipantsRef = useRef<Map<string, { displayName: string; color: string }>>(


### PR DESCRIPTION
## Summary

`screen-share-rejoin-badges.spec.mjs`'s regression check for the audio-only
share badge on rejoin was failing again. Root cause was distinct from
everything already ruled out in the issue (backend snapshot, sub-room join
count, test timeouts) — it's a frontend bug in `useShareViewerWindows.ts`,
not in the backend or the `share_state`/`share_started` signaling handlers.

**Root cause:** the watch-all-sync effect in `useShareViewerWindows.ts`
diffs `roomState.audioOnlySharers` against `prevAudioOnlySharersRef`, a ref
that starts empty on every mount of the hook (i.e. every time `ActiveRoom`
mounts at the `/room` route, including a rejoin). On rejoin, the backend's
`ShareState` snapshot correctly reports the sharer's audio-only slot as
still active (verified directly against the real backend — see Verification
below) — but this freshly-mounted, empty ref makes the effect misclassify
that already-active share as "newly seen," which unconditionally forces it
to start muted (`shareMutedRef.current.set(identity, true)`). The badge
renders correctly (it's not missing), just with the wrong title —
`"unmute audio share"` instead of `"mute audio share"` — which is why the
exact-title assertion in the regression test times out.

**Fix:** defer establishing the "already active" baseline until
`joinedSubRoomId` settles. The backend always sends `SubRoomJoined`/
`SubRoomState` *after* `ShareState` in the join sequence
(`voice_orchestrator.rs`'s `join_voice`), so once `joinedSubRoomId` is
non-null, `audioOnlySharers` is guaranteed to already reflect every share
active at join time. Shares present at that point seed the baseline (not
treated as new); only a share that starts *after* that point is genuinely
new to this viewing session and gets the existing "start muted" treatment.

The decision itself (`planAudioOnlySharerBaselineSeed`) is extracted into
`share-viewer-windows-model.ts`, following that file's existing convention
for pulling logic out of the 1000+-line hook (which can't be rendered under
vitest's `node` environment) into directly-testable pure functions.

## Second fix: e2e test harness bug (`driver.mjs`)

While verifying the above against the real e2e suite, hit several failures
unrelated to the badge fix itself — traced them to a real bug in the test
harness, not the app: `@wdio/tauri-service@1.2.0`'s `createTauriCapabilities()`
silently drops the `embeddedPort` and `env` fields `driver.mjs` passes it
(verified directly against the installed package's source). Concretely:

1. Every launch fell back to the same default embedded-WebDriver port
   regardless of the `port` argument, so `two-instances.spec.mjs`'s second
   instance always collided with the first.
2. None of the custom env vars (`WAVIS_AUTH_STORE_NAME`,
   `WAVIS_KEYRING_SERVICE`, `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS`,
   `WAVIS_DIAGNOSTICS_WINDOW`) ever reached the spawned app process — every
   launch silently used the build's single default auth store regardless of
   what `authStoreName` was requested, causing cross-contamination between
   unrelated spec runs.

Fixed by writing both fields directly onto the `wdio:tauriServiceOptions`
object `createTauriCapabilities()` returns. Also added
`WEBVIEW2_USER_DATA_FOLDER` isolation (keyed by port): WebView2's data
folder otherwise defaults to a location keyed purely off the Tauri app
identifier, shared by *every* build of the app on the machine — including a
developer's own long-running normal launch — and a second WebView2
environment can't open against a folder another process already has open
with different settings (confirmed via `captureBackendLogs`, the crash is
WebView2 `HRESULT 0x8007139F`).

## Verification

- Reproduced the exact reported failure against a live backend + the real
  built desktop app before fixing (`Expected: "displayed", Received: "not
  displayed"` on the `mute audio share` title, same as the issue).
- Isolated the backend independently with a raw-signaling repro (no GUI) —
  confirmed the `ShareState` snapshot on rejoin already correctly includes
  both the video-type and audio-only slots, ruling out the backend as the
  cause.
- Added console/DOM instrumentation to the real running app to confirm
  `roomState.audioOnlySharers`/`isAudioOnlySharer` were already correct
  post-fix-target, and that the rendered button's actual `title` was
  `"unmute audio share"` — proving this was a local-mute-default bug, not a
  missing-badge bug.
- `screen-share-rejoin-badges.spec.mjs` (unmodified): fails on `pre-dev`,
  passes with this fix — run twice to confirm it's not a timing fluke.
- New focused unit tests for `planAudioOnlySharerBaselineSeed`
  (`share-viewer-windows-model.test.ts`), including the exact regression
  scenario and a property test.
- Full GUI test suite: 873 passed, 0 failed.
- `npx tsc --noEmit`, `npm run lint` (0 errors), `npm run lint:deps`,
  `npm run format:check`, `node scripts/arch-check.mjs` — all clean.
- `two-instances.spec.mjs`'s "two accounts... no displacement" test (the
  originally reported harness failure) now passes against a live backend +
  the real built app.
- `audio-received`/`camera`/`chat`/`leave-rejoin`/`login` specs — all
  previously failing with the stale-auth-store symptom — now pass
  sequentially against a live backend + the real built app.

## Test plan

- [x] `screen-share-rejoin-badges.spec.mjs` passes against a live backend
      (verified twice)
- [x] `share-viewer-windows-model.test.ts` — new tests pass, full voice
      suite (873 tests) passes
- [x] typecheck / lint / lint:deps / format:check / arch-check all clean
- [x] `two-instances.spec.mjs` + 5 other previously-failing live-backend
      specs verified passing against the real built app

Closes #346